### PR TITLE
Small fixes

### DIFF
--- a/esp_data/dataset.py
+++ b/esp_data/dataset.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Iterator, Optional
 import semver
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from esp_data.io import anypath
 from esp_data.transforms import RegisteredTransformConfigs, transform_from_config
 
 
@@ -65,7 +64,7 @@ class DatasetConfig(BaseModel):
 class DatasetInfo(BaseModel):
     """A Pydantic base model for the info (cfg) of a dataset.
 
-    Parameters
+    Attributes
     ---------
     name : str
         Name of the dataset
@@ -144,41 +143,6 @@ class DatasetInfo(BaseModel):
     changelog: str = Field(
         default_factory=lambda: "", description="Changelog from previous version"
     )
-
-    @field_validator("split_paths", mode="after")
-    @classmethod
-    def validate_split_exists(cls, v: dict) -> str:
-        """Validate that the split path exists in cloud storage or locally
-
-        Parameters
-        ---------
-        v : dict[str, str]
-            The locations to validate
-
-        Returns
-        -------
-        dict[str, str]
-            The validated locations
-
-        Raises
-        ------
-        ValueError
-            If the location does not exist in cloud storage or locally
-        ValueError
-            If the location is a directory and is empty
-        """
-        if not v:
-            raise ValueError("Split paths cannot be empty.")
-        for _, value in v.items():
-            path = anypath(value)
-            if not path.exists():
-                raise ValueError(f"Local path {value} does not exist.")
-
-            # if location is directory, check that it is not empty
-            if path.is_dir() and not any(path.iterdir()):
-                raise ValueError(f"Directory {value} is empty.")
-
-        return v
 
     @field_validator("version")
     @classmethod
@@ -360,7 +324,9 @@ class Dataset(ABC):
         """
         raise NotImplementedError
 
-    def apply_transformations(self, transformations: list[RegisteredTransformConfigs]) -> list[Any]:
+    def apply_transformations(
+        self, transformations: list[RegisteredTransformConfigs]
+    ) -> dict[str, Any]:
         """Apply the given list of transformations to the dataset.
 
         This method applies each transformation in sequence to the dataset's data.
@@ -373,7 +339,7 @@ class Dataset(ABC):
 
         Returns
         -------
-        dict[str, Any]
+        transform_metadata: dict[str, Any]
             A dictionary containing metadata for each transformation applied.
             The keys are the transformation types, and the values are the metadata
             returned by each transformation.
@@ -392,7 +358,6 @@ class Dataset(ABC):
             self._data, metadata = transform(self._data)
             transform_metadata[cfg.type] = metadata
 
-            # TODO (milad): what about metadata?
         return transform_metadata
 
 
@@ -444,13 +409,13 @@ def dataset_from_config(
     ----------
     dataset_config : DatasetConfig
         The configuration for the dataset.
-    transform_metadata : dict[str, Any]
-        Metadata about transformations applied, if any. Can be empty.
 
     Returns
     -------
     Dataset
         The requested dataset instance
+    transform_metadata : dict[str, Any]
+        Metadata about transformations applied, if any. Can be empty.
 
     Raises
     ------

--- a/esp_data/datasets/animalspeak.py
+++ b/esp_data/datasets/animalspeak.py
@@ -190,7 +190,7 @@ class AnimalSpeak(Dataset):
         IndexError
             If the index is out of bounds.
         """
-        if idx < 0 or idx >= len(self._data):
+        if idx >= len(self._data):
             raise IndexError(f"Index {idx} out of bounds for dataset of length {len(self._data)}.")
 
         row = self._data.iloc[idx].to_dict()
@@ -233,15 +233,7 @@ class AnimalSpeak(Dataset):
         -------
         Dict[str, Any]
             Each sample in the dataset.
-
-        Raises
-        ------
-        RuntimeError
-            If no split has been loaded yet.
         """
-        if self._data is None:
-            raise RuntimeError("No split has been loaded yet. Call load() first.")
-
         for idx in range(len(self)):
             yield self[idx]
 

--- a/esp_data/datasets/barkley_canyon.py
+++ b/esp_data/datasets/barkley_canyon.py
@@ -193,7 +193,7 @@ class BarkleyCanyon(Dataset):
         IndexError
             If the index is out of bounds.
         """
-        if idx < 0 or idx >= len(self._data):
+        if idx >= len(self._data):
             raise IndexError(f"Index {idx} out of bounds for dataset of length {len(self._data)}.")
 
         row = self._data.iloc[idx].to_dict()
@@ -258,15 +258,7 @@ class BarkleyCanyon(Dataset):
         -------
         Dict[str, Any]
             Each sample in the dataset.
-
-        Raises
-        ------
-        RuntimeError
-            If no split has been loaded yet.
         """
-        if self._data is None:
-            raise RuntimeError("No split has been loaded yet. Call load() first.")
-
         for idx in range(len(self)):
             yield self[idx]
 

--- a/esp_data/datasets/beans.py
+++ b/esp_data/datasets/beans.py
@@ -247,7 +247,7 @@ class Beans(Dataset):
         IndexError
             If the index is out of bounds.
         """
-        if idx < 0 or idx >= len(self._data):
+        if idx >= len(self._data):
             raise IndexError(f"Index {idx} out of bounds for dataset of length {len(self._data)}.")
 
         row = self._data.iloc[idx].to_dict()
@@ -290,15 +290,7 @@ class Beans(Dataset):
         -------
         Dict[str, Any]
             Each sample in the dataset.
-
-        Raises
-        ------
-        RuntimeError
-            If no split has been loaded yet.
         """
-        if self._data is None:
-            raise RuntimeError("No split has been loaded yet. Call load() first.")
-
         for idx in range(len(self)):
             yield self[idx]
 

--- a/esp_data/datasets/birdset.py
+++ b/esp_data/datasets/birdset.py
@@ -210,7 +210,7 @@ class BirdSet(Dataset):
         IndexError
             If the index is out of bounds.
         """
-        if idx < 0 or idx >= len(self._data):
+        if idx >= len(self._data):
             raise IndexError(f"Index {idx} out of bounds for dataset of length {len(self._data)}.")
 
         row = self._data.iloc[idx].to_dict()
@@ -253,15 +253,7 @@ class BirdSet(Dataset):
         -------
         Dict[str, Any]
             Each sample in the dataset.
-
-        Raises
-        ------
-        RuntimeError
-            If no split has been loaded yet.
         """
-        if self._data is None:
-            raise RuntimeError("No split has been loaded yet. Call load() first.")
-
         for idx in range(len(self)):
             yield self[idx]
 

--- a/esp_data/datasets/insectset_459.py
+++ b/esp_data/datasets/insectset_459.py
@@ -193,7 +193,7 @@ class InsectSet459(Dataset):
         IndexError
             If the index is out of bounds.
         """
-        if idx < 0 or idx >= len(self._data):
+        if idx >= len(self._data):
             raise IndexError(f"Index {idx} out of bounds for dataset of length {len(self._data)}.")
 
         row = self._data.iloc[idx].to_dict()
@@ -236,15 +236,7 @@ class InsectSet459(Dataset):
         -------
         Dict[str, Any]
             Each sample in the dataset.
-
-        Raises
-        ------
-        RuntimeError
-            If no split has been loaded yet.
         """
-        if self._data is None:
-            raise RuntimeError("No split has been loaded yet. Call load() first.")
-
         for idx in range(len(self)):
             yield self[idx]
 

--- a/esp_data/transforms/label_from_feature.py
+++ b/esp_data/transforms/label_from_feature.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Literal
+from typing import Any, Literal
 
 import pandas as pd
 from pydantic import BaseModel
@@ -12,7 +12,7 @@ logger = logging.Logger("esp_data")
 class LabelFromFeatureConfig(BaseModel):
     type: Literal["label_from_feature"]
     feature: str
-    label_map: dict[str, int] | None = None
+    label_map: dict[Any, int] | None = None
     output_feature: str = "label"
     override: bool = False
 
@@ -26,7 +26,7 @@ class LabelFromFeature:
     ----------
     feature: str
         The name of the feature in the DataFrame from which to create labels.
-    label_map: dict[str, int] | None
+    label_map: dict[Any, int] | None
         A mapping of feature values to integer labels. If None, the labels will be
         created from the unique values in the feature.
     output_feature: str
@@ -47,7 +47,7 @@ class LabelFromFeature:
         self,
         *,
         feature: str,
-        label_map: dict[str, int] | None = None,
+        label_map: dict[Any, int] | None = None,
         output_feature: str = "label",
         override: bool = False,
     ) -> None:

--- a/esp_data/transforms/multilabel_from_features.py
+++ b/esp_data/transforms/multilabel_from_features.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Literal
+from typing import Any, Literal
 
 import pandas as pd
 from pydantic import BaseModel
@@ -12,7 +12,7 @@ logger = logging.Logger("esp_data")
 class MultiLabelFromFeaturesConfig(BaseModel):
     type: Literal["labels_from_features"]
     features: str | list[str]
-    label_map: dict[str, int] | None = None
+    label_map: dict[Any, int] | None = None
     output_feature: str = "label"
     override: bool = False
 
@@ -38,7 +38,7 @@ class MultiLabelFromFeatures:
     features : list[str]
         The names of the columns in the DataFrame to use as sources for the labels. Each
         column can contain a single value or a list of values per row.
-    label_map : dict[str, int] | None, default=None
+    label_map : dict[Any, int] | None, default=None
         A mapping of unique values to integer IDs. If not provided, the transform will
         generate a mapping based on the unique values in the specified feature columns.
     output_feature : str, default="label"
@@ -78,7 +78,7 @@ class MultiLabelFromFeatures:
         self,
         *,
         features: list[str],
-        label_map: dict[str, int] | None = None,
+        label_map: dict[Any, int] | None = None,
         output_feature: str = "label",
         override: bool = False,
     ) -> None:

--- a/tests/test_animal_speak.py
+++ b/tests/test_animal_speak.py
@@ -4,6 +4,7 @@ import pytest
 
 from esp_data.datasets import AnimalSpeak
 from esp_data import Dataset, DatasetConfig
+from esp_data.io import anypath
 
 
 @pytest.fixture
@@ -114,6 +115,9 @@ def test_info_property(dataset: Dataset) -> None:
     assert dataset.info.version == "0.1.0"
     assert "train" in dataset.info.split_paths
     assert "validation" in dataset.info.split_paths
+    # test splits exist
+    assert anypath(dataset.info.split_paths["train"]).exists()
+    assert anypath(dataset.info.split_paths["validation"]).exists()
 
 
 def test_data_property(dataset: Dataset) -> None:

--- a/tests/test_barkley_canyon.py
+++ b/tests/test_barkley_canyon.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from esp_data.datasets import BarkleyCanyon, BarkleyCanyonDetection
 from esp_data import Dataset, DatasetConfig
+from esp_data.io import anypath
 
 
 @pytest.fixture
@@ -174,6 +175,7 @@ def test_info_property(dataset: Dataset) -> None:
     assert dataset.info.version == "0.1.0"
     assert "train" in dataset.info.split_paths
     assert "validation" not in dataset.info.split_paths
+    assert anypath(dataset.info.split_paths["train"]).exists()
 
 
 def test_data_property(dataset: Dataset) -> None:
@@ -324,6 +326,7 @@ def test_detection_info_property(dataset_detection: Dataset) -> None:
     assert dataset_detection.info.version == "0.1.0"
     assert "train" in dataset_detection.info.split_paths
     assert "validation" not in dataset_detection.info.split_paths
+    assert anypath(dataset_detection.info.split_paths["train"]).exists()
 
 
 def test_detection_data_property(dataset_detection: Dataset) -> None:

--- a/tests/test_beans.py
+++ b/tests/test_beans.py
@@ -4,6 +4,7 @@ import pytest
 
 from esp_data.datasets import Beans
 from esp_data import Dataset, DatasetConfig
+from esp_data.io import anypath
 
 
 @pytest.fixture
@@ -74,6 +75,8 @@ def test_info_property(dataset: Dataset) -> None:
     assert dataset.info.version == "0.1.0"
     assert "train" in dataset.info.split_paths
     assert "validation" in dataset.info.split_paths
+    for split in dataset.info.split_paths.values():
+        assert anypath(split).exists(), f"Split path {split} does not exist"
 
 
 def test_data_property(dataset: Dataset) -> None:

--- a/tests/test_birdset.py
+++ b/tests/test_birdset.py
@@ -4,6 +4,7 @@ import pytest
 
 from esp_data.datasets import BirdSet
 from esp_data import Dataset, DatasetConfig
+from esp_data.io import anypath
 
 
 @pytest.fixture
@@ -69,6 +70,8 @@ def test_info_property(dataset: Dataset) -> None:
     assert "HSN-train" in dataset.info.split_paths
     assert "PER-validation" in dataset.info.split_paths
     assert "POW-test" in dataset.info.split_paths
+    for split in dataset.info.split_paths.values():
+        assert anypath(split).exists(), f"Split path {split} does not exist"
 
 
 def test_data_property(dataset: Dataset) -> None:

--- a/tests/test_insectset_459.py
+++ b/tests/test_insectset_459.py
@@ -4,6 +4,7 @@ import pytest
 
 from esp_data.datasets import InsectSet459
 from esp_data import Dataset, DatasetConfig
+from esp_data.io import anypath
 
 
 @pytest.fixture
@@ -76,6 +77,8 @@ def test_info_property(dataset: Dataset) -> None:
     assert dataset.info.version == "0.1.0"
     assert "train" in dataset.info.split_paths
     assert "validation" in dataset.info.split_paths
+    for split in dataset.info.split_paths.values():
+        assert anypath(split).exists(), f"Split path {split} does not exist"
 
 
 def test_data_property(dataset: Dataset) -> None:


### PR DESCRIPTION
- [x] An indexing error was wrongly raised for negative python array indexing (e.g. `x = [1,2,3]; x[-1]` is allowed in python
- [x] The split_path validation in `DatasetInfo` is now removed. Because of how datasets get "registered" when one is imported, all split_path validations occur which slows down imports a lot. The validation is now moved to unit tests.
- [x] Small doc string fixes that were causing problems when running build_docs.yml CI
- [x] Fix for issue #59 