### PR TITLE
Small transform fix

### DIFF
--- a/esp_data/transforms/label_from_feature.py
+++ b/esp_data/transforms/label_from_feature.py
@@ -93,7 +93,13 @@ class LabelFromFeature:
         else:
             label_map = self.label_map
 
-        df_clean.loc[:, [self.output_feature]] = df_clean[self.feature].map(label_map)
+        if self.output_feature in df_clean:
+            # This will overwrite the existing feature if it exists
+            df_clean.loc[:, self.output_feature] = df_clean[self.feature].map(label_map)
+        else:
+            # Doing this avoids the SettingWithCopyWarning, i.e.
+            # "A value is trying to be set on a copy of a slice from a DataFrame."
+            df_clean.loc[:, [self.output_feature]] = df_clean[self.feature].map(label_map)
 
         metadata = {
             "label_feature": self.feature,

--- a/esp_data/transforms/label_from_feature.py
+++ b/esp_data/transforms/label_from_feature.py
@@ -93,6 +93,10 @@ class LabelFromFeature:
         else:
             label_map = self.label_map
 
+        # We use assign here because it allows us to create the
+        # self.output_feature column if it doesn't exist, or overwrite
+        # it if it does, without needing to use .copy() or
+        # .loc with different syntax's depending on overwrite or not.
         df_clean = df_clean.assign(**{self.output_feature: df_clean[self.feature].map(label_map)})
 
         metadata = {

--- a/esp_data/transforms/label_from_feature.py
+++ b/esp_data/transforms/label_from_feature.py
@@ -93,13 +93,7 @@ class LabelFromFeature:
         else:
             label_map = self.label_map
 
-        if self.output_feature in df_clean:
-            # This will overwrite the existing feature if it exists
-            df_clean.loc[:, self.output_feature] = df_clean[self.feature].map(label_map)
-        else:
-            # Doing this avoids the SettingWithCopyWarning, i.e.
-            # "A value is trying to be set on a copy of a slice from a DataFrame."
-            df_clean.loc[:, [self.output_feature]] = df_clean[self.feature].map(label_map)
+        df_clean = df_clean.assign(**{self.output_feature: df_clean[self.feature].map(label_map)})
 
         metadata = {
             "label_feature": self.feature,

--- a/esp_data/transforms/multilabel_from_features.py
+++ b/esp_data/transforms/multilabel_from_features.py
@@ -98,7 +98,9 @@ class MultiLabelFromFeatures:
 
     def __call__(self, df: pd.DataFrame) -> tuple[pd.DataFrame, dict]:
         if self.output_feature in df and not self.override:
-            raise AssertionError("TODO (milad)")
+            raise AssertionError(
+                "Feature already exists in DataFrame. Set `override=True` to replace it."
+            )
 
         if self.label_map is None:
             uniques = set()

--- a/tests/test_label_from_feature.py
+++ b/tests/test_label_from_feature.py
@@ -30,7 +30,7 @@ def test_label_from_feature(
     expected_map: dict[str, int],
 ) -> None:
     t = LabelFromFeature(feature=feature)
-    df_out, meta = t(df.copy())
+    df_out, meta = t(df)
     assert df_out["label"].tolist() == expected_labels
     assert meta["label_map"] == expected_map
     assert meta["num_classes"] == len(expected_map)
@@ -40,7 +40,7 @@ def test_label_from_feature_with_label_map() -> None:
     df = pd.DataFrame({"col1": ["banana", "apple", "banana", "orange"]})
     label_map = {"apple": 0, "banana": 1, "orange": 2, "grape": 3}
     t = LabelFromFeature(feature="col1", label_map=label_map)
-    df_out, meta = t(df.copy())
+    df_out, meta = t(df)
     assert df_out["label"].tolist() == [1, 0, 1, 2]
     assert meta["label_map"] == label_map
     assert meta["num_classes"] == len(label_map)
@@ -50,7 +50,7 @@ def test_label_from_feature_with_noncontiguous_indices() -> None:
     df = pd.DataFrame({"col1": ["banana", "apple", "banana", "orange"]})
     label_map = {"apple": 100, "banana": 101, "orange": 102}
     t = LabelFromFeature(feature="col1", label_map=label_map)
-    df_out, meta = t(df.copy())
+    df_out, meta = t(df)
     assert df_out["label"].tolist() == [101, 100, 101, 102]
     assert meta["label_map"] == label_map
     assert meta["num_classes"] == len(label_map)
@@ -60,8 +60,34 @@ def test_label_from_feature_label_map_remains_none() -> None:
     df = pd.DataFrame({"col1": ["banana", "apple", "banana", "orange"]})
     t = LabelFromFeature(feature="col1")
     assert t.label_map is None
-    df_out, meta = t(df.copy())
+    df_out, meta = t(df)
     assert t.label_map is None
     assert sorted(meta["label_map"].keys()) == ["apple", "banana", "orange"]
     assert meta["num_classes"] == 3
     assert df_out["label"].tolist() == [1, 0, 1, 2]
+
+
+def test_label_from_feature_with_label_map_two_cols() -> None:
+    df = pd.DataFrame({
+        "col1": ["banana", "apple", "banana", "orange"],
+        "col2": ["dog", "cat", "dog", "mouse"]
+    })
+    label_map = {"apple": 0, "banana": 1, "orange": 2, "dog": 3, "cat": 4, "mouse": 5}
+    t = LabelFromFeature(feature="col1", label_map=label_map)
+    df_out, meta = t(df)
+    assert df_out["label"].tolist() == [1, 0, 1, 2]
+    assert meta["label_map"] == label_map
+    assert meta["num_classes"] == len(label_map)
+
+
+def test_label_from_feature_with_label_map_two_cols_identicalnames() -> None:
+    df = pd.DataFrame({
+        "label": ["banana", "apple", "banana", "orange"],
+        "col2": ["dog", "cat", "dog", "mouse"]
+    })
+    label_map = {"apple": 0, "banana": 1, "orange": 2, "dog": 3, "cat": 4, "mouse": 5}
+    t = LabelFromFeature(feature="label", label_map=label_map, output_feature="label", override=True)
+    df_out, meta = t(df)
+    assert df_out["label"].tolist() == [1, 0, 1, 2]
+    assert meta["label_map"] == label_map
+    assert meta["num_classes"] == len(label_map)

--- a/tests/test_multilabel_from_features.py
+++ b/tests/test_multilabel_from_features.py
@@ -159,3 +159,16 @@ def test_multilabel_from_features_allow_missing_labels() -> None:
     # The resulting DataFrame should only contain the rows with labels ("banana" and "orange")
     assert df_drop["label"].tolist() == [[0], [1]]
     assert len(df_drop) == 2
+
+
+def test_multilabel_from_features_outputfeature_already_present() -> None:
+    """Ensure that an AssertionError is raised if the output feature already exists and override is False."""
+    df = pd.DataFrame({"col1": ["banana", "apple", "banana", "orange"],
+                       "label": ["dog", "cat", "dog", "mouse"]})
+    t = MultiLabelFromFeatures(features=["label"], output_feature="label", override=False)
+    with pytest.raises(AssertionError, match="Feature already exists in DataFrame"):
+        t(df)
+
+    t = MultiLabelFromFeatures(features=["label"], output_feature="label", override=True)
+    df_out, meta = t(df)
+    assert df_out["label"].tolist() == [[1], [0], [1], [2]]


### PR DESCRIPTION
1. Fixes a bug in `label_to_feature` when a feature with the same name as `output_feature` is being overwritten by a given label map
2. Assertion error change in `multilabel_from_feature`. (Does this do what its supposed to do ?)