### PR TITLE
allowing negatives in multilabel

### DIFF
--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -127,6 +127,7 @@ The `MultiLabelFromFeatures` transform extends the functionality of `LabelFromFe
     options:
         show_root_heading: true
         show_source: true
+        allow_missing_labels: true
 
 ### Subsample Transform
 The `Subsample` transform reduces the size of your dataset by sampling a subset of the data.  Example use case: Creating a 10% random sample of a large dataset for initial testing.

--- a/esp_data/transforms/multilabel_from_features.py
+++ b/esp_data/transforms/multilabel_from_features.py
@@ -46,6 +46,9 @@ class MultiLabelFromFeatures:
     override : bool, default=False
         If False and the output_feature already exists in the dataset, an error is
         raised. If True, the output_feature will be overwritten.
+    allow_missing_labels : bool, default=True
+        If True, rows with no labels will be included in the output. If False, rows with
+        no labels will be dropped.
 
     Methods
     -------
@@ -63,11 +66,13 @@ class MultiLabelFromFeatures:
         label_map: dict[str, int] | None = None,
         output_feature: str = "label",
         override: bool = False,
+        allow_missing_labels: bool = True,
     ) -> None:
         self.features = features
         self.label_map = label_map
         self.override = override
         self.output_feature = output_feature
+        self.allow_missing_labels = allow_missing_labels
 
     @classmethod
     def from_config(cls, cfg: MultiLabelFromFeaturesConfig) -> "MultiLabelFromFeatures":
@@ -97,7 +102,8 @@ class MultiLabelFromFeatures:
                 else:
                     v = [row[f]]
                 row_labels.extend(map(lambda x: label_map[x], v))
-
+            if not self.allow_missing_labels and len(row_labels) == 0:
+                return None
             return sorted(row_labels)
 
         df[self.output_feature] = df[self.features].apply(_row_to_ids, axis="columns")

--- a/esp_data/transforms/multilabel_from_features.py
+++ b/esp_data/transforms/multilabel_from_features.py
@@ -87,7 +87,7 @@ class MultiLabelFromFeatures:
         else:
             label_map = self.label_map
 
-        def _row_to_ids(row: pd.Series) -> list | None:
+        def _row_to_ids(row: pd.Series) -> list:
             row_labels = []
             for f in self.features:
                 if isinstance(row[f], list):
@@ -98,10 +98,7 @@ class MultiLabelFromFeatures:
                     v = [row[f]]
                 row_labels.extend(map(lambda x: label_map[x], v))
 
-            if row_labels:
-                return sorted(row_labels)
-            else:
-                return None
+            return sorted(row_labels)
 
         df[self.output_feature] = df[self.features].apply(_row_to_ids, axis="columns")
 

--- a/esp_data/transforms/multilabel_from_features.py
+++ b/esp_data/transforms/multilabel_from_features.py
@@ -92,7 +92,7 @@ class MultiLabelFromFeatures:
         else:
             label_map = self.label_map
 
-        def _row_to_ids(row: pd.Series) -> list:
+        def _row_to_ids(row: pd.Series) -> list | None:
             row_labels = []
             for f in self.features:
                 if isinstance(row[f], list):

--- a/tests/test_multilabel_from_features.py
+++ b/tests/test_multilabel_from_features.py
@@ -95,7 +95,7 @@ def test_multilabel_from_features(
     expected_labels: list[list[str]],
     expected_map: dict[str, int],
 ) -> None:
-    t = MultiLabelFromFeatures(features=features)
+    t = MultiLabelFromFeatures(features=features, allow_missing_labels=False)
     df_out, meta = t(df.copy())
     assert df_out["label"].tolist() == expected_labels
     assert meta["label_map"] == expected_map
@@ -105,7 +105,7 @@ def test_multilabel_from_features(
 def test_multilabel_from_features_with_extra_labels() -> None:
     df = pd.DataFrame({"col1": ["banana", "apple", "banana", "orange"]})
     label_map = {"apple": 0, "banana": 1, "orange": 2, "grape": 3, "melon": 4}
-    t = MultiLabelFromFeatures(features=["col1"], label_map=label_map)
+    t = MultiLabelFromFeatures(features=["col1"], label_map=label_map, allow_missing_labels=False)
     df_out, meta = t(df.copy())
     # Only present labels should be used in output
     assert df_out["label"].tolist() == [[1], [0], [1], [2]]
@@ -116,7 +116,7 @@ def test_multilabel_from_features_with_extra_labels() -> None:
 def test_multilabel_from_features_with_noncontiguous_indices() -> None:
     df = pd.DataFrame({"col1": ["banana", "apple", "banana", "orange"]})
     label_map = {"apple": 100, "banana": 101, "orange": 102}
-    t = MultiLabelFromFeatures(features=["col1"], label_map=label_map)
+    t = MultiLabelFromFeatures(features=["col1"], label_map=label_map, allow_missing_labels=False)
     df_out, meta = t(df.copy())
     assert df_out["label"].tolist() == [[101], [100], [101], [102]]
     assert meta["label_map"] == label_map
@@ -125,7 +125,7 @@ def test_multilabel_from_features_with_noncontiguous_indices() -> None:
 
 def test_multilabel_from_features_label_map_remains_none() -> None:
     df = pd.DataFrame({"col1": ["banana", "apple", "banana", "orange"]})
-    t = MultiLabelFromFeatures(features=["col1"])
+    t = MultiLabelFromFeatures(features=["col1"], allow_missing_labels=False)
     assert t.label_map is None
     df_out, meta = t(df.copy())
     # The transform should still not set t.label_map
@@ -134,3 +134,28 @@ def test_multilabel_from_features_label_map_remains_none() -> None:
     assert sorted(meta["label_map"].keys()) == ["apple", "banana", "orange"]
     assert meta["num_classes"] == 3
     assert df_out["label"].tolist() == [[1], [0], [1], [2]]
+
+
+def test_multilabel_from_features_allow_missing_labels() -> None:
+    """Ensure that the *allow_missing_labels* flag correctly retains or drops rows with no labels."""
+    df = pd.DataFrame({"col1": ["banana", [], "orange"]})
+
+    # When allow_missing_labels=True (default) we expect to **keep** rows with no labels.
+    t_keep = MultiLabelFromFeatures(features=["col1"], allow_missing_labels=True)
+    df_keep, meta_keep = t_keep(df.copy())
+
+    # The label map should contain only the present, non-empty labels
+    assert meta_keep["label_map"] == {"banana": 0, "orange": 1}
+    assert meta_keep["num_classes"] == 2
+    # All original rows should remain, with empty rows represented by an empty list
+    assert df_keep["label"].tolist() == [[0], [], [1]]
+
+    # When allow_missing_labels=False we expect rows with no labels to be **dropped**.
+    t_drop = MultiLabelFromFeatures(features=["col1"], allow_missing_labels=False)
+    df_drop, meta_drop = t_drop(df.copy())
+
+    # Metadata should be identical to the previous run
+    assert meta_drop == meta_keep
+    # The resulting DataFrame should only contain the rows with labels ("banana" and "orange")
+    assert df_drop["label"].tolist() == [[0], [1]]
+    assert len(df_drop) == 2


### PR DESCRIPTION
During evaluation on multilabel datasets, for instance on BEANS detection, we need to include the negative examples, i.e. those which have no labels. I'm assuming this will be true for other multilabel cases as well, though excluding them by e.g. a transform may be common. Examples were previously being dropped by .dropna() since this _row_to_ids previously returned None. 