### PR TITLE
fix concurrency issue with building docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,10 @@ on:
       - v[0-9]+.[0-9]+*
       - latest
 
+concurrency:
+  group: docs-build
+  cancel-in-progress: false
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When making a release we often push two tags at once (e.g. `v1.0.0` and `latest`). This triggers two github actions for building the docs. Both jobs try to push to `docs-site` branch which can cause an error. This PR makes sure we only run one of these jobs in parallel