### PR TITLE
refactor: remove open_file utility and replace with AnyPath usage in …

### DIFF
--- a/esp_data/config/db_config.py
+++ b/esp_data/config/db_config.py
@@ -321,7 +321,7 @@ class DatasetConfig(BaseModel):
     def generate_readme(self, file_path: str | os.PathLike) -> None:
         """Generate a README file for the dataset"""
         text = str(self)
-        with open_file(file_path, "w") as f:
+        with AnyPath(file_path).open("w") as f:
             f.write(text)
 
     @classmethod

--- a/esp_data/file_io/functional.py
+++ b/esp_data/file_io/functional.py
@@ -127,76 +127,6 @@ def yield_files(dir_path: str | os.PathLike | AnyPath, pattern: str = "*", use_f
         raise IOError(f"Failed to yield files in {dir_path} using both methods: {e}") from e
 
 
-def write_bytes(file_path: str | os.PathLike | AnyPath, data: bytes, use_fs: bool = False) -> bool:
-    """Write the data to the file.
-
-    Args:
-        file_path (str | os.PathLike | AnyPath): The path to the file, local or cloud.
-        data (bytes): The data to write to the file.
-        use_fs (bool, optional): If True, use the FileSystem approach. Defaults to False.
-
-    Returns:
-        bool: True if the data was written successfully.
-    """
-    file_path = AnyPath(file_path)
-
-    if is_local_path(file_path):
-        file_path.write_bytes(data)
-        return True
-
-    if not use_fs:
-        try:
-            file_path.write_bytes(data)
-            return True
-        except Exception as e:
-            logger.warning(f"Could not write bytes using AnyPath method: {e}, trying FileSystem approach.")
-
-    try:
-        fs = make_fs(file_path)
-        file_path_str = strip_cloud_prefix(file_path)
-        fs.write_bytes(file_path_str, data)
-        return True
-    except Exception as e:
-        raise IOError(f"Failed to write bytes to {file_path} using both methods: {e}") from e
-
-
-def write_text(
-    file_path: str | os.PathLike | AnyPath, text: str, use_fs: bool = False, encoding: str = None, newline=None
-) -> bool:
-    """Write the text to the file.
-
-    Args:
-        file_path (str | os.PathLike | AnyPath): The path to the file, local or cloud.
-        text (str): The text to write to the file.
-        use_fs (bool, optional): If True, use the FileSystem approach. Defaults to False.
-        encoding (str, optional): The encoding to use. Defaults to None.
-        newline ([type], optional): The newline character to use. Defaults to None.
-
-    Returns:
-        bool: True if the text was written successfully
-    """
-    file_path = AnyPath(file_path)
-
-    if is_local_path(file_path):
-        file_path.write_text(text, encoding=encoding, newline=newline)
-        return True
-
-    if not use_fs:
-        try:
-            file_path.write_text(text, encoding=encoding, newline=newline)
-            return True
-        except Exception as e:
-            logger.warning(f"Could not write text using AnyPath method: {e}, trying FileSystem approach.")
-
-    try:
-        fs = make_fs(file_path)
-        file_path_str = strip_cloud_prefix(file_path)
-        fs.write_text(file_path_str, text, encoding=encoding, newline=newline)
-        return True
-    except Exception as e:
-        raise IOError(f"Failed to write text to {file_path} using both methods: {e}") from e
-
-
 def delete_file(file_path: str | os.PathLike | AnyPath, use_fs: bool = False) -> bool:
     """Delete the file at the given path.
 
@@ -397,28 +327,6 @@ def copy(
         return True
     except Exception as e:
         raise IOError(f"Failed to copy {source} to {destination} using both methods: {e}") from e
-
-
-def upload(source: str | os.PathLike | AnyPath, destination: str | os.PathLike | AnyPath, use_fs: bool = False) -> bool:
-    """Upload a file/directory from local path to destination (typically cloud).
-    Please end dirs to upload to with a trailing /.
-
-    Args:
-        source (str | os.PathLike | AnyPath): The local path to upload from.
-        destination (str | os.PathLike | AnyPath): The destination path.
-        use_fs (bool, optional): If True, use the FileSystem approach. Defaults to False.
-
-    Returns:
-        bool: True if the upload was successful.
-
-    Example:
-        # Upload a file to a cloud bucket
-        upload("local_file.txt", "gs://bucket_name/path/to/file.txt")
-
-        # Upload a dir to a cloud bucket
-        upload("local_dir/", "gs://bucket_name/path/to/dir/")
-    """
-    return copy(source, destination, use_fs)
 
 
 def download(

--- a/esp_data/file_io/functional.py
+++ b/esp_data/file_io/functional.py
@@ -127,38 +127,6 @@ def yield_files(dir_path: str | os.PathLike | AnyPath, pattern: str = "*", use_f
         raise IOError(f"Failed to yield files in {dir_path} using both methods: {e}") from e
 
 
-def read_text(file_path: str | os.PathLike | AnyPath, use_fs: bool = False) -> str:
-    """Read the contents of the file as text.
-
-    Args:
-        file_path (str | os.PathLike | AnyPath): The path to the file, local or cloud.
-        use_fs (bool, optional): If True, use the FileSystem approach. Defaults to False.
-
-    Returns:
-        str: The contents of the file as text if successful.
-    """
-    file_path = AnyPath(file_path)
-
-    if not file_path.exists():
-        raise FileNotFoundError(f"File {file_path} does not exist")
-
-    if is_local_path(file_path):
-        return file_path.read_text()
-
-    if not use_fs:
-        try:
-            return file_path.read_text()
-        except Exception as e:
-            logger.warning(f"Could not read file as text using AnyPath method: {e}, trying FileSystem approach.")
-
-    try:
-        fs = make_fs(file_path)
-        file_path_str = strip_cloud_prefix(file_path)
-        return fs.read_text(file_path_str)
-    except Exception as e:
-        raise IOError(f"Failed to read file {file_path} as text using both methods: {e}") from e
-
-
 def write_bytes(file_path: str | os.PathLike | AnyPath, data: bytes, use_fs: bool = False) -> bool:
     """Write the data to the file.
 

--- a/esp_data/file_io/functional.py
+++ b/esp_data/file_io/functional.py
@@ -10,7 +10,6 @@ import os
 import shutil
 import subprocess
 from io import StringIO
-from typing import Any
 
 from cloudpathlib import GSPath
 
@@ -19,37 +18,6 @@ from esp_data.paths import AnyPath, is_local_path, strip_cloud_prefix
 from .utils import make_fs
 
 logger = logging.getLogger("esp_data")
-
-
-def open_file(file_path: str | os.PathLike | AnyPath, mode: str, use_fs: bool = False, **open_kwargs) -> Any:
-    """Open the file at the given path.
-
-    Args:
-        file_path (str | os.PathLike | AnyPath): The path to the file.
-        mode (str): The mode to open the file in.
-        use_fs (bool, optional): If True, use the FileSystem approach. Defaults to False, which is using cloudpathlib.
-        **open_kwargs: Additional keyword arguments to pass to the open function.
-
-    Returns:
-        Any: The file object.
-    """
-    file_path = AnyPath(file_path)
-
-    if is_local_path(file_path):
-        return file_path.open(mode, **open_kwargs)
-
-    if not use_fs:
-        try:
-            return file_path.open(mode, **open_kwargs)
-        except Exception as e:
-            logger.warning(f"Could not open file using AnyPath method: {e}, trying FileSystem approach.")
-
-    try:
-        fs = make_fs(file_path)
-        file_path_str = strip_cloud_prefix(file_path)
-        return fs.open(str(file_path_str), mode, **open_kwargs)
-    except Exception as e:
-        raise IOError(f"Failed to open file at {file_path} using both methods: {e}") from e
 
 
 def move_file(

--- a/esp_data/file_io/functional.py
+++ b/esp_data/file_io/functional.py
@@ -329,30 +329,6 @@ def copy(
         raise IOError(f"Failed to copy {source} to {destination} using both methods: {e}") from e
 
 
-def download(
-    source: str | os.PathLike | AnyPath, destination: str | os.PathLike | AnyPath, use_fs: bool = False
-) -> bool:
-    """Download a file/directory from source (typically cloud) to local path.
-    Please end dirs to download with a trailing /.
-
-    Args:
-        source (str | os.PathLike | AnyPath): The source path to download from.
-        destination (str | os.PathLike | AnyPath): The local destination path.
-        use_fs (bool, optional): If True, use the FileSystem approach. Defaults to False.
-
-    Returns:
-        bool: True if the download was successful.
-
-    Example:
-        # Download a file from a cloud bucket
-        download("gs://bucket_name/path/to/file.txt", "local_file.txt")
-
-        # Download a dir from a cloud bucket
-        download("gs://bucket_name/path/to/dir/", "local_dir/")
-    """
-    return copy(source, destination, use_fs)
-
-
 def gcloud_rsync(
     source: str | os.PathLike | AnyPath,
     destination: str | os.PathLike | AnyPath,

--- a/esp_data/file_io/functional.py
+++ b/esp_data/file_io/functional.py
@@ -329,67 +329,6 @@ def copy(
         raise IOError(f"Failed to copy {source} to {destination} using both methods: {e}") from e
 
 
-def gcloud_rsync(
-    source: str | os.PathLike | AnyPath,
-    destination: str | os.PathLike | AnyPath,
-    avoid_copy_if_same: bool = False,
-    delete_unmatched: bool = False,
-    continue_on_error: bool = True,
-    recursive: bool = True,
-    gzip_in_flight: str = "",
-) -> None:
-    """Sync the bucket directory with a local / cloud directory.
-
-    Args:
-        source (str | os.PathLike | AnyPath): The source path to sync from.
-        destination (str | os.PathLike | AnyPath): The destination path to sync to.
-        avoid_copy_if_same: Whether to avoid copying files that are the same in source and destination. Default is False
-        delete_unmatched: Whether to delete files in the destination that are not in the source. Default is False
-        continue_on_error: Whether to continue syncing if an error occurs. Default is True
-        recursive: Whether to sync recursively. Default is True
-        gzip_in_flight: Whether to compress files with the given extensions in flight for faster transfer.
-            For e.g. gzip_in_flight="txt,csv,jpg". Default is "" which means none. If "all",
-            will try to compress everything, but this may be counterproductive for files that should not be
-            compressed.
-
-    Raises:
-        subprocess.CalledProcessError: If rsync command fails
-    """
-    # uses gcloud storage rsync command
-    cmd = ["gcloud", "storage", "rsync", str(source), str(destination)]
-
-    if recursive:
-        cmd.append("--recursive")
-    if delete_unmatched:
-        cmd.append("--delete-unmatched-destination-objects")
-    if continue_on_error:
-        cmd.append("--continue-on-error")
-    if avoid_copy_if_same:
-        cmd.append("--no-clobber")
-
-    if gzip_in_flight == "all":
-        cmd.append("--gzip-in-flight-all")
-    elif gzip_in_flight != "":
-        cmd.append(f"--gzip-in-flight={gzip_in_flight}")
-
-    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = p.communicate()
-
-    if p.returncode != 0:
-        error_msg = stderr.decode("utf-8").strip()
-        logger.error(f"Rsync failed with return code {p.returncode}: {error_msg}")
-        logger.error(f"Command used: {' '.join(cmd)}")
-        if not continue_on_error:
-            raise subprocess.CalledProcessError(p.returncode, cmd, stdout, stderr)
-    else:
-        # Log success message with some stats if available
-        output = stdout.decode("utf-8").strip()
-        if output:
-            logger.info(f"Rsync completed successfully: {output}")
-        else:
-            logger.info("Rsync completed successfully")
-
-
 def write_rows_to_csv(rows: list[dict], *, file_path: str | AnyPath, mode: str = "a", use_fs: bool = False) -> None:
     """Write a list of dicts to a remote CSV file. Allows appending to the file.
 

--- a/esp_data/file_io/functional.py
+++ b/esp_data/file_io/functional.py
@@ -127,38 +127,6 @@ def yield_files(dir_path: str | os.PathLike | AnyPath, pattern: str = "*", use_f
         raise IOError(f"Failed to yield files in {dir_path} using both methods: {e}") from e
 
 
-def read_bytes(file_path: str | os.PathLike | AnyPath, use_fs: bool = False) -> bytes:
-    """Read the contents of the file.
-
-    Args:
-        file_path (str | os.PathLike | AnyPath): The path to the file, local or cloud.
-        use_fs (bool, optional): If True, use the FileSystem approach. Defaults to False.
-
-    Returns:
-        bytes: The contents of the file if successful.
-    """
-    file_path = AnyPath(file_path)
-
-    if not file_path.exists():
-        raise FileNotFoundError(f"File {file_path} does not exist")
-
-    if is_local_path(file_path):
-        return file_path.read_bytes()
-
-    if not use_fs:
-        try:
-            return file_path.read_bytes()
-        except Exception as e:
-            logger.warning(f"Could not read file using AnyPath method: {e}, trying FileSystem approach.")
-
-    try:
-        fs = make_fs(file_path)
-        file_path_str = strip_cloud_prefix(file_path)
-        return fs.read_bytes(file_path_str)
-    except Exception as e:
-        raise IOError(f"Failed to read file {file_path} using both methods: {e}") from e
-
-
 def read_text(file_path: str | os.PathLike | AnyPath, use_fs: bool = False) -> str:
     """Read the contents of the file as text.
 

--- a/scripts/beans0/beans_cfg.py
+++ b/scripts/beans0/beans_cfg.py
@@ -105,10 +105,10 @@ LOCAL_PATHS = {k: os.path.join(local_path, (k + ".jsonl")) for k in DATASET_JSON
 def download_jsonl_files(exists_ok: Optional[bool] = True):
     for name, path in DATASET_JSONL_PATHS.items():
         if exists_ok:
-            F.download(path, LOCAL_PATHS[name])
+            F.copy(path, LOCAL_PATHS[name])
 
         if not exists_ok and not AnyPath(LOCAL_PATHS[name]).exists():
-            F.download(path, LOCAL_PATHS[name])
+            F.copy(path, LOCAL_PATHS[name])
 
 
 METADATA = {

--- a/scripts/naturelm/create_sharded_dataset.py
+++ b/scripts/naturelm/create_sharded_dataset.py
@@ -37,17 +37,20 @@ AUDIO_PROMPT = "<Audio><AudioHere></Audio>"
 
 def read_jsonl(path: str | AnyPath) -> list[dict]:
     try:
-        with F.open_file(path, "r") as f:
+        path = AnyPath(path)
+        with path.open(path, "r") as f:
             data = json.load(f)
             annotation = data["annotation"]
     except (json.JSONDecodeError, KeyError):
-        with F.open_file(path, "r") as f:
+        with path.open(path, "r") as f:
             annotation = [json.loads(line) for line in f]
     return annotation
 
 
 def load_audio(audio_path: str | AnyPath) -> np.ndarray:
-    with F.open_file(audio_path, "rb") as f:
+    audio_path = AnyPath(audio_path)
+
+    with audio_path.open("rb") as f:
         audio_data, sr = torchaudio.load(f)
     audio_data = audio_data.numpy().squeeze().tolist()
     return audio_data, sr

--- a/scripts/zip_audios.py
+++ b/scripts/zip_audios.py
@@ -23,7 +23,7 @@ def create_zip_batch(files: list[str], batch_number: int, output_bucket_path: st
             # Download blob to memory
             print(f"Fecthing {file}...")
             try:
-                content = F.read_bytes(file)
+                content = AnyPath(file).read_bytes()
             except Exception as e:
                 raise e
             # Add to zip with just the filename (not the full path)

--- a/scripts/zip_audios.py
+++ b/scripts/zip_audios.py
@@ -32,7 +32,7 @@ def create_zip_batch(files: list[str], batch_number: int, output_bucket_path: st
 
     # Upload the zip file to the output bucket
     output_zip_path = AnyPath(output_bucket_path) / f"batch_{batch_number:04d}.zip"
-    F.upload(zip_path, output_zip_path)
+    F.copy(zip_path, output_zip_path)
 
     # Remove temporary file
     os.remove(zip_path)

--- a/tests/test_fileio_functional.py
+++ b/tests/test_fileio_functional.py
@@ -7,8 +7,6 @@ from esp_data.file_io.functional import (
     download,
     list_files,
     makedirs,
-    read_bytes,
-    read_text,
     upload,
     write_bytes,
     write_text,
@@ -111,7 +109,7 @@ def test_read_text(local_test_dir):
     """Test reading text from a file."""
     test_file = local_test_dir / "test_read.txt"
     test_file.write_text("Hello")
-    content = read_text(str(test_file))
+    content = test_file.read_text(test_file)
     assert content == "Hello"
 
 

--- a/tests/test_fileio_functional.py
+++ b/tests/test_fileio_functional.py
@@ -2,14 +2,11 @@ import pytest
 
 from esp_data import AnyPath
 from esp_data.file_io.functional import (
-    # create_file,
     delete_dir,
     delete_file,
     download,
-    # exists,
     list_files,
     makedirs,
-    open_file,
     read_bytes,
     read_text,
     upload,
@@ -75,14 +72,14 @@ def test_open_file_read_write(local_test_dir):
     test_file = local_test_dir / "test_open.txt"
     test_file.write_text("Line1")
 
-    with open_file(str(test_file), "r") as f:
+    with test_file.open("r") as f:
         data = f.read()
     assert data == "Line1"
 
-    with open_file(str(test_file), "a") as f:
+    with test_file.open("a") as f:
         f.write("Line2")
 
-    with open_file(str(test_file), "r") as f:
+    with test_file.open("r") as f:
         data = f.read()
     assert data == "Line1Line2"
 

--- a/tests/test_fileio_functional.py
+++ b/tests/test_fileio_functional.py
@@ -103,7 +103,7 @@ def test_read_bytes(local_test_dir):
     """Test reading bytes from a file."""
     test_file = local_test_dir / "test_read.bin"
     test_file.write_bytes(b"\x00\xff\x10")
-    data = read_bytes(str(test_file))
+    data = test_file.read_bytes()
     assert data == b"\x00\xff\x10"
 
 

--- a/tests/test_fileio_functional.py
+++ b/tests/test_fileio_functional.py
@@ -5,7 +5,6 @@ from esp_data.file_io.functional import (
     copy,
     delete_dir,
     delete_file,
-    download,
     list_files,
     makedirs,
 )
@@ -38,7 +37,7 @@ def test_upload_download_cloud(local_test_dir, cloud_path):
     assert copy(local_file, cloud_path) is True
     # Download back to a different local file
     download_target = local_test_dir / "cloud_test_download.bin"
-    assert download(cloud_path, str(download_target)) is True
+    assert copy(cloud_path, str(download_target)) is True
     assert download_target.read_bytes() == b"Hello Cloud"
     assert delete_file(cloud_path) is True
 

--- a/tests/test_fileio_functional.py
+++ b/tests/test_fileio_functional.py
@@ -2,14 +2,12 @@ import pytest
 
 from esp_data import AnyPath
 from esp_data.file_io.functional import (
+    copy,
     delete_dir,
     delete_file,
     download,
     list_files,
     makedirs,
-    upload,
-    write_bytes,
-    write_text,
 )
 
 
@@ -37,7 +35,7 @@ def test_upload_download_cloud(local_test_dir, cloud_path):
     assert local_file.exists() is True
 
     # Upload to remote
-    assert upload(local_file, cloud_path) is True
+    assert copy(local_file, cloud_path) is True
     # Download back to a different local file
     download_target = local_test_dir / "cloud_test_download.bin"
     assert download(cloud_path, str(download_target)) is True
@@ -109,21 +107,21 @@ def test_read_text(local_test_dir):
     """Test reading text from a file."""
     test_file = local_test_dir / "test_read.txt"
     test_file.write_text("Hello")
-    content = test_file.read_text(test_file)
+    content = test_file.read_text()
     assert content == "Hello"
 
 
 def test_write_bytes(local_test_dir):
     """Test writing bytes to a file."""
     test_file = local_test_dir / "test_write.bin"
-    assert write_bytes(str(test_file), b"ABC") is True
+    assert test_file.write_bytes(b"ABC") == 3
     assert test_file.read_bytes() == b"ABC"
 
 
 def test_write_text(local_test_dir):
     """Test writing text to a file."""
     test_file = local_test_dir / "test_write.txt"
-    assert write_text(str(test_file), "Hello World") is True
+    assert test_file.write_text("Hello World") == 11
     assert test_file.read_text() == "Hello World"
 
 
@@ -172,7 +170,7 @@ def test_list_files_in_cloud(cloud_dir, local_test_dir):
     test_file = local_test_dir / "file_to_list_cloud.txt"
     test_file.write_text("Cloud content")
     remote_path = f"{cloud_dir}/file_to_list_cloud.txt"
-    assert upload(str(test_file), remote_path)
+    assert copy(str(test_file), remote_path)
     files = list_files(cloud_dir)
     assert any("file_to_list_cloud.txt" in f for f in files)
     assert delete_file(remote_path) is True
@@ -191,7 +189,7 @@ def test_delete_files_in_cloud(cloud_dir, local_test_dir):
     test_file = local_test_dir / "file_delete_cloud.txt"
     test_file.write_text("Delete from cloud")
     remote_path = f"{cloud_dir}/file_delete_cloud.txt"
-    upload(str(test_file), remote_path)
+    copy(str(test_file), remote_path)
     assert delete_file(remote_path) is True
     # Try listing again to ensure file is gone
     files = list_files(cloud_dir)
@@ -211,7 +209,7 @@ def test_delete_dir_in_cloud(cloud_dir, local_test_dir):
     test_file = local_test_dir / "file_delete_dir_cloud.txt"
     test_file.write_text("Delete from cloud")
     remote_path = f"{cloud_dir}/file_delete_dir_cloud.txt"
-    upload(str(test_file), remote_path)
+    copy(str(test_file), remote_path)
     assert delete_file(remote_path) is True
     # Try listing again to ensure file is gone
     files = list_files(cloud_dir)


### PR DESCRIPTION
- Removed `open_file()` from functional. Was only used in the naturelm script
- Removed `read_bytes()` and `read_text()`
- Removed `upload()`. This literally just calls `copy()` with the same args.
- Removed `download()`. This is again just a wrapper for `copy()`