### PR TITLE
 Refactor cloud path operations and streamline R2 path handling

### DIFF
--- a/esp_data/dataset/shard_creator.py
+++ b/esp_data/dataset/shard_creator.py
@@ -25,7 +25,7 @@ from esp_data.config.project_config import default_shard_creator_cfg
 from esp_data.paths import AnyPath, make_storage_options
 from esp_data.utils import make_id, make_simple_logger
 
-from .utils import _make_file_opener
+from .utils import make_file_opener
 
 logger = make_simple_logger(__name__)
 
@@ -113,7 +113,7 @@ def write_webdataset_shard(
         str(shard_path),
         maxcount=100_000_000_000,  # Set very high to ensure all samples go in one shard
         maxsize=100_000_000_000,
-        opener=_make_file_opener(shard_path),
+        opener=make_file_opener(shard_path),
     )
 
     # Process each sample
@@ -307,7 +307,7 @@ def create_iterative_writer(
     schema = infer_schema_from_sample(sample, default_float_type)
 
     # Create opener and file
-    opener = _make_file_opener(path, mode="wb")
+    opener = make_file_opener(path, mode="wb")
     file_obj = opener(path)
 
     # Create appropriate writer

--- a/esp_data/dataset/utils.py
+++ b/esp_data/dataset/utils.py
@@ -8,7 +8,7 @@ from esp_data.config import DataSample
 from esp_data.paths import AnyPath, is_cloud_path, is_local_path
 
 
-def _make_file_opener(file_path: str | AnyPath, mode: str = "wb") -> Callable:
+def make_file_opener(file_path: str | AnyPath, mode: str = "wb") -> Callable:
     """Make a file opener function for WebDataset"""
     file_path = AnyPath(file_path)
 

--- a/esp_data/file_io/functional.py
+++ b/esp_data/file_io/functional.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from cloudpathlib import GSPath
 
-from esp_data.paths import AnyPath, get_cloud_prefix, is_local_path, strip_cloud_prefix
+from esp_data.paths import AnyPath, is_local_path, strip_cloud_prefix
 from esp_data.utils import make_simple_logger
 
 from .utils import make_fs
@@ -274,7 +274,7 @@ def yield_files(dir_path: str | os.PathLike | AnyPath, pattern: str = "*", use_f
     try:
         fs = make_fs(dir_path)
         glob_path = strip_cloud_prefix(dir_path / pattern)
-        cloud_prefix = get_cloud_prefix(dir_path)
+        cloud_prefix = AnyPath(dir_path).cloud_prefix
 
         for f in fs.glob(glob_path):
             if fs.isfile(f) and f != glob_path:

--- a/esp_data/file_io/utils.py
+++ b/esp_data/file_io/utils.py
@@ -6,7 +6,7 @@ from typing import TypeVar
 from gcsfs import GCSFileSystem
 from s3fs import S3FileSystem
 
-from esp_data.paths import AnyPath, is_cloudflarer2_path, is_gcs_path, is_s3_path
+from esp_data.paths import AnyPath, is_gcs_path, is_r2_path, is_s3_path
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ def make_fs(file_path: str | AnyPath) -> FileSystem | None:
         return make_gcsfs()
     if is_s3_path(file_path):
         return make_s3fs()
-    if is_cloudflarer2_path(file_path):
+    if is_r2_path(file_path):
         return make_cloudflarer2fs()
 
     logger.info("Could not determine cloud filesystem, returning None = local filesystem")

--- a/esp_data/paths.py
+++ b/esp_data/paths.py
@@ -95,8 +95,8 @@ class GSPath(cloudpathlib.GSPath):
 
 class R2Path(cloudpathlib.S3Path):
     def __init__(self, cloud_path: str | cloudpathlib.S3Path, client=_get_r2_client()):
-        if isinstance(cloudpathlib, str):
-            cloud_path = cloudpathlib.replace("r2://", "s3://")
+        if isinstance(cloud_path, str):
+            cloud_path = cloud_path.replace("r2://", "s3://")
 
         super().__init__(cloud_path, client=client)
 

--- a/esp_data/paths.py
+++ b/esp_data/paths.py
@@ -7,10 +7,8 @@ from pathlib import Path
 
 import cloudpathlib
 from cloudpathlib import S3Path
-from dotenv import load_dotenv
 from google.cloud.storage.client import Client as GSClient
 
-load_dotenv()
 warnings.filterwarnings("ignore", "Your application has authenticated using end user credentials")
 
 
@@ -22,41 +20,21 @@ def is_s3_path(path: str | Path | os.PathLike) -> bool:
     return str(path).startswith("s3://")
 
 
-def is_cloudflarer2_path(path: str | Path | os.PathLike) -> bool:
+def is_r2_path(path: str | Path | os.PathLike) -> bool:
     # FIXME: This is a temporary solution
     return "r2://" in str(path)
 
 
 def is_local_path(path: str | Path | os.PathLike) -> bool:
-    return not (is_gcs_path(path) or is_s3_path(path) or is_cloudflarer2_path(path))
+    return not (is_gcs_path(path) or is_s3_path(path) or is_r2_path(path))
 
 
 def is_cloud_path(path: str | Path | os.PathLike) -> bool:
-    return is_gcs_path(path) or is_s3_path(path) or is_cloudflarer2_path(path)
+    return is_gcs_path(path) or is_s3_path(path) or is_r2_path(path)
 
 
 def strip_cloud_prefix(path: str | Path | os.PathLike) -> str:
     return str(path).replace("gs://", "").replace("s3://", "").replace("r2://", "")
-
-
-def get_cloud_prefix(path: str | Path | os.PathLike) -> str:
-    if is_gcs_path(path):
-        return "gs://"
-    elif is_s3_path(path):
-        return "s3://"
-    elif is_cloudflarer2_path(path):
-        return "r2://"
-    else:
-        return ""
-
-
-def _make_r2_path_with_auth(path: str | os.PathLike | Path) -> S3Path:
-    c = cloudpathlib.S3Client(
-        aws_access_key_id=os.getenv("CLOUDFLARE_R2_ACCESS_KEY_ID"),
-        aws_secret_access_key=os.getenv("CLOUDFLARE_R2_SECRET_ACCESS_KEY"),
-        endpoint_url=os.getenv("CLOUDFLARE_R2_ENDPOINT_URL"),
-    )
-    return c.S3Path(path)
 
 
 def make_gscs_storage_options() -> dict:
@@ -76,15 +54,27 @@ def make_s3_storage_options() -> dict:
 def make_storage_options(path: str | os.PathLike) -> dict | None:
     if is_gcs_path(path):
         return make_gscs_storage_options()
-    elif is_s3_path(path) or is_cloudflarer2_path(path):
+    elif is_s3_path(path) or is_r2_path(path):
         return make_s3_storage_options()
     else:
         return None
 
 
+# TODO (milad) maybe we want to use a singleton pattern here using __new__? I think
+# class variables are instantiated when class statement is executed so they will make
+# imports a tiny bit slower.
 @lru_cache(maxsize=1)
-def _get_client():
+def _get_gs_client():
     return cloudpathlib.GSClient(storage_client=GSClient())
+
+
+@lru_cache(maxsize=1)
+def _get_r2_client():
+    return cloudpathlib.S3Client(
+        aws_access_key_id=os.getenv("CLOUDFLARE_R2_ACCESS_KEY_ID"),
+        aws_secret_access_key=os.getenv("CLOUDFLARE_R2_SECRET_ACCESS_KEY"),
+        endpoint_url=os.getenv("CLOUDFLARE_R2_ENDPOINT_URL"),
+    )
 
 
 class GSPath(cloudpathlib.GSPath):
@@ -99,38 +89,42 @@ class GSPath(cloudpathlib.GSPath):
     For more details, see: https://github.com/drivendataorg/cloudpathlib/issues/390
     """
 
-    def __init__(self, client_path, client=_get_client()):
-        super().__init__(client_path, client=client)
+    def __init__(self, cloud_path: str | cloudpathlib.GSPath, client=_get_gs_client()):
+        super().__init__(cloud_path, client=client)
+
+
+class R2Path(cloudpathlib.S3Path):
+    def __init__(self, cloud_path: str | cloudpathlib.S3Path, client=_get_r2_client()):
+        if isinstance(cloudpathlib, str):
+            cloud_path = cloudpathlib.replace("r2://", "s3://")
+
+        super().__init__(cloud_path, client=client)
 
 
 class AnyPath:
     """A class that returns the correct path object based on the path string."""
 
-    def __new__(cls, path: str | os.PathLike | Path) -> Path | GSPath | S3Path:
+    def __new__(cls, path: str | Path | GSPath | R2Path) -> Path | GSPath | R2Path:
         """This is a factory function. It returns the correct path object based on the path string.
         Solves the issue of disappearing // in the path string when using cloudpathlib.AnyPath.
 
         Args:
-            path (str | os.PathLike | Path | AnyPath): The path to a file or directory.
+            path (str | Path | GSPath | R2Path): The path to a file or directory.
 
         Returns:
             Path | GSPath | S3Path: The correct path object based on the path string.
         """
-        if isinstance(path, cls):
-            return path
 
-        elif is_gcs_path(path):
-            return GSPath(path)
+        if isinstance(path, (Path, GSPath, R2Path | S3Path)):
+            path = str(path)
 
+        if is_gcs_path(path):
+            return GSPath(str(path))
         elif is_s3_path(path):
-            # FIXME: Since we are not going to use AWS, we can use the same constructor for R2 and S3
-            return _make_r2_path_with_auth(path)
-
-        elif is_cloudflarer2_path(path):
-            # Since Cloudflare R2 uses the S3 api, only distinguishing itself on the endpoint_url,
-            # we can use the S3Path class for Cloudflare R2 paths.
-            p = str(path).replace("r2://", "s3://")
-            return _make_r2_path_with_auth(p)
-
-        # local path
-        return Path(path)
+            # Since we are currently not using AWS we assume that all S3 paths are R2 paths.
+            # TODO This must be changed if we start using AWS.
+            return R2Path(str(path), client=_get_r2_client())
+        elif is_r2_path(path):
+            return R2Path(str(path))
+        else:
+            return Path(path)


### PR DESCRIPTION
🚚 renamed `_make_file_opener` -> `make_file_opener`. It wasn't local.
🗑️ Removed `get_cloud_prefix()`. There's _currently_ no need for it because Cloudpathlib classes have `cloud_prefix` class variables
🚚 renamed `is_cloudflarer2_path()` -> `is_r2_path()`. R2 is clear enough?
🔨 removed `_make_r2_path_with_auth()` and replaced it with the same mechanism we use for `GSPath` i.e. a cached client and a replacement class (`R2Path`)
🔨 Refactored `AnyPath`