### PR TITLE
cached_class_property for dealing with storage options and clients

### DIFF
--- a/esp_data/dataset/esp_dataset.py
+++ b/esp_data/dataset/esp_dataset.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from esp_data.paths import AnyPath, make_storage_options
+from esp_data.paths import AnyPath
 
 from .hf import HF_DATASET_TYPES, load_hf_dataset
 from .webds import WebDataset
@@ -24,28 +24,27 @@ def load_esp_dataset(dataset_type: str, path: str | AnyPath, **kwargs):
     -------
         pd.DataFrame | WebDataset | HFDataset: The loaded dataset.
     """
+    path = AnyPath(path)
+
     if dataset_type not in DATASET_TYPES:
         raise ValueError(f"Unsupported dataset type: {dataset_type}, supported types are: {DATASET_TYPES}")
 
-    storage_options = make_storage_options(path)
-
     if dataset_type == "webdataset":
-        return WebDataset.from_path(path, storage_options=storage_options, **kwargs)
+        return WebDataset.from_path(str(path), storage_options=path.storage_options, **kwargs)
 
     elif dataset_type in HF_DATASET_TYPES:
-        return load_hf_dataset(dataset_type, path, storage_options=storage_options, **kwargs)
+        return load_hf_dataset(dataset_type, str(path), storage_options=path.storage_options, **kwargs)
 
     elif dataset_type == "pandas":
-        # get extension
-        ext = AnyPath(path).suffix
+        ext = path.suffix
         if ext == ".csv":
-            return pd.read_csv(path, storage_options=storage_options, **kwargs)
+            return pd.read_csv(str(path), storage_options=path.storage_options, **kwargs)
         elif ext == ".tsv":
-            return pd.read_csv(path, sep="\t", storage_options=storage_options, **kwargs)
+            return pd.read_csv(str(path), sep="\t", storage_options=path.storage_options, **kwargs)
         elif ext == ".json":
-            return pd.read_json(path, storage_options=storage_options, **kwargs)
+            return pd.read_json(str(path), storage_options=path.storage_options, **kwargs)
         elif ext == ".parquet":
-            return pd.read_parquet(path, storage_options=storage_options, **kwargs)
+            return pd.read_parquet(str(path), storage_options=path.storage_options, **kwargs)
 
     else:
         raise ValueError(f"Unsupported dataset type: {dataset_type}")

--- a/esp_data/dataset/hf.py
+++ b/esp_data/dataset/hf.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Generator, Iterable, Literal, Optional
 from datasets import Dataset, concatenate_datasets, load_dataset, load_from_disk
 
 from esp_data.config.db_config import DataSample, DatasetConfig
-from esp_data.paths import AnyPath, make_storage_options
+from esp_data.paths import AnyPath
 
 from .base import BaseMapDataset
 from .shard_creator import write_huggingface_shard
@@ -411,7 +411,7 @@ class HFDataset(BaseMapDataset):
 
         # set storage options if not provided
         if not storage_options:
-            storage_options = make_storage_options(storage_options)
+            storage_options = path.storage_options
 
         if changelog:
             self.config.update_changelog(changelog)

--- a/esp_data/dataset/shard_creator.py
+++ b/esp_data/dataset/shard_creator.py
@@ -24,7 +24,7 @@ from tqdm.auto import tqdm
 import esp_data.file_io.functional as F
 from esp_data.config import DatasetConfig
 from esp_data.config.project_config import default_shard_creator_cfg
-from esp_data.paths import AnyPath, make_storage_options
+from esp_data.paths import AnyPath
 from esp_data.utils import make_id
 
 logger = logging.getLogger("esp_data")
@@ -522,7 +522,7 @@ def write_huggingface_shard(
     # Create shard path
     output_path = AnyPath(output_path)
     shard_path = output_path / (f"{shard_name}_{shard_id:06d}")
-    storage_options = make_storage_options(output_path) if storage_options is None else storage_options
+    storage_options = output_path.storage_options if storage_options is None else storage_options
 
     # Process the data using generator for memory efficiency
     total_samples = len(batch)
@@ -1005,7 +1005,7 @@ def create_sharded_dataset(
 
     # Save updated metadata if requested
     if save_metadata_as and len(metadata_df) > 0:
-        storage_options = make_storage_options(output_path)
+        storage_options = AnyPath(output_path).storage_options
         save_metadata(metadata_df, output_path / save_metadata_as, storage_options)
 
     # Report final statistics

--- a/esp_data/file_io/functional.py
+++ b/esp_data/file_io/functional.py
@@ -8,7 +8,6 @@ We prefer using the FileSystem approach, defaulting to cloudpathlib if it doesn'
 import logging
 import os
 import shutil
-import subprocess
 from io import StringIO
 
 from cloudpathlib import GSPath

--- a/esp_data/paths.py
+++ b/esp_data/paths.py
@@ -1,62 +1,16 @@
 """Path definitions that get rid of some issues with the AnyPath type hint."""
 
 import os
-from pathlib import Path
+from pathlib import PosixPath
 from typing import Optional
 
 import cloudpathlib
 from cloudpathlib import GSClient, S3Client, S3Path
 from google.cloud.storage.client import Client as GS_Client_Official
 
-from esp_data.utils import read_gcp_secret
+from esp_data.utils import cached_class_attribute, read_gcp_secret
 
-
-def is_gcs_path(path: str | Path | os.PathLike) -> bool:
-    return str(path).startswith("gs://")
-
-
-def is_s3_path(path: str | Path | os.PathLike) -> bool:
-    return str(path).startswith("s3://")
-
-
-def is_r2_path(path: str | Path | os.PathLike) -> bool:
-    # FIXME: This is a temporary solution
-    return "r2://" in str(path)
-
-
-def is_local_path(path: str | Path | os.PathLike) -> bool:
-    return not (is_gcs_path(path) or is_s3_path(path) or is_r2_path(path))
-
-
-def is_cloud_path(path: str | Path | os.PathLike) -> bool:
-    return is_gcs_path(path) or is_s3_path(path) or is_r2_path(path)
-
-
-def strip_cloud_prefix(path: str | Path | os.PathLike) -> str:
-    return str(path).replace("gs://", "").replace("s3://", "").replace("r2://", "")
-
-
-def _make_gscs_storage_options() -> dict:
-    return {"project": os.getenv("GCP_DEFAULT_PROJECT")}
-
-
-def _make_s3_storage_options() -> dict:
-    return {
-        "client_kwargs": {
-            "aws_access_key_id": os.getenv("CLOUDFLARE_R2_ACCESS_KEY_ID"),
-            "aws_secret_access_key": os.getenv("CLOUDFLARE_R2_SECRET_ACCESS_KEY"),
-            "endpoint_url": os.getenv("CLOUDFLARE_R2_ENDPOINT_URL"),
-        }
-    }
-
-
-def make_storage_options(path: str | os.PathLike) -> dict | None:
-    if is_gcs_path(path):
-        return _make_gscs_storage_options()
-    elif is_s3_path(path) or is_r2_path(path):
-        return _make_s3_storage_options()
-    else:
-        return None
+_DEFAULT_GCP_PROJECT = "okapi-274503"
 
 
 class GSPath(cloudpathlib.GSPath):
@@ -71,34 +25,50 @@ class GSPath(cloudpathlib.GSPath):
     For more details, see: https://github.com/drivendataorg/cloudpathlib/issues/390
     """
 
-    _client = None
+    storage_options: dict = {"project": _DEFAULT_GCP_PROJECT}
 
     def __init__(self, cloud_path: str | cloudpathlib.GSPath, client: Optional[GSClient] = None):
         if not client:
-            if not GSPath._client:
-                GSPath._client = cloudpathlib.GSClient(storage_client=GS_Client_Official())
-            client = GSPath._client
+            client = GSPath.__client
         super().__init__(cloud_path, client=client)
+
+    @cached_class_attribute
+    def __client(cls) -> cloudpathlib.GSClient:
+        return cloudpathlib.GSClient(storage_client=GS_Client_Official())
 
 
 class R2Path(cloudpathlib.S3Path):
-    _client = None
-
     def __init__(self, cloud_path: str | cloudpathlib.S3Path, client: Optional[S3Client] = None):
         if not client:
-            if not R2Path._client:
-                # TOOD: complain if these environment variables are not defined?
-                R2Path._client = cloudpathlib.S3Client(
-                    aws_access_key_id=read_gcp_secret("cloudflare_r2_bucket_readwrite_access_key_id"),
-                    aws_secret_access_key=read_gcp_secret("cloudflare_r2_bucket_readwrite_secret_access_key"),
-                    endpoint_url=read_gcp_secret("cloudflare_r2_bucket_readwrite_endpoint_url"),
-                )
-            client = R2Path._client
+            client = R2Path.__client
 
         if isinstance(cloud_path, str):
             cloud_path = cloud_path.replace("r2://", "s3://")
 
         super().__init__(cloud_path, client=client)
+
+    @cached_class_attribute
+    def __client(cls) -> S3Client:
+        return cloudpathlib.S3Client(
+            aws_access_key_id=read_gcp_secret("cloudflare_r2_bucket_readwrite_access_key_id"),
+            aws_secret_access_key=read_gcp_secret("cloudflare_r2_bucket_readwrite_secret_access_key"),
+            endpoint_url=read_gcp_secret("cloudflare_r2_bucket_readwrite_endpoint_url"),
+        )
+
+    @cached_class_attribute
+    def storage_options(self) -> dict:
+        return {
+            "client_kwargs": {
+                "aws_access_key_id": read_gcp_secret("cloudflare_r2_bucket_readwrite_access_key_id"),
+                "aws_secret_access_key": read_gcp_secret("cloudflare_r2_bucket_readwrite_secret_access_key"),
+                "endpoint_url": read_gcp_secret("cloudflare_r2_bucket_readwrite_endpoint_url"),
+            }
+        }
+
+
+class Path(PosixPath):
+    # TODO: Path is a factory class and we're dropping support for WindowsPath class. Let's see if we can bring it back.
+    storage_options = None
 
 
 class AnyPath:
@@ -128,3 +98,28 @@ class AnyPath:
             return R2Path(str(path))
         else:
             return Path(path)
+
+
+def is_gcs_path(path: str | Path | os.PathLike) -> bool:
+    return str(path).startswith("gs://")
+
+
+def is_s3_path(path: str | Path | os.PathLike) -> bool:
+    return str(path).startswith("s3://")
+
+
+def is_r2_path(path: str | Path | os.PathLike) -> bool:
+    # FIXME: This is a temporary solution
+    return "r2://" in str(path)
+
+
+def is_local_path(path: str | Path | os.PathLike) -> bool:
+    return not (is_gcs_path(path) or is_s3_path(path) or is_r2_path(path))
+
+
+def is_cloud_path(path: str | Path | os.PathLike) -> bool:
+    return is_gcs_path(path) or is_s3_path(path) or is_r2_path(path)
+
+
+def strip_cloud_prefix(path: str | Path | os.PathLike) -> str:
+    return str(path).replace("gs://", "").replace("s3://", "").replace("r2://", "")

--- a/esp_data/paths.py
+++ b/esp_data/paths.py
@@ -8,7 +8,7 @@ import cloudpathlib
 from cloudpathlib import GSClient, S3Client, S3Path
 from google.cloud.storage.client import Client as GS_Client_Official
 
-from esp_data.utils import cached_class_attribute, read_gcp_secret
+from esp_data.utils import cached_class_property, read_gcp_secret
 
 _DEFAULT_GCP_PROJECT = "okapi-274503"
 
@@ -32,7 +32,7 @@ class GSPath(cloudpathlib.GSPath):
             client = GSPath.__client
         super().__init__(cloud_path, client=client)
 
-    @cached_class_attribute
+    @cached_class_property
     def __client(cls) -> cloudpathlib.GSClient:
         return cloudpathlib.GSClient(storage_client=GS_Client_Official())
 
@@ -47,7 +47,7 @@ class R2Path(cloudpathlib.S3Path):
 
         super().__init__(cloud_path, client=client)
 
-    @cached_class_attribute
+    @cached_class_property
     def __client(cls) -> S3Client:
         return cloudpathlib.S3Client(
             aws_access_key_id=read_gcp_secret("cloudflare_r2_bucket_readwrite_access_key_id"),
@@ -55,7 +55,7 @@ class R2Path(cloudpathlib.S3Path):
             endpoint_url=read_gcp_secret("cloudflare_r2_bucket_readwrite_endpoint_url"),
         )
 
-    @cached_class_attribute
+    @cached_class_property
     def storage_options(self) -> dict:
         return {
             "client_kwargs": {

--- a/esp_data/utils.py
+++ b/esp_data/utils.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 from datetime import datetime, timedelta, timezone
+from typing import Callable
 from uuid import UUID, uuid4
 
 import google_crc32c
@@ -85,21 +86,21 @@ def increment_version(version: str, mode: str = "patch") -> str:
     return f"{major}.{minor}.{patch}"
 
 
-# async def run_as_async(func: Callable, new_event_loop: bool = False, **func_kwargs) -> Callable:
-#     """Run the function asynchronously.
+async def run_as_async(func: Callable, new_event_loop: bool = False, **func_kwargs) -> Callable:
+    """Run the function asynchronously.
 
-#     Args:
-#         func (Callable): The function to run asynchronously.
+    Args:
+        func (Callable): The function to run asynchronously.
 
-#     Returns:
-#         Callable: The function that runs asynchronously.
-#     """
-#     if new_event_loop:
-#         loop = asyncio.new_event_loop()
-#     else:
-#         loop = asyncio.get_event_loop()
-#     with concurrent.futures.ThreadPoolExecutor() as pool:
-#         return await loop.run_in_executor(pool, partial(func, **func_kwargs))
+    Returns:
+        Callable: The function that runs asynchronously.
+    """
+    if new_event_loop:
+        loop = asyncio.new_event_loop()
+    else:
+        loop = asyncio.get_event_loop()
+    with concurrent.futures.ThreadPoolExecutor() as pool:
+        return await loop.run_in_executor(pool, partial(func, **func_kwargs))
 
 
 def read_gcp_secret(secret_id: str, version_id: str = "latest", project_id: str = "okapi-274503") -> str:

--- a/esp_data/utils.py
+++ b/esp_data/utils.py
@@ -127,10 +127,10 @@ def read_gcp_secret(secret_id: str, version_id: str = "latest", project_id: str 
 
 
 # TODO (milad) add unit tests for this
-class CachedClassAttribute:
+class CachedClassProperty:
     def __init__(self, method):
         self.method = method
-        self.cache_attrname = f"_cached_class_attribute_{method.__name__}"
+        self.cache_attrname = f"_cached_class_attr_{method.__name__}"
 
     def __get__(self, instance, owner=None):
         if owner is None:
@@ -141,5 +141,5 @@ class CachedClassAttribute:
         return getattr(owner, self.cache_attrname)
 
 
-def cached_class_attribute(method):
-    return CachedClassAttribute(method)
+def cached_class_property(method):
+    return CachedClassProperty(method)

--- a/esp_data/utils.py
+++ b/esp_data/utils.py
@@ -1,12 +1,7 @@
-import asyncio
-import concurrent.futures
 import json
 import logging
-import os
 import re
 from datetime import datetime, timedelta, timezone
-from functools import partial
-from typing import Callable
 from uuid import UUID, uuid4
 
 import google_crc32c
@@ -90,21 +85,21 @@ def increment_version(version: str, mode: str = "patch") -> str:
     return f"{major}.{minor}.{patch}"
 
 
-async def run_as_async(func: Callable, new_event_loop: bool = False, **func_kwargs) -> Callable:
-    """Run the function asynchronously.
+# async def run_as_async(func: Callable, new_event_loop: bool = False, **func_kwargs) -> Callable:
+#     """Run the function asynchronously.
 
-    Args:
-        func (Callable): The function to run asynchronously.
+#     Args:
+#         func (Callable): The function to run asynchronously.
 
-    Returns:
-        Callable: The function that runs asynchronously.
-    """
-    if new_event_loop:
-        loop = asyncio.new_event_loop()
-    else:
-        loop = asyncio.get_event_loop()
-    with concurrent.futures.ThreadPoolExecutor() as pool:
-        return await loop.run_in_executor(pool, partial(func, **func_kwargs))
+#     Returns:
+#         Callable: The function that runs asynchronously.
+#     """
+#     if new_event_loop:
+#         loop = asyncio.new_event_loop()
+#     else:
+#         loop = asyncio.get_event_loop()
+#     with concurrent.futures.ThreadPoolExecutor() as pool:
+#         return await loop.run_in_executor(pool, partial(func, **func_kwargs))
 
 
 def read_gcp_secret(secret_id: str, version_id: str = "latest", project_id: str = "okapi-274503") -> str:
@@ -129,3 +124,21 @@ def read_gcp_secret(secret_id: str, version_id: str = "latest", project_id: str 
 
     payload = response.payload.data.decode("UTF-8")
     return payload
+
+
+class CachedClassAttribute:
+    def __init__(self, method):
+        self.method = method
+        self.cache_attrname = f"_cached_class_attribute_{method.__name__}"
+
+    def __get__(self, instance, owner=None):
+        if owner is None:
+            owner = type(instance)
+        if not hasattr(owner, self.cache_attrname):
+            value = self.method(owner)
+            setattr(owner, self.cache_attrname, value)
+        return getattr(owner, self.cache_attrname)
+
+
+def cached_class_attribute(method):
+    return CachedClassAttribute(method)

--- a/esp_data/utils.py
+++ b/esp_data/utils.py
@@ -126,6 +126,7 @@ def read_gcp_secret(secret_id: str, version_id: str = "latest", project_id: str 
     return payload
 
 
+# TODO (milad) add unit tests for this
 class CachedClassAttribute:
     def __init__(self, method):
         self.method = method

--- a/scripts/beans0/run_naturelm_gradio_api.py
+++ b/scripts/beans0/run_naturelm_gradio_api.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 
 from esp_data.dataset.esp_dataset import load_esp_dataset
 from esp_data.file_io.parsers import read_audio_bytes
-from esp_data.paths import AnyPath, make_storage_options
+from esp_data.paths import AnyPath
 
 
 def data_processor(data: dict):
@@ -102,7 +102,7 @@ def main():
                 args.output_path,
                 orient="records",
                 lines=True,
-                storage_options=make_storage_options(args.output_path),
+                storage_options=AnyPath(args.output_path).storage_options,
                 mode="a",
             )
             output_df = empty_df()
@@ -113,7 +113,7 @@ def main():
             args.output_path,
             orient="records",
             lines=True,
-            storage_options=make_storage_options(args.output_path),
+            storage_options=AnyPath(args.output_path).storage_options,
             mode="a",
         )
 

--- a/tests/test_hf_dataset.py
+++ b/tests/test_hf_dataset.py
@@ -6,7 +6,7 @@ import pytest
 import esp_data.file_io.functional as F
 from esp_data.config import DataSample, DatasetConfig
 from esp_data.dataset import HFDataset
-from esp_data.paths import AnyPath, make_storage_options
+from esp_data.paths import AnyPath
 
 # constants for all tests
 cfg = DatasetConfig(
@@ -174,7 +174,7 @@ def test_saving_methods():
 
     ds.save_to_path(
         "gs://esp-ci-cd-tests/esp-data-tests/hf_test_dataset",
-        storage_options=make_storage_options("gs://esp-ci-cd-tests/esp-data-tests/hf_test_dataset"),
+        storage_options=AnyPath("gs://esp-ci-cd-tests/esp-data-tests/hf_test_dataset").storage_options,
     )
 
     assert AnyPath("gs://esp-ci-cd-tests/esp-data-tests/hf_test_dataset").exists()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytest
 
 from esp_data.utils import (
+    cached_class_property,
     increment_version,
     make_id,
     utc_now,
@@ -54,3 +55,57 @@ def test_validate_datetime():
 def test_make_id():
     id = make_id()
     assert validate_id(id) == id
+
+
+def test_cached_class_property_print_output(capsys):
+    class PrintTestClass:
+        @cached_class_property
+        def expensive_property(cls):
+            print("computing expensive value")
+            return "expensive_value"
+
+    # First access should print the message
+    test_instance = PrintTestClass()
+    assert test_instance.expensive_property == "expensive_value"
+    captured = capsys.readouterr()
+    assert "computing expensive value" in captured.out
+
+    # Second access should not print the message
+    assert test_instance.expensive_property == "expensive_value"
+    captured = capsys.readouterr()
+    assert "computing expensive value" not in captured.out
+
+    # Access through another instance should not print the message
+    another_instance = PrintTestClass()
+    assert another_instance.expensive_property == "expensive_value"
+    captured = capsys.readouterr()
+    assert "computing expensive value" not in captured.out
+
+    # Access through class should not print the message
+    assert PrintTestClass.expensive_property == "expensive_value"
+    captured = capsys.readouterr()
+    assert "computing expensive value" not in captured.out
+
+
+def test_cached_class_property_without_instantiation(capsys):
+    class DirectAccessClass:
+        @cached_class_property
+        def expensive_property(cls):
+            print("computing expensive value")
+            return "expensive_value"
+
+    # Access directly through class without any instances
+    assert DirectAccessClass.expensive_property == "expensive_value"
+    captured = capsys.readouterr()
+    assert "computing expensive value" in captured.out
+
+    # Second access should not print the message
+    assert DirectAccessClass.expensive_property == "expensive_value"
+    captured = capsys.readouterr()
+    assert "computing expensive value" not in captured.out
+
+    # Now create an instance and verify it uses the cached value
+    instance = DirectAccessClass()
+    assert instance.expensive_property == "expensive_value"
+    captured = capsys.readouterr()
+    assert "computing expensive value" not in captured.out

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,6 @@ import pytest
 from esp_data.utils import (
     increment_version,
     make_id,
-    run_as_async,
     utc_now,
     validate_datetime,
     validate_id,
@@ -55,11 +54,3 @@ def test_validate_datetime():
 def test_make_id():
     id = make_id()
     assert validate_id(id) == id
-
-
-async def test_run_as_async():
-    def add(a, b):
-        return a + b
-
-    result = await run_as_async(add, a=1, b=2)
-    assert result == 3


### PR DESCRIPTION
- Added `cached_class_attribute` decorator. Python has `@cached_property` but they're for instance attributes not class attributes. 
- Removed `make_storage_options()` and instead used the new `cached_class_attribute` to have a `.storage_options` attr
- Do the client caching with the new decorator
- Removed `run_as_async`. I think it's out of scope of this library