### PR TITLE
Adding Voxaboxen datasets

### DIFF
--- a/esp_data/__init__.py
+++ b/esp_data/__init__.py
@@ -22,6 +22,8 @@ from .datasets import (
     LittleOwlId,
     MacaquesCooCalls,
     PipitId,
+    Voxaboxen,
+    VoxaboxenEvents,
     ZebraFinchJulieElie,
 )
 
@@ -48,4 +50,6 @@ __all__ = [
     "ZebraFinchJulieElie",
     "BengaleseFinchCalls",
     "MacaquesCooCalls",
+    "Voxaboxen",
+    "VoxaboxenEvents",
 ]

--- a/esp_data/datasets/__init__.py
+++ b/esp_data/datasets/__init__.py
@@ -10,6 +10,7 @@ from .insectset_459 import InsectSet459
 from .littleowl_id import LittleOwlId
 from .macaques_coo_calls import MacaquesCooCalls
 from .pipit_id import PipitId
+from .voxaboxen import Voxaboxen, VoxaboxenEvents
 from .zebra_finch_julie_elie import ZebraFinchJulieElie
 
 __all__ = [
@@ -27,4 +28,6 @@ __all__ = [
     "PipitId",
     "AudioSet",
     "MacaquesCooCalls",
+    "Voxaboxen",
+    "VoxaboxenEvents",
 ]

--- a/esp_data/datasets/voxaboxen.py
+++ b/esp_data/datasets/voxaboxen.py
@@ -1,0 +1,973 @@
+"""Voxaboxen-data dataset"""
+
+import math
+from io import StringIO
+from typing import Any, Dict, Iterator, Optional
+
+import librosa
+import numpy as np
+import pandas as pd
+from intervaltree import IntervalTree
+from numpy.random import default_rng
+
+from esp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
+from esp_data.io import (
+    AnyPathT,
+    anypath,
+    audio_stereo_to_mono,
+    get_audio_info,
+    read_audio,
+)
+
+
+@register_dataset
+class Voxaboxen(Dataset):
+    """Voxaboxen dataset.
+
+    Description
+    -----------
+    Voxaboxen is the dataset used in the Voxaboxen project. It consists of
+    several datasets with annotated call start and end times via selection tables.
+    Excerpt from paper:
+    "...a method for accurately detecting bioacoustic sound events that is robust
+    to overlapping events... We also release a new dataset designed to measure
+    performance on detecting overlapping vocalizations. This consists of recordings of
+    zebra finches annotated with temporally-strong labels and showing frequent overlaps.
+    We test Voxaboxen on seven existing data sets and on our new data set."
+
+    References
+    ----------
+    Robust detection of overlapping bioacoustic sound events
+    Louis Mahon, Benjamin Hoffman, Logan S James, Maddie Cusimano,
+    Masato Hagiwara, Sarah C Woolley, Olivier Pietquin
+    https://arxiv.org/abs/2503.02389
+
+    Examples
+    -------
+    >>> from esp_data.datasets import Voxaboxen
+    >>> dataset = Voxaboxen(
+    ...     split="BV_val",
+    ...     output_take_and_give={"selection_table": "st"}
+    ... )
+    >>> print(dataset.info.name)
+    voxaboxen
+    """
+
+    info = DatasetInfo(
+        name="voxaboxen",
+        owner="benjamin; gagan",
+        split_paths={
+            "Anuraset_train": "gs://esp-ml-datasets/voxaboxen/files/Anuraset/formatted/train_info.csv",
+            "Anuraset_val": "gs://esp-ml-datasets/voxaboxen/files/Anuraset/formatted/val_info.csv",
+            "Anuraset_test": "gs://esp-ml-datasets/voxaboxen/files/Anuraset/formatted/test_info.csv",
+            "BV_train": "gs://esp-ml-datasets/voxaboxen/files/BV/formatted/train_info.csv",
+            "BV_val": "gs://esp-ml-datasets/voxaboxen/files/BV/formatted/val_info.csv",
+            "BV_test": "gs://esp-ml-datasets/voxaboxen/files/BV/formatted/test_info.csv",
+            "MT_train": "gs://esp-ml-datasets/voxaboxen/files/MT/formatted/train_info.csv",
+            "MT_val": "gs://esp-ml-datasets/voxaboxen/files/MT/formatted/val_info.csv",
+            "MT_test": "gs://esp-ml-datasets/voxaboxen/files/MT/formatted/test_info.csv",
+            "OZF_train": "gs://esp-ml-datasets/voxaboxen/files/OZF/formatted/train_info.csv",
+            "OZF_val": "gs://esp-ml-datasets/voxaboxen/files/OZF/formatted/val_info.csv",
+            "OZF_test": "gs://esp-ml-datasets/voxaboxen/files/OZF/formatted/test_info.csv",
+            "hawaii_train": "gs://esp-ml-datasets/voxaboxen/files/hawaii/formatted/train_info.csv",
+            "hawaii_val": "gs://esp-ml-datasets/voxaboxen/files/hawaii/formatted/val_info.csv",
+            "hawaii_test": "gs://esp-ml-datasets/voxaboxen/files/hawaii/formatted/test_info.csv",
+            "humpback_train": "gs://esp-ml-datasets/voxaboxen/files/humpback/formatted/train_info.csv",
+            "humpback_val": "gs://esp-ml-datasets/voxaboxen/files/humpback/formatted/val_info.csv",
+            "humpback_test": "gs://esp-ml-datasets/voxaboxen/files/humpback/formatted/test_info.csv",
+            "katydids_train": "gs://esp-ml-datasets/voxaboxen/files/katydids/formatted/train_info.csv",
+            "katydids_val": "gs://esp-ml-datasets/voxaboxen/files/katydids/formatted/val_info.csv",
+            "katydids_test": "gs://esp-ml-datasets/voxaboxen/files/katydids/formatted/test_info.csv",
+            "powdermill_train": "gs://esp-ml-datasets/voxaboxen/files/powdermill/formatted/train_info.csv",
+            "powdermill_val": "gs://esp-ml-datasets/voxaboxen/files/powdermill/formatted/val_info.csv",
+            "powdermill_test": "gs://esp-ml-datasets/voxaboxen/files/powdermill/formatted/test_info.csv",
+            "OZF_synthetic_overlap_0_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0/train_info.csv",
+            "OZF_synthetic_overlap_0_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0/val_info.csv",
+            "OZF_synthetic_overlap_0_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0/test_info.csv",
+            "OZF_synthetic_overlap_0.2_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.2/train_info.csv",
+            "OZF_synthetic_overlap_0.2_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.2/val_info.csv",
+            "OZF_synthetic_overlap_0.2_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.2/test_info.csv",
+            "OZF_synthetic_overlap_0.4_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.4/train_info.csv",
+            "OZF_synthetic_overlap_0.4_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.4/val_info.csv",
+            "OZF_synthetic_overlap_0.4_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.4/test_info.csv",
+            "OZF_synthetic_overlap_0.6_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.6/train_info.csv",
+            "OZF_synthetic_overlap_0.6_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.6/val_info.csv",
+            "OZF_synthetic_overlap_0.6_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.6/test_info.csv",
+            "OZF_synethetic_overlap_1_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/train_info.csv",
+            "OZF_synethetic_overlap_1_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/val_info.csv",
+            "OZF_synethetic_overlap_1_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/test_info.csv",
+        },
+        version="0.1.0",
+        description="Voxaboxen dataset for acoustic sound event detection",
+        sources=[
+            "Anuraset",
+            "BV",
+            "MT",
+            "OZF",
+            "Hawaii",
+            "Humpback",
+            "Katydids",
+            "Powdermill",
+        ],
+        license="CC BY",
+    )
+
+    def __init__(
+        self,
+        split: str = "train",
+        output_take_and_give: dict[str, str] = None,
+        sample_rate: Optional[int] = None,
+        data_root: Optional[str | AnyPathT] = None,
+        mono_method: Optional[str] = "average",
+    ) -> None:
+        """Initialize the Voxaboxen dataset.
+
+        Parameters
+        ----------
+        split : str
+            The split to load. One of info.split_paths keys.
+        output_take_and_give : dict[str, str]
+            A dictionary mapping the original column names to the new column names.
+            It acts as a filter as well.
+        sample_rate : int
+            The sample rate to which audio files should be resampled.
+        data_root : str | AnyPathT, optional
+            The root directory for the dataset. This is optionally appended to the
+            path item of a sample in the dataset.
+            If None, the default is the parent directory of the split path.
+        """
+        super().__init__(output_take_and_give)  # Initialize the parent Dataset class
+        self.split = split
+        self._data: pd.DataFrame = None
+        self._load()  # Load the dataset (fills self._data)
+        self.sample_rate = sample_rate
+        self.data_root = data_root
+        self.mono_method = mono_method
+        if self.data_root is None:
+            # we assume that parent dir of the split path is the data root
+            self.data_root = anypath(self.info.split_paths[self.split]).parent
+
+    @property
+    def columns(self) -> list[str]:
+        """Return the columns of the dataset."""
+        return list(self._data.columns)
+
+    @property
+    def available_splits(self) -> list[str]:
+        """Return the available splits of the dataset."""
+        return list(self.info.split_paths.keys())
+
+    def _load(self) -> None:
+        """Load the dataset.
+
+        Raises
+        ------
+        LookupError
+            If the split is not valid.
+        """
+        if self.split not in self.info.split_paths:
+            raise LookupError(
+                f"Invalid split: {self.split}."
+                "Expected one of {list(self.info.split_paths.keys())}"
+            )
+
+        location = self.info.split_paths[self.split]
+        # Read CSV content
+        csv_text = anypath(location).read_text(encoding="utf-8")
+        self._data = pd.read_csv(StringIO(csv_text))
+
+    @classmethod
+    def from_config(cls, dataset_config: DatasetConfig) -> tuple["Voxaboxen", dict[str, Any]]:
+        """Create a Dataset instance from a configuration dictionary.
+
+        Parameters
+        ----------
+        dataset_config : DatasetConfig
+            Configuration dictionary containing dataset parameters.
+
+        Returns
+        -------
+        tuple[Dataset, dict[str, Any]]
+            A tuple containing the dataset instance and metadata.
+            If the dataset_config contains transformations, they will be applied
+            and the metadata will be returned as dict, otherwise an empty dict.
+
+        Raises
+        -------
+        LookupError
+            If the specified split is not available in the dataset info.
+        """
+        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+
+        split = cfg.get("split", None)
+        if not split or split not in cls.info.split_paths:
+            raise LookupError(
+                f"Invalid split '{split}'."
+                f"Available splits: {', '.join(cls.info.split_paths.keys())}"
+            )
+
+        ds = cls(
+            split=split,
+            output_take_and_give=cfg.get("output_take_and_give", None),
+            data_root=cfg.get("data_root"),
+            sample_rate=cfg["sample_rate"],
+            mono_method=cfg.get("mono_method", "average"),
+        )
+
+        if dataset_config.transformations:
+            transform_metadata = ds.apply_transformations(dataset_config.transformations)
+            return ds, transform_metadata
+
+        return ds, {}
+
+    def __len__(self) -> int:
+        """Return the number of samples in the dataset.
+
+        Returns
+        -------
+        int
+            Number of samples in the current split.
+
+        Raises
+        ------
+        RuntimeError
+            If no split has been loaded yet.
+        """
+        if self._data is None:
+            raise RuntimeError("No split has been loaded yet. Call _load() first.")
+        return len(self._data)
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        """Get a specific sample from the dataset.
+        Parameters
+        ----------
+        idx : int
+            Index of the sample to get.
+
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary containing the audio data, text label, label, and path.
+
+        Raises
+        ------
+        IndexError
+            If the index is out of bounds.
+        """
+        if idx >= len(self._data):
+            raise IndexError(f"Index {idx} out of bounds for dataset of length {len(self._data)}.")
+
+        row = self._data.iloc[idx].to_dict()
+
+        # Ensure audio path is valid
+        if self.data_root:
+            audio_path = anypath(self.data_root) / row["audio_fp"]
+        else:
+            audio_path = anypath(row["audio_fp"])
+
+        audio, sr = read_audio(audio_path)
+        audio = audio.astype(np.float32)
+
+        if self.mono_method:
+            audio = audio_stereo_to_mono(audio, mono_method="average")
+
+        if self.sample_rate is not None and sr != self.sample_rate:
+            audio = librosa.resample(
+                y=audio,
+                orig_sr=sr,
+                target_sr=self.sample_rate,
+                scale=True,
+                res_type="kaiser_best",
+            )
+
+        row["audio"] = audio
+
+        # read selection table
+        if self.data_root:
+            selection_table_path = anypath(self.data_root) / row["selection_table_fp"]
+        else:
+            selection_table_path = anypath(row["selection_table_fp"])
+
+        with selection_table_path.open("r", encoding="utf-8") as f:
+            selection_table = pd.read_csv(StringIO(f.read()), sep="\t")
+
+        row["selection_table"] = selection_table
+
+        if self.output_take_and_give:
+            item = {}
+            for key, value in self.output_take_and_give.items():
+                item[value] = row[key]
+        else:
+            item = row
+
+        return item
+
+    def __iter__(self) -> Iterator[Dict[str, Any]]:
+        """Iterate over samples in the dataset.
+
+        Yields
+        -------
+        Dict[str, Any]
+            Each sample in the dataset.
+        """
+        for idx in range(len(self)):
+            yield self[idx]
+
+    def __str__(self) -> str:
+        """Return a string representation of the dataset.
+
+        Returns
+        -------
+        str
+            A string representation of the dataset including its name, version,
+            and basic statistics if data is loaded.
+        """
+        base_info = f"{self.info.name} (v{self.info.version})"
+
+        return (
+            f"{base_info}\n"
+            f"Description: {self.info.description}\n"
+            f"Sources: {', '.join(self.info.sources)}\n"
+            f"License: {self.info.license}\n"
+            f"Available splits: {', '.join(self.info.split_paths.keys())}"
+        )
+
+
+@register_dataset
+class VoxaboxenEvents(Dataset):
+    """Voxaboxen dataset as events
+
+    Description
+    -----------
+    Same as Voxaboxen, but the audio is split according to the information
+    in the selection table.
+
+    References
+    ----------
+    Robust detection of overlapping bioacoustic sound events
+    Louis Mahon, Benjamin Hoffman, Logan S James, Maddie Cusimano,
+    Masato Hagiwara, Sarah C Woolley, Olivier Pietquin
+    https://arxiv.org/abs/2503.02389
+
+    Examples
+    -------
+    >>> from esp_data.datasets import VoxaboxenEvents
+    >>> dataset = VoxaboxenEvents(
+    ...     split="BV_val",
+    ...     output_take_and_give={"selection_table": "st"}
+    ... )
+    >>> print(dataset.info.name)
+    voxaboxen_events
+    """
+
+    info = DatasetInfo(
+        name="voxaboxen_events",
+        owner="benjamin; gagan",
+        split_paths={
+            "Anuraset_train": "gs://esp-ml-datasets/voxaboxen/files/Anuraset/formatted/train_info.csv",
+            "Anuraset_val": "gs://esp-ml-datasets/voxaboxen/files/Anuraset/formatted/val_info.csv",
+            "Anuraset_test": "gs://esp-ml-datasets/voxaboxen/files/Anuraset/formatted/test_info.csv",
+            "BV_train": "gs://esp-ml-datasets/voxaboxen/files/BV/formatted/train_info.csv",
+            "BV_val": "gs://esp-ml-datasets/voxaboxen/files/BV/formatted/val_info.csv",
+            "BV_test": "gs://esp-ml-datasets/voxaboxen/files/BV/formatted/test_info.csv",
+            "MT_train": "gs://esp-ml-datasets/voxaboxen/files/MT/formatted/train_info.csv",
+            "MT_val": "gs://esp-ml-datasets/voxaboxen/files/MT/formatted/val_info.csv",
+            "MT_test": "gs://esp-ml-datasets/voxaboxen/files/MT/formatted/test_info.csv",
+            "OZF_train": "gs://esp-ml-datasets/voxaboxen/files/OZF/formatted/train_info.csv",
+            "OZF_val": "gs://esp-ml-datasets/voxaboxen/files/OZF/formatted/val_info.csv",
+            "OZF_test": "gs://esp-ml-datasets/voxaboxen/files/OZF/formatted/test_info.csv",
+            "hawaii_train": "gs://esp-ml-datasets/voxaboxen/files/hawaii/formatted/train_info.csv",
+            "hawaii_val": "gs://esp-ml-datasets/voxaboxen/files/hawaii/formatted/val_info.csv",
+            "hawaii_test": "gs://esp-ml-datasets/voxaboxen/files/hawaii/formatted/test_info.csv",
+            "humpback_train": "gs://esp-ml-datasets/voxaboxen/files/humpback/formatted/train_info.csv",
+            "humpback_val": "gs://esp-ml-datasets/voxaboxen/files/humpback/formatted/val_info.csv",
+            "humpback_test": "gs://esp-ml-datasets/voxaboxen/files/humpback/formatted/test_info.csv",
+            "katydids_train": "gs://esp-ml-datasets/voxaboxen/files/katydids/formatted/train_info.csv",
+            "katydids_val": "gs://esp-ml-datasets/voxaboxen/files/katydids/formatted/val_info.csv",
+            "katydids_test": "gs://esp-ml-datasets/voxaboxen/files/katydids/formatted/test_info.csv",
+            "powdermill_train": "gs://esp-ml-datasets/voxaboxen/files/powdermill/formatted/train_info.csv",
+            "powdermill_val": "gs://esp-ml-datasets/voxaboxen/files/powdermill/formatted/val_info.csv",
+            "powdermill_test": "gs://esp-ml-datasets/voxaboxen/files/powdermill/formatted/test_info.csv",
+            "OZF_synthetic_overlap_0_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0/train_info.csv",
+            "OZF_synthetic_overlap_0_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0/val_info.csv",
+            "OZF_synthetic_overlap_0_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0/test_info.csv",
+            "OZF_synthetic_overlap_0.2_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.2/train_info.csv",
+            "OZF_synthetic_overlap_0.2_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.2/val_info.csv",
+            "OZF_synthetic_overlap_0.2_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.2/test_info.csv",
+            "OZF_synthetic_overlap_0.4_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.4/train_info.csv",
+            "OZF_synthetic_overlap_0.4_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.4/val_info.csv",
+            "OZF_synthetic_overlap_0.4_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.4/test_info.csv",
+            "OZF_synthetic_overlap_0.6_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.6/train_info.csv",
+            "OZF_synthetic_overlap_0.6_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.6/val_info.csv",
+            "OZF_synthetic_overlap_0.6_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.6/test_info.csv",
+            "OZF_synethetic_overlap_1_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/train_info.csv",
+            "OZF_synethetic_overlap_1_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/val_info.csv",
+            "OZF_synethetic_overlap_1_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/test_info.csv",
+        },
+        version="0.1.0",
+        description="Voxaboxen events dataset for acoustic sound event detection",
+        sources=[
+            "Anuraset",
+            "BV",
+            "MT",
+            "OZF",
+            "Hawaii",
+            "Humpback",
+            "Katydids",
+            "Powdermill",
+        ],
+        license="CC BY",
+    )
+
+    def __init__(
+        self,
+        split: str = "train",
+        output_take_and_give: dict[str, str] = None,
+        sample_rate: Optional[int] = None,
+        data_root: Optional[str | AnyPathT] = None,
+        stereo_or_mono: str = "stereo",
+        mono_method: str = "average",
+        clip_duration: float = 10.0,
+        clip_hop: float = 5.0,
+        clip_start_offset: float = 0.0,
+        omit_empty_clip_prob: float = 0.0,
+        scale_factor: int = 1,
+        segmentation_based: bool = True,
+    ) -> None:
+        """Initialize the VoxaboxenEvents dataset.
+
+        Parameters
+        ----------
+        split : str
+            The split to load. One of info.split_paths keys.
+        output_take_and_give : dict[str, str]
+            A dictionary mapping the original column names to the new column names.
+            It acts as a filter as well.
+        sample_rate : int
+            The sample rate to which audio files should be resampled.
+        data_root : str | AnyPathT, optional
+            The root directory for the dataset. This is optionally appended to the
+            path item of a sample in the dataset.
+            If None, the default is the parent directory of the split path.
+        mono_method : str, optional
+            The method to convert stereo audio to mono. Defaults to "average".
+            Other options are "average" and "keep_first"
+        clip_duration : float, optional
+            Duration of each audio clip in seconds.
+        clip_hop : float, optional
+            Hop size between consecutive audio clips in seconds. If None, the full
+            audio is used without overlapping clips.
+        clip_start_offset : float, optional
+            Offset in seconds to start the first clip. Defaults to 0.0 seconds.
+            This is useful for skipping a portion of the audio before the first clip.
+        scale_factor : float, optional
+            Scale factor for downsampling the audio. This is needed when representations
+            have been downsampled by encoders like AVES.
+        omit_empty_clip_prob : float, optional
+            Probability of omitting empty clips (no annotations).
+            Defaults to 0.0, meaning no empty clips are omitted.
+        segmentation_based : bool, optional
+            If True, the dataset is segmented based on the selection table.
+            If False, the entire audio file is treated as a single segment.
+            Defaults to True.
+        """
+        super().__init__(output_take_and_give)  # Initialize the parent Dataset class
+        self.split = split
+        self._data: pd.DataFrame = None
+        self._load()  # Load the dataset (fills self._data)
+        self.sample_rate = sample_rate
+        self.data_root = data_root
+        self.stereo_or_mono = stereo_or_mono
+        self.mono_method = mono_method
+        self.clip_duration = clip_duration
+        self.clip_hop = clip_hop
+        self.clip_start_offset = clip_start_offset
+        self.scale_factor = scale_factor
+        self.segmentation_based = segmentation_based
+
+        self.omit_empty_clip_prob = omit_empty_clip_prob
+        self.rng = default_rng()
+        if self.data_root is None:
+            # we assume that parent dir of the split path is the data root
+            self.data_root = anypath(self.info.split_paths[self.split]).parent
+
+        self._make_metadata()
+        self._create_label_map()
+
+    @property
+    def columns(self) -> list[str]:
+        """Return the columns of the dataset."""
+        return list(self._data.columns)
+
+    @property
+    def available_splits(self) -> list[str]:
+        """Return the available splits of the dataset."""
+        return list(self.info.split_paths.keys())
+
+    def _load(self) -> None:
+        """Load the dataset.
+
+        Raises
+        ------
+        LookupError
+            If the split is not valid.
+        """
+        if self.split not in self.info.split_paths:
+            raise LookupError(
+                f"Invalid split: {self.split}."
+                "Expected one of {list(self.info.split_paths.keys())}"
+            )
+
+        location = self.info.split_paths[self.split]
+        # Read CSV content
+        csv_text = anypath(location).read_text(encoding="utf-8")
+        self._data = pd.read_csv(StringIO(csv_text))
+
+    @classmethod
+    def from_config(cls, dataset_config: DatasetConfig) -> tuple["VoxaboxenEvents", dict[str, Any]]:
+        """Create a Dataset instance from a configuration dictionary.
+
+        Parameters
+        ----------
+        dataset_config : DatasetConfig
+            Configuration dictionary containing dataset parameters.
+
+        Returns
+        -------
+        tuple[Dataset, dict[str, Any]]
+            A tuple containing the dataset instance and metadata.
+            If the dataset_config contains transformations, they will be applied
+            and the metadata will be returned as dict, otherwise an empty dict.
+
+        Raises
+        -------
+        LookupError
+            If the specified split is not available in the dataset info.
+        """
+        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+
+        split = cfg.get("split", None)
+        if not split or split not in cls.info.split_paths:
+            raise LookupError(
+                f"Invalid split '{split}'."
+                f"Available splits: {', '.join(cls.info.split_paths.keys())}"
+            )
+
+        ds = cls(
+            split=split,
+            output_take_and_give=cfg.get("output_take_and_give", None),
+            data_root=cfg.get("data_root"),
+            sample_rate=cfg["sample_rate"],
+            mono_method=cfg.get("mono_method", "average"),
+            clip_duration=cfg.get("clip_duration", 10.0),
+            clip_hop=cfg.get("clip_hop", 5.0),
+            clip_start_offset=cfg.get("clip_start_offset", 0.0),
+        )
+
+        if dataset_config.transformations:
+            transform_metadata = ds.apply_transformations(dataset_config.transformations)
+            return ds, transform_metadata
+
+        return ds, {}
+
+    def __len__(self) -> int:
+        """Return the number of samples in the dataset.
+
+        Returns
+        -------
+        int
+            Number of samples in the current split.
+        """
+        return len(self._metadata)
+
+    def _create_label_map(self) -> None:
+        """Create a mapping from label names to indices.
+
+        Raises
+        ------
+        ValueError
+            If no labels are found in the dataset.
+        """
+        self.label_set = sorted(set(self._data["Annotation"].dropna().unique().tolist()))
+        if not self.label_set:
+            raise ValueError("No labels found in the dataset.")
+
+        self.label_mapping = {label: idx for idx, label in enumerate(self.label_set)}
+        self.n_classes = len(self.label_set)
+        self.unknown_label = "unknown"
+        self.label_set.append(self.unknown_label)
+        self.label_mapping[self.unknown_label] = -1
+
+    def _process_selection_table(self, selection_table_fp: str) -> IntervalTree:
+        """
+        Process annotation file into interval tree format.
+
+        Parameters
+        ----------
+        selection_table_fp : str
+            Path to annotation file (tab-separated)
+
+        Returns
+        -------
+        IntervalTree
+            Tree containing labeled time intervals
+        """
+        selection_table_fp = anypath(self.data_root) / selection_table_fp
+        selection_table = pd.read_csv(selection_table_fp, sep="\t")
+        tree = IntervalTree()
+
+        for _, row in selection_table.iterrows():
+            start = row["Begin Time (s)"]
+            end = row["End Time (s)"]
+            label = row["Annotation"]
+
+            if end <= start:
+                continue
+
+            if label in self.label_mapping:
+                label = self.label_mapping[label]
+            else:
+                continue
+
+            if label == self.unknown_label:
+                label_idx = -1
+            else:
+                label_idx = self.label_set.index(label)
+            tree.addi(start, end, label_idx)
+
+        return tree
+
+    def _make_metadata(self) -> None:
+        """Generate dataset metadata including clip boundaries."""
+
+        selection_table_dict = dict()
+        metadata = []
+
+        for _ii, row in self._data.iterrows():
+            fn = row["fn"]
+            audio_fp = anypath(self.data_root) / row["audio_fp"]
+
+            duration = get_audio_info(audio_fp)["duration"]
+            selection_table_fp = row["selection_table_fp"]
+
+            selection_table = self._process_selection_table(selection_table_fp)
+            selection_table_dict[fn] = selection_table
+
+            num_clips = max(
+                0,
+                int(
+                    np.floor(
+                        (duration - self.clip_duration - self.clip_start_offset) // self.clip_hop
+                    )
+                ),
+            )
+
+            for tt in range(num_clips):
+                start = tt * self.clip_hop + self.clip_start_offset
+                end = start + self.clip_duration
+
+                ivs: IntervalTree = selection_table[start:end]
+                # if no annotated intervals, skip with specified probability
+                if not ivs:
+                    if self.omit_empty_clip_prob > self.rng.uniform():
+                        continue
+
+                metadata.append([fn, str(audio_fp), start, end])
+
+        self._selection_table_dict = selection_table_dict
+        self._metadata = metadata
+
+    def _get_pos_intervals(
+        self, fn: str, start: float, end: float
+    ) -> list[tuple[float, float, str]]:
+        """
+        Get annotated intervals within specified time range.
+
+        Parameters
+        ----------
+        fn : str
+            Filename identifier
+        start : float
+            Start time in seconds
+        end : float
+            End time in seconds
+
+        Returns
+        -------
+        list[tuple[float, float, str]]
+            List of tuples containing (start, end, label) for each interval
+        """
+
+        tree = self._selection_table_dict[fn]
+
+        intervals = tree[start:end]
+        intervals = [
+            (max(iv.begin, start) - start, min(iv.end, end) - start, iv.data) for iv in intervals
+        ]
+
+        return intervals
+
+    def _get_class_proportions(self) -> np.ndarray:
+        """
+        Calculate class distribution in dataset.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of class proportions
+        """
+
+        counts = np.zeros((self.n_classes,))
+
+        for k in self.selection_table_dict:
+            st = self.selection_table_dict[k]
+            for interval in st:
+                annot = interval.data
+                if annot == -1:
+                    continue
+                else:
+                    counts[annot] += 1
+
+        total_count = np.sum(counts)
+        proportions = counts / total_count
+
+        return proportions
+
+    def _get_annotation(
+        self, pos_intervals: list[tuple[float, float, int]], audio: np.ndarray
+    ) -> tuple[
+        np.ndarray,  # anchor_annos
+        np.ndarray,  # regression_annos
+        np.ndarray,  # class_annos
+        np.ndarray,  # rev_anchor_annos
+        np.ndarray,  # rev_regression_annos
+        np.ndarray,  # rev_class_annos
+    ]:
+        """
+        Generate target annotations from positive intervals.
+
+        Parameters
+        ----------
+        pos_intervals : list
+            List of (start, end, label_idx) tuples
+        audio : np.ndarray
+            Input audio tensor
+
+        Returns
+        -------
+        tuple
+            Tuple containing:
+            - anchor_annos: Anchor point annotations
+            - regression_annos: Duration annotations
+            - class_annos: Class probability annotations
+            - rev_anchor_annos: Reverse anchor points
+            - rev_regression_annos: Reverse duration
+            - rev_class_annos: Reverse class probabilities
+        """
+
+        raw_seq_len = audio.shape[-1]
+        seq_len = int(math.ceil(raw_seq_len / self.scale_factor))
+
+        regression_annos = np.zeros((seq_len,))
+        class_annos = np.zeros((seq_len, self.n_classes))
+        anchor_annos = [
+            np.zeros(
+                seq_len,
+            )
+        ]
+        rev_regression_annos = np.zeros((seq_len,))
+        rev_class_annos = np.zeros((seq_len, self.n_classes))
+        rev_anchor_annos = [
+            np.zeros(
+                seq_len,
+            )
+        ]
+
+        for iv in pos_intervals:
+            start, end, class_idx = iv
+            dur = end - start
+            dur_samples = np.ceil(dur * self.sample_rate)
+
+            start_idx = int(math.floor(start * self.sample_rate))
+            start_idx = max(min(start_idx, seq_len - 1), 0)
+
+            end_idx = int(math.ceil(end * self.sample_rate))
+            end_idx = max(min(end_idx, seq_len - 1), 0)
+            dur_samples = int(np.ceil(dur * self.sample_rate))
+
+            anchor_anno = _get_anchor_anno(start_idx, dur_samples, seq_len)
+            anchor_annos.append(anchor_anno)
+            regression_annos[start_idx] = dur
+
+            rev_anchor_anno = _get_anchor_anno(end_idx, dur_samples, seq_len)
+            rev_anchor_annos.append(rev_anchor_anno)
+            rev_regression_annos[end_idx] = dur
+
+            if self.segmentation_based:
+                if class_idx == -1:
+                    pass
+                else:
+                    class_annos[start_idx : start_idx + dur_samples, class_idx] = 1.0
+
+            else:
+                if class_idx != -1:
+                    class_annos[start_idx, class_idx] = 1.0
+                    rev_class_annos[end_idx, class_idx] = 1.0
+                else:
+                    class_annos[start_idx, :] = (
+                        1.0 / self.n_classes
+                    )  # if unknown, enforce uncertainty
+                    rev_class_annos[end_idx, :] = (
+                        1.0 / self.n_classes
+                    )  # if unknown, enforce uncertainty
+
+        anchor_annos = np.stack(anchor_annos)
+        anchor_annos = np.amax(anchor_annos, axis=0)
+        rev_anchor_annos = np.stack(rev_anchor_annos)
+        rev_anchor_annos = np.amax(rev_anchor_annos, axis=0)
+        # shapes [time_steps, ], [time_steps, ], [time_steps, n_classes] (times two)
+        return (
+            anchor_annos,
+            regression_annos,
+            class_annos,
+            rev_anchor_annos,
+            rev_regression_annos,
+            rev_class_annos,
+        )
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        """Get a specific sample from the dataset.
+        Parameters
+        ----------
+        idx : int
+            Index of the sample to get.
+
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary containing the audio data, text label, label, and path.
+
+        Raises
+        ------
+        IndexError
+            If the index is out of bounds.
+        """
+        if idx >= len(self._data):
+            raise IndexError(f"Index {idx} out of bounds for dataset of length {len(self._data)}.")
+
+        fn, audio_fp, start, end = self._metadata[idx]
+
+        # Read audio clip
+        audio, sr = read_audio(audio_fp, start_time=start, end_time=end)
+        audio = audio.astype(np.float32)
+
+        if self.stereo_or_mono == "mono":
+            audio = audio_stereo_to_mono(audio, mono_method=self.mono_method)
+        else:
+            channel_dim = np.argmin(audio.shape)
+            if channel_dim != 0:
+                audio = audio.T
+
+        if self.sample_rate is not None and sr != self.sample_rate:
+            audio = librosa.resample(
+                y=audio,
+                orig_sr=sr,
+                target_sr=self.sample_rate,
+                scale=True,
+                res_type="kaiser_best",
+            )
+
+        pos_intervals = self._get_pos_intervals(fn, start, end)
+        (
+            anchor_anno,
+            regression_anno,
+            class_anno,
+            rev_anchor_anno,
+            rev_regression_anno,
+            rev_class_anno,
+        ) = self.get_annotation(pos_intervals, audio)
+
+        row = {
+            "audio": audio,
+            "fn": fn,
+            "audio_fp": audio_fp,
+            "start": start,
+            "end": end,
+            "anchor_anno": anchor_anno,
+            "regression_anno": regression_anno,
+            "class_anno": class_anno,
+            "rev_regression_anno": rev_regression_anno,
+            "rev_anchor_anno": rev_anchor_anno,
+            "rev_class_anno": rev_class_anno,
+        }
+
+        if self.output_take_and_give:
+            item = {}
+            for key, value in self.output_take_and_give.items():
+                item[value] = row[key]
+        else:
+            item = row
+
+        return item
+
+    def __iter__(self) -> Iterator[Dict[str, Any]]:
+        """Iterate over samples in the dataset.
+
+        Yields
+        -------
+        Dict[str, Any]
+            Each sample in the dataset.
+        """
+        for idx in range(len(self)):
+            yield self[idx]
+
+    def __str__(self) -> str:
+        """Return a string representation of the dataset.
+
+        Returns
+        -------
+        str
+            A string representation of the dataset including its name, version,
+            and basic statistics if data is loaded.
+        """
+        base_info = f"{self.info.name} (v{self.info.version})"
+
+        return (
+            f"{base_info}\n"
+            f"Description: {self.info.description}\n"
+            f"Sources: {', '.join(self.info.sources)}\n"
+            f"License: {self.info.license}\n"
+            f"Available splits: {', '.join(self.info.split_paths.keys())}"
+        )
+
+
+def _get_anchor_anno(start_idx: int, dur_samples: int, seq_len: int) -> np.ndarray:
+    """
+    Represent start idx as a Gaussian blurred onehot encoding.
+
+        Parameters
+    ----------
+    start_idx : int
+        Start index of annotation
+    dur_samples : int
+        Duration in samples
+    seq_len : int
+        Total sequence length
+
+    Returns
+    -------
+    numpy.ndarray
+        Anchor point annotations
+
+    Notes
+    -----
+    This setting of `std` follows CornerNet, where adaptive standard deviation
+    is set to 1/3 image radius.
+
+    """
+
+    std = dur_samples / 6
+    x = (np.arange(seq_len) - start_idx) ** 2
+    x = x / (2 * std**2)
+    x = np.exp(-x)
+    return x

--- a/esp_data/datasets/voxaboxen.py
+++ b/esp_data/datasets/voxaboxen.py
@@ -15,9 +15,119 @@ from esp_data.io import (
     AnyPathT,
     anypath,
     audio_stereo_to_mono,
-    get_audio_info,
     read_audio,
 )
+
+LABEL_SETS = {
+    "Anuraset_train": [
+        "SPHSUR_M",
+        "PHYALB_L",
+        "Unknown",
+        "LEPPOD_L",
+        "DENMIN_M",
+        "BOABIS_M",
+        "BOABIS_L",
+        "PITAZU_L",
+        "LEPLAT_L",
+        "BOAALB_L",
+        "DENMIN_L",
+    ],
+    "Anuraset_val": [
+        "SPHSUR_M",
+        "PHYALB_L",
+        "Unknown",
+        "LEPPOD_L",
+        "DENMIN_M",
+        "BOABIS_M",
+        "BOABIS_L",
+        "PITAZU_L",
+        "LEPLAT_L",
+        "BOAALB_L",
+        "DENMIN_L",
+    ],
+    "Anuraset_test": [
+        "SPHSUR_M",
+        "PHYALB_L",
+        "Unknown",
+        "LEPPOD_L",
+        "DENMIN_M",
+        "BOABIS_M",
+        "BOABIS_L",
+        "PITAZU_L",
+        "LEPLAT_L",
+        "BOAALB_L",
+        "DENMIN_L",
+    ],
+    "BV_train": ["voc", "Unknown"],
+    "BV_val": ["voc", "Unknown"],
+    "BV_test": ["voc", "Unknown"],
+    "MT_train": ["voc", "Unknown"],
+    "MT_val": ["voc", "Unknown"],
+    "MT_test": ["voc", "Unknown"],
+    "OZF_train": ["voc", "Unknown"],
+    "OZF_val": ["voc", "Unknown"],
+    "OZF_test": ["voc", "Unknown"],
+    "hawaii_train": [
+        "ercfra",
+        "reblei",
+        "Unknown",
+        "warwhe1",
+        "skylar",
+        "hawama",
+        "houfin",
+        "apapan",
+        "omao",
+        "iiwi",
+    ],
+    "hawaii_val": [
+        "ercfra",
+        "reblei",
+        "Unknown",
+        "warwhe1",
+        "skylar",
+        "hawama",
+        "houfin",
+        "apapan",
+        "omao",
+        "iiwi",
+    ],
+    "hawaii_test": [
+        "ercfra",
+        "reblei",
+        "Unknown",
+        "warwhe1",
+        "hawama",
+        "skylar",
+        "houfin",
+        "apapan",
+        "omao",
+        "iiwi",
+    ],
+    "humpback_train": ["Mn", "Unknown"],
+    "humpback_val": ["Mn", "Unknown"],
+    "humpback_test": ["Mn", "Unknown"],
+    "katydids_train": ["Unknown", "katydid"],
+    "katydids_val": ["Unknown", "katydid"],
+    "katydids_test": ["Unknown", "katydid"],
+    "powdermill_train": ["Unknown", "NOCA", "BCCH", "EATO", "BTNW", "REVI", "TUTI"],
+    "powdermill_val": ["Unknown", "NOCA", "BCCH", "EATO", "BTNW", "REVI", "TUTI"],
+    "powdermill_test": ["Unknown", "NOCA", "BCCH", "EATO", "BTNW", "REVI", "TUTI"],
+    "OZF_synthetic_overlap_0_train": ["Unknown", "POS"],
+    "OZF_synthetic_overlap_0_val": ["Unknown", "POS"],
+    "OZF_synthetic_overlap_0_test": ["Unknown", "POS"],
+    "OZF_synthetic_overlap_0.2_train": ["Unknown", "POS"],
+    "OZF_synthetic_overlap_0.2_val": ["Unknown", "POS"],
+    "OZF_synthetic_overlap_0.2_test": ["Unknown", "POS"],
+    "OZF_synthetic_overlap_0.4_train": ["Unknown", "POS"],
+    "OZF_synthetic_overlap_0.4_val": ["Unknown", "POS"],
+    "OZF_synthetic_overlap_0.4_test": ["Unknown", "POS"],
+    "OZF_synthetic_overlap_0.6_train": ["Unknown", "POS"],
+    "OZF_synthetic_overlap_0.6_val": ["Unknown", "POS"],
+    "OZF_synthetic_overlap_0.6_test": ["Unknown", "POS"],
+    "OZF_synthetic_overlap_1_train": ["Unknown", "POS"],
+    "OZF_synthetic_overlap_1_val": ["Unknown", "POS"],
+    "OZF_synthetic_overlap_1_test": ["Unknown", "POS"],
+}
 
 
 @register_dataset
@@ -93,9 +203,9 @@ class Voxaboxen(Dataset):
             "OZF_synthetic_overlap_0.6_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.6/train_info.csv",
             "OZF_synthetic_overlap_0.6_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.6/val_info.csv",
             "OZF_synthetic_overlap_0.6_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.6/test_info.csv",
-            "OZF_synethetic_overlap_1_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/train_info.csv",
-            "OZF_synethetic_overlap_1_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/val_info.csv",
-            "OZF_synethetic_overlap_1_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/test_info.csv",
+            "OZF_synthetic_overlap_1_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/train_info.csv",
+            "OZF_synthetic_overlap_1_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/val_info.csv",
+            "OZF_synthetic_overlap_1_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/test_info.csv",
         },
         version="0.1.0",
         description="Voxaboxen dataset for acoustic sound event detection",
@@ -283,15 +393,7 @@ class Voxaboxen(Dataset):
         row["audio"] = audio
 
         # read selection table
-        if self.data_root:
-            selection_table_path = anypath(self.data_root) / row["selection_table_fp"]
-        else:
-            selection_table_path = anypath(row["selection_table_fp"])
-
-        with selection_table_path.open("r", encoding="utf-8") as f:
-            selection_table = pd.read_csv(StringIO(f.read()), sep="\t")
-
-        row["selection_table"] = selection_table
+        row["selection_table"] = pd.read_csv(StringIO(row["selection_table_str"]), sep="\t")
 
         if self.output_take_and_give:
             item = {}
@@ -400,9 +502,9 @@ class VoxaboxenEvents(Dataset):
             "OZF_synthetic_overlap_0.6_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.6/train_info.csv",
             "OZF_synthetic_overlap_0.6_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.6/val_info.csv",
             "OZF_synthetic_overlap_0.6_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_0.6/test_info.csv",
-            "OZF_synethetic_overlap_1_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/train_info.csv",
-            "OZF_synethetic_overlap_1_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/val_info.csv",
-            "OZF_synethetic_overlap_1_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/test_info.csv",
+            "OZF_synthetic_overlap_1_train": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/train_info.csv",
+            "OZF_synthetic_overlap_1_val": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/val_info.csv",
+            "OZF_synthetic_overlap_1_test": "gs://esp-ml-datasets/voxaboxen/files/OZF_synthetic/overlap_1/test_info.csv",
         },
         version="0.1.0",
         description="Voxaboxen events dataset for acoustic sound event detection",
@@ -423,7 +525,7 @@ class VoxaboxenEvents(Dataset):
         self,
         split: str = "train",
         output_take_and_give: dict[str, str] = None,
-        sample_rate: Optional[int] = None,
+        sample_rate: int = 16000,
         data_root: Optional[str | AnyPathT] = None,
         stereo_or_mono: str = "stereo",
         mono_method: str = "average",
@@ -433,6 +535,7 @@ class VoxaboxenEvents(Dataset):
         omit_empty_clip_prob: float = 0.0,
         scale_factor: int = 1,
         segmentation_based: bool = True,
+        unknown_label: str = "Unknown",
     ) -> None:
         """Initialize the VoxaboxenEvents dataset.
 
@@ -470,6 +573,8 @@ class VoxaboxenEvents(Dataset):
             If True, the dataset is segmented based on the selection table.
             If False, the entire audio file is treated as a single segment.
             Defaults to True.
+        unknown_label : str, optional
+            The label used for unknown annotations. Defaults to "unknown".
         """
         super().__init__(output_take_and_give)  # Initialize the parent Dataset class
         self.split = split
@@ -484,6 +589,7 @@ class VoxaboxenEvents(Dataset):
         self.clip_start_offset = clip_start_offset
         self.scale_factor = scale_factor
         self.segmentation_based = segmentation_based
+        self.unknown_label = unknown_label
 
         self.omit_empty_clip_prob = omit_empty_clip_prob
         self.rng = default_rng()
@@ -491,8 +597,16 @@ class VoxaboxenEvents(Dataset):
             # we assume that parent dir of the split path is the data root
             self.data_root = anypath(self.info.split_paths[self.split]).parent
 
-        self._make_metadata()
+        self.label_mapping: dict = None
+        if split in LABEL_SETS:
+            self.label_set: list = LABEL_SETS[split]
+        else:
+            self.label_set = []
+
+        self.n_classes = 0
         self._create_label_map()
+
+        self._make_metadata()
 
     @property
     def columns(self) -> list[str]:
@@ -557,11 +671,15 @@ class VoxaboxenEvents(Dataset):
             split=split,
             output_take_and_give=cfg.get("output_take_and_give", None),
             data_root=cfg.get("data_root"),
-            sample_rate=cfg["sample_rate"],
+            sample_rate=cfg.get("sample_rate", 16000),
             mono_method=cfg.get("mono_method", "average"),
             clip_duration=cfg.get("clip_duration", 10.0),
             clip_hop=cfg.get("clip_hop", 5.0),
             clip_start_offset=cfg.get("clip_start_offset", 0.0),
+            omit_empty_clip_prob=cfg.get("omit_empty_clip_prob", 0.0),
+            scale_factor=cfg.get("scale_factor", 1),
+            segmentation_based=cfg.get("segmentation_based", True),
+            unknown_label=cfg.get("unknown_label", "Unknown"),
         )
 
         if dataset_config.transformations:
@@ -588,32 +706,42 @@ class VoxaboxenEvents(Dataset):
         ValueError
             If no labels are found in the dataset.
         """
-        self.label_set = sorted(set(self._data["Annotation"].dropna().unique().tolist()))
+        # load all selection tables and create a label set
+        if not self.label_set:
+            self.label_set = set()
+            for row in self._data.itertuples():
+                selection_table = pd.read_csv(StringIO(row.selection_table_str), sep="\t")
+
+                labels = selection_table["Annotation"].unique().tolist()
+                if not hasattr(self, "label_set"):
+                    self.label_set = set(labels)
+                else:
+                    self.label_set.update(labels)
+
+            self.label_set.add(self.unknown_label)
+            self.label_set = list(self.label_set)
+
         if not self.label_set:
             raise ValueError("No labels found in the dataset.")
 
-        self.label_mapping = {label: idx for idx, label in enumerate(self.label_set)}
+        self.label_mapping = {label: label for label in self.label_set}
         self.n_classes = len(self.label_set)
-        self.unknown_label = "unknown"
-        self.label_set.append(self.unknown_label)
-        self.label_mapping[self.unknown_label] = -1
 
-    def _process_selection_table(self, selection_table_fp: str) -> IntervalTree:
+    def _process_selection_table(self, selection_table_str: str) -> IntervalTree:
         """
         Process annotation file into interval tree format.
 
         Parameters
         ----------
-        selection_table_fp : str
-            Path to annotation file (tab-separated)
+        selection_table_str : str
+            String representation of the selection table in TSV format.
 
         Returns
         -------
         IntervalTree
             Tree containing labeled time intervals
         """
-        selection_table_fp = anypath(self.data_root) / selection_table_fp
-        selection_table = pd.read_csv(selection_table_fp, sep="\t")
+        selection_table = pd.read_csv(StringIO(selection_table_str), sep="\t")
         tree = IntervalTree()
 
         for _, row in selection_table.iterrows():
@@ -647,12 +775,11 @@ class VoxaboxenEvents(Dataset):
             fn = row["fn"]
             audio_fp = anypath(self.data_root) / row["audio_fp"]
 
-            duration = get_audio_info(audio_fp)["duration"]
-            selection_table_fp = row["selection_table_fp"]
-
-            selection_table = self._process_selection_table(selection_table_fp)
+            selection_table = self._process_selection_table(row["selection_table_str"])
             selection_table_dict[fn] = selection_table
 
+            # Determine number of clips based on audio duration
+            duration = row["audio_duration"]
             num_clips = max(
                 0,
                 int(
@@ -885,7 +1012,7 @@ class VoxaboxenEvents(Dataset):
             rev_anchor_anno,
             rev_regression_anno,
             rev_class_anno,
-        ) = self.get_annotation(pos_intervals, audio)
+        ) = self._get_annotation(pos_intervals, audio)
 
         row = {
             "audio": audio,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "gcsfs>=2024.9.0.post1",
     "google-cloud-secret-manager>=2.23.1",
     "google-cloud-storage>=2.19.0",
+    "interval>=1.0.0",
     "librosa>=0.11.0",
     "pandas",
     "pydantic>=2",
@@ -16,6 +17,7 @@ dependencies = [
     "s3fs>=2024.9.0",
     "semver",
     "soundfile>=0.13.1",
+    "tree>=0.2.4",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "gcsfs>=2024.9.0.post1",
     "google-cloud-secret-manager>=2.23.1",
     "google-cloud-storage>=2.19.0",
-    "interval>=1.0.0",
+    "intervaltree>=3.1.0",
     "librosa>=0.11.0",
     "pandas",
     "pydantic>=2",
@@ -17,7 +17,6 @@ dependencies = [
     "s3fs>=2024.9.0",
     "semver",
     "soundfile>=0.13.1",
-    "tree>=0.2.4",
 ]
 
 [dependency-groups]

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,7 @@ cachetools==5.5.2
 certifi==2025.4.26
 cffi==1.17.1
 charset-normalizer==3.4.2
-click==8.1.8
 cloudpathlib==0.21.0
-colorama==0.4.6 ; platform_system == 'Windows'
 cryptography==44.0.3
 decorator==5.2.1
 frozenlist==1.6.0
@@ -41,7 +39,7 @@ grpc-google-iam-v1==0.14.2
 grpcio==1.71.0
 grpcio-status==1.71.0
 idna==3.10
-interval==1.0.0
+intervaltree==3.1.0
 isodate==0.7.2
 jmespath==1.0.1
 joblib==1.5.1
@@ -55,7 +53,6 @@ numpy==2.2.5
 oauthlib==3.2.2
 packaging==25.0
 pandas==2.2.3
-pillow==11.3.0
 platformdirs==4.3.7
 pooch==1.8.2
 propcache==0.3.1
@@ -77,16 +74,14 @@ s3transfer==0.11.3
 scikit-learn==1.6.1
 scipy==1.15.3
 semver==3.0.4
-setuptools==80.3.1
 six==1.17.0
+sortedcontainers==2.4.0
 soundfile==0.13.1
 soxr==0.5.0.post1
 standard-aifc==3.13.0 ; python_full_version >= '3.13'
 standard-chunk==3.13.0 ; python_full_version >= '3.13'
 standard-sunau==3.13.0 ; python_full_version >= '3.13'
-svgwrite==1.4.3
 threadpoolctl==3.6.0
-tree==0.2.4
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,9 @@ cachetools==5.5.2
 certifi==2025.4.26
 cffi==1.17.1
 charset-normalizer==3.4.2
+click==8.1.8
 cloudpathlib==0.21.0
+colorama==0.4.6 ; platform_system == 'Windows'
 cryptography==44.0.3
 decorator==5.2.1
 frozenlist==1.6.0
@@ -39,6 +41,7 @@ grpc-google-iam-v1==0.14.2
 grpcio==1.71.0
 grpcio-status==1.71.0
 idna==3.10
+interval==1.0.0
 isodate==0.7.2
 jmespath==1.0.1
 joblib==1.5.1
@@ -52,6 +55,7 @@ numpy==2.2.5
 oauthlib==3.2.2
 packaging==25.0
 pandas==2.2.3
+pillow==11.3.0
 platformdirs==4.3.7
 pooch==1.8.2
 propcache==0.3.1
@@ -73,13 +77,16 @@ s3transfer==0.11.3
 scikit-learn==1.6.1
 scipy==1.15.3
 semver==3.0.4
+setuptools==80.3.1
 six==1.17.0
 soundfile==0.13.1
 soxr==0.5.0.post1
 standard-aifc==3.13.0 ; python_full_version >= '3.13'
 standard-chunk==3.13.0 ; python_full_version >= '3.13'
 standard-sunau==3.13.0 ; python_full_version >= '3.13'
+svgwrite==1.4.3
 threadpoolctl==3.6.0
+tree==0.2.4
 typing-extensions==4.13.2
 typing-inspection==0.4.1
 tzdata==2025.2

--- a/tests/unittests/datasets_tests/test_voxaboxen.py
+++ b/tests/unittests/datasets_tests/test_voxaboxen.py
@@ -1,0 +1,244 @@
+"""Voxaboxen dataset tests."""
+
+import pytest
+import pandas as pd
+import numpy as np
+from pydantic import BaseModel
+from typing import Literal
+
+from esp_data.io import anypath
+from esp_data.transforms import register_transform
+from esp_data import Dataset, DatasetConfig, Voxaboxen, VoxaboxenEvents
+
+
+class RenameConfig(BaseModel):
+    type: Literal["rename_transform"]
+    input_features: list[str]
+    output_features: list[str]
+    feature_map: dict[str, str] | None = None
+
+
+class RenameTransform:
+    def __init__(self, input_features: list[str], output_features: list[str], feature_map: dict[str, str] | None = None) -> None:
+        """Initialize the RenameTransform."""
+
+        if feature_map is None:
+            # Create a map from input features to output features
+            self.input_features = input_features
+            self.output_features = output_features
+            if len(self.input_features) != len(self.output_feature):
+                raise ValueError("input_features and output_feature must have the same length")
+
+            self.feature_map = dict(zip(self.input_features, self.output_features))
+        else:
+            # Use the provided feature map
+            self.feature_map = feature_map
+
+    @classmethod
+    def from_config(cls, cfg: RenameConfig) -> "RenameTransform":
+        return cls(**cfg.model_dump(exclude=("type",)))
+
+    def __call__(self, data: pd.DataFrame) -> tuple[pd.DataFrame, dict]:
+        # Rename
+        transformed_data = data.rename(columns=self.feature_map)
+        return transformed_data, self.feature_map
+
+
+register_transform(RenameConfig, RenameTransform)
+
+
+@pytest.fixture
+def voxaboxen_dataset() -> Voxaboxen:
+    """Fixture providing an AnimalSpeak dataset instance.
+
+    Returns
+    -------
+    Dataset
+        An instance of the AnimalSpeak dataset.
+    """
+    ds = Voxaboxen(split="hawaii_val", sample_rate=None)
+    return ds
+
+
+@pytest.fixture
+def voxaboxen_events_dataset() -> VoxaboxenEvents:
+    """Fixture providing a VoxaboxenEvents dataset instance.
+
+    Returns
+    -------
+    VoxaboxenEvents
+        An instance of the VoxaboxenEvents dataset.
+    """
+    ds = VoxaboxenEvents(split="hawaii_val", sample_rate=None)
+    return ds
+
+
+@pytest.fixture
+def voxaboxen_with_transforms() -> Voxaboxen:
+    """Fixture providing an AnimalSpeak dataset instance with transformations
+    applied.
+
+    Returns
+    -------
+    Voxaboxen
+        An instance of the AnimalSpeak dataset with transformations applied.
+    """
+
+    dataset_config = DatasetConfig(
+        dataset_name="voxaboxen",
+        transformations=[
+            {
+                "type": "rename_transform",
+                "input_features": ["fn"],
+                "output_features": ["file_name"],
+            },
+        ],
+    )
+    ds = Voxaboxen(split="hawaii_val")
+    ds.apply_transformations(dataset_config.transformations)
+    return ds
+
+
+@pytest.fixture
+def voxaboxen_events_with_transforms() -> Dataset:
+    """Fixture providing an AnimalSpeak dataset instance with transformations
+    applied.
+
+    Returns
+    -------
+    Dataset
+        An instance of the AnimalSpeak dataset with transformations applied.
+    """
+
+    dataset_config = DatasetConfig(
+        dataset_name="voxaboxen_events",
+        transformations=[
+            {
+                "type": "label_from_feature",
+                "feature": "Annotation",
+                "output_feature": "label",
+            },
+        ],
+        stereo_to_mono="mono",
+        segmentation_based=True,
+        scale_factor=2,
+    )
+    ds = VoxaboxenEvents(split="hawaii_val")
+    ds.apply_transformations(dataset_config.transformations)
+    return ds
+
+
+def test_info_property(voxaboxen_dataset: Dataset) -> None:
+    """Test if the info property returns correct metadata."""
+    assert voxaboxen_dataset.info.name == "voxaboxen"
+    assert voxaboxen_dataset.info.version == "0.1.0"
+    assert "Anuraset_train" in voxaboxen_dataset.info.split_paths
+    for split in voxaboxen_dataset.info.split_paths.values():
+        assert anypath(split).exists(), f"Split path {split} does not exist"
+
+
+def test_data_property(voxaboxen_dataset: Dataset) -> None:
+    """Test if the data property returns correct dataframes."""
+    # Data should be _loaded in __init__
+    assert voxaboxen_dataset._data is not None
+    assert "selection_table_fp" in voxaboxen_dataset._data.columns
+    assert "fn" in voxaboxen_dataset._data.columns
+
+
+def test_available_splits(voxaboxen_dataset: Dataset) -> None:
+    """Test if available_splits returns correct split names."""
+    # Available splits should contain these
+    expected_splits = ["Anuraset_train", "humpback_val", "test", "cbi_test", "esc50_validation"]
+    assert all(split in voxaboxen_dataset.available_splits for split in expected_splits)
+
+
+def test_length(voxaboxen_dataset: Dataset) -> None:
+    """Test if __len__ returns correct counts."""
+    # Length should be sum of all splits
+    expected_len = voxaboxen_dataset._data.shape[0]
+    assert len(voxaboxen_dataset) == expected_len
+    print(f"Dataset length: {len(voxaboxen_dataset)}")
+    assert len(voxaboxen_dataset) == 126
+
+
+def test_getitem(voxaboxen_dataset: Dataset) -> None:
+    """Test if __getitem__ returns correct sample format."""
+    # Get first sample
+    sample = voxaboxen_dataset[0]
+    assert isinstance(sample, dict)
+    assert "selection_table" in sample
+    assert "audio" in sample
+
+
+def test_iteration(voxaboxen_dataset: Dataset) -> None:
+    """Test if iteration works correctly."""
+    for _, sample in enumerate(voxaboxen_dataset):
+        assert isinstance(sample, dict)
+        # Ensure we can access a known key
+        assert "audio" in sample
+        break
+
+
+def test_load_from_config() -> None:
+    """Test if dataset can be loaded from configuration."""
+    dataset_config = DatasetConfig(
+        dataset_name="voxaboxen",
+        split="hawaii_val",
+    )
+    dataset, _ = Voxaboxen.from_config(dataset_config)
+    assert dataset.info.name == "voxaboxen"
+    assert dataset.info.split_paths["katydids_train"] is not None
+    assert len(dataset) > 0, "Dataset should not be empty"
+
+
+def test_invalid_split() -> None:
+    """Test if _loading invalid split raises error."""
+    with pytest.raises(LookupError):
+        Voxaboxen(split="invalid_split")
+
+
+def test_dataset_with_transforms(voxaboxen_with_transforms: Dataset) -> None:
+    """Test if dataset with transformations works correctly."""
+    # Ensure the transformation was applied
+    assert "file_name" in voxaboxen_with_transforms._data.columns
+    assert "fn" not in voxaboxen_with_transforms._data.columns
+
+    # Check if the transformation works
+    sample = voxaboxen_with_transforms[0]
+    assert isinstance(sample, dict)
+    assert "file_name" in sample
+    assert "audio" in sample
+
+
+## VoxaboxenEvents Tests
+
+def test_voxaboxen_events_info(voxaboxen_events_dataset: Dataset) -> None:
+    """Test if the info property returns correct metadata for VoxaboxenEvents."""
+    assert voxaboxen_events_dataset.info.name == "voxaboxen_events"
+    assert voxaboxen_events_dataset.info.version == "0.1.0"
+    assert "hawaii_val" in voxaboxen_events_dataset.info.split_paths
+    for split in voxaboxen_events_dataset.info.split_paths.values():
+        assert anypath(split).exists(), f"Split path {split} does not exist"
+
+
+def test_voxaboxen_events_data_property(voxaboxen_events_dataset: Dataset) -> None:
+    """Test if the data property returns correct dataframes for detection dataset."""
+    # Data should be _loaded in __init__
+    assert voxaboxen_events_dataset._data is not None
+    assert "local_path" in voxaboxen_events_dataset._data
+    assert "gbifID" in voxaboxen_events_dataset._data
+    assert voxaboxen_events_dataset._metadata is not None
+    assert isinstance(voxaboxen_events_dataset._selection_table_dict, dict)
+    assert len(voxaboxen_events_dataset._selection_table_dict) > 0, "Selection table should not be empty"
+
+
+def test_getitem(voxaboxen_events_dataset: Dataset) -> None:
+    """Test if __getitem__ returns correct sample format."""
+    # Get first sample
+    sample = voxaboxen_events_dataset[0]
+    assert isinstance(sample, dict)
+    assert "rev_anchor_anno" in sample
+    assert "audio" in sample
+    assert "class_anno" in sample
+    assert isinstance(sample["class_anno"], np.ndarray)
+    assert sample["class_anno"].ndim == 2

--- a/tests/unittests/datasets_tests/test_voxaboxen.py
+++ b/tests/unittests/datasets_tests/test_voxaboxen.py
@@ -7,8 +7,7 @@ from pydantic import BaseModel
 from typing import Literal
 
 from esp_data.io import anypath
-from esp_data.transforms import register_transform
-from esp_data import Dataset, DatasetConfig, Voxaboxen, VoxaboxenEvents
+from esp_data.transforms import register_transform, transform_from_config
 
 
 class RenameConfig(BaseModel):
@@ -26,7 +25,7 @@ class RenameTransform:
             # Create a map from input features to output features
             self.input_features = input_features
             self.output_features = output_features
-            if len(self.input_features) != len(self.output_feature):
+            if len(self.input_features) != len(self.output_features):
                 raise ValueError("input_features and output_feature must have the same length")
 
             self.feature_map = dict(zip(self.input_features, self.output_features))
@@ -45,6 +44,9 @@ class RenameTransform:
 
 
 register_transform(RenameConfig, RenameTransform)
+
+
+from esp_data import Dataset, DatasetConfig, Voxaboxen, VoxaboxenEvents
 
 
 @pytest.fixture
@@ -69,7 +71,7 @@ def voxaboxen_events_dataset() -> VoxaboxenEvents:
     VoxaboxenEvents
         An instance of the VoxaboxenEvents dataset.
     """
-    ds = VoxaboxenEvents(split="hawaii_val", sample_rate=None)
+    ds = VoxaboxenEvents(split="hawaii_val", sample_rate=16000)
     return ds
 
 
@@ -83,19 +85,15 @@ def voxaboxen_with_transforms() -> Voxaboxen:
     Voxaboxen
         An instance of the AnimalSpeak dataset with transformations applied.
     """
-
-    dataset_config = DatasetConfig(
-        dataset_name="voxaboxen",
-        transformations=[
-            {
-                "type": "rename_transform",
-                "input_features": ["fn"],
-                "output_features": ["file_name"],
-            },
-        ],
+    transform_config = RenameConfig(
+        type="rename_transform",
+        input_features=["fn"],
+        output_features=["file_name"],
     )
+    transform = RenameTransform.from_config(transform_config)
+
     ds = Voxaboxen(split="hawaii_val")
-    ds.apply_transformations(dataset_config.transformations)
+    ds._data, _ = transform(ds._data)
     return ds
 
 
@@ -148,7 +146,7 @@ def test_data_property(voxaboxen_dataset: Dataset) -> None:
 def test_available_splits(voxaboxen_dataset: Dataset) -> None:
     """Test if available_splits returns correct split names."""
     # Available splits should contain these
-    expected_splits = ["Anuraset_train", "humpback_val", "test", "cbi_test", "esc50_validation"]
+    expected_splits = ["Anuraset_train", "humpback_val", "hawaii_test", "katydids_train", "OZF_synthetic_overlap_1_train"]
     assert all(split in voxaboxen_dataset.available_splits for split in expected_splits)
 
 
@@ -176,6 +174,7 @@ def test_iteration(voxaboxen_dataset: Dataset) -> None:
         assert isinstance(sample, dict)
         # Ensure we can access a known key
         assert "audio" in sample
+        assert sample["audio"].shape[0] > 0, "Audio data should not be empty"
         break
 
 
@@ -225,14 +224,14 @@ def test_voxaboxen_events_data_property(voxaboxen_events_dataset: Dataset) -> No
     """Test if the data property returns correct dataframes for detection dataset."""
     # Data should be _loaded in __init__
     assert voxaboxen_events_dataset._data is not None
-    assert "local_path" in voxaboxen_events_dataset._data
-    assert "gbifID" in voxaboxen_events_dataset._data
+    assert "audio_duration" in voxaboxen_events_dataset._data
+    assert "audio_fp" in voxaboxen_events_dataset._data
     assert voxaboxen_events_dataset._metadata is not None
     assert isinstance(voxaboxen_events_dataset._selection_table_dict, dict)
     assert len(voxaboxen_events_dataset._selection_table_dict) > 0, "Selection table should not be empty"
 
 
-def test_getitem(voxaboxen_events_dataset: Dataset) -> None:
+def test_voxaboxen_events_getitem(voxaboxen_events_dataset: Dataset) -> None:
     """Test if __getitem__ returns correct sample format."""
     # Get first sample
     sample = voxaboxen_events_dataset[0]

--- a/uv.lock
+++ b/uv.lock
@@ -597,7 +597,7 @@ dependencies = [
     { name = "gcsfs" },
     { name = "google-cloud-secret-manager" },
     { name = "google-cloud-storage" },
-    { name = "interval" },
+    { name = "intervaltree" },
     { name = "librosa" },
     { name = "pandas" },
     { name = "pydantic" },
@@ -605,7 +605,6 @@ dependencies = [
     { name = "s3fs" },
     { name = "semver" },
     { name = "soundfile" },
-    { name = "tree" },
 ]
 
 [package.dev-dependencies]
@@ -626,7 +625,7 @@ requires-dist = [
     { name = "gcsfs", specifier = ">=2024.9.0.post1" },
     { name = "google-cloud-secret-manager", specifier = ">=2.23.1" },
     { name = "google-cloud-storage", specifier = ">=2.19.0" },
-    { name = "interval", specifier = ">=1.0.0" },
+    { name = "intervaltree", specifier = ">=3.1.0" },
     { name = "librosa", specifier = ">=0.11.0" },
     { name = "pandas" },
     { name = "pydantic", specifier = ">=2" },
@@ -634,7 +633,6 @@ requires-dist = [
     { name = "s3fs", specifier = ">=2024.9.0" },
     { name = "semver" },
     { name = "soundfile", specifier = ">=0.13.1" },
-    { name = "tree", specifier = ">=0.2.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -1096,10 +1094,13 @@ wheels = [
 ]
 
 [[package]]
-name = "interval"
-version = "1.0.0"
+name = "intervaltree"
+version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b3/2d/b337afbd232ea1ea9c38401135054bf763e7930ea5e2e49bc39af35c3443/interval-1.0.0.tar.bz2", hash = "sha256:6619937f3fcb5cf85bb3a60b4e4391664e8d7b30ae3dc4d04c3fc1d063ff1c3b", size = 11621 }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/fb/396d568039d21344639db96d940d40eb62befe704ef849b27949ded5c3bb/intervaltree-3.1.0.tar.gz", hash = "sha256:902b1b88936918f9b2a19e0e5eb7ccb430ae45cde4f39ea4b36932920d33952d", size = 32861 }
 
 [[package]]
 name = "isodate"
@@ -1750,108 +1751,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
-]
-
-[[package]]
-name = "pillow"
-version = "11.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523", size = 47113069 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/5d/45a3553a253ac8763f3561371432a90bdbe6000fbdcf1397ffe502aa206c/pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860", size = 5316554 },
-    { url = "https://files.pythonhosted.org/packages/7c/c8/67c12ab069ef586a25a4a79ced553586748fad100c77c0ce59bb4983ac98/pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad", size = 4686548 },
-    { url = "https://files.pythonhosted.org/packages/2f/bd/6741ebd56263390b382ae4c5de02979af7f8bd9807346d068700dd6d5cf9/pillow-11.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7107195ddc914f656c7fc8e4a5e1c25f32e9236ea3ea860f257b0436011fddd0", size = 5859742 },
-    { url = "https://files.pythonhosted.org/packages/ca/0b/c412a9e27e1e6a829e6ab6c2dca52dd563efbedf4c9c6aa453d9a9b77359/pillow-11.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc3e831b563b3114baac7ec2ee86819eb03caa1a2cef0b481a5675b59c4fe23b", size = 7633087 },
-    { url = "https://files.pythonhosted.org/packages/59/9d/9b7076aaf30f5dd17e5e5589b2d2f5a5d7e30ff67a171eb686e4eecc2adf/pillow-11.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f182ebd2303acf8c380a54f615ec883322593320a9b00438eb842c1f37ae50", size = 5963350 },
-    { url = "https://files.pythonhosted.org/packages/f0/16/1a6bf01fb622fb9cf5c91683823f073f053005c849b1f52ed613afcf8dae/pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4445fa62e15936a028672fd48c4c11a66d641d2c05726c7ec1f8ba6a572036ae", size = 6631840 },
-    { url = "https://files.pythonhosted.org/packages/7b/e6/6ff7077077eb47fde78739e7d570bdcd7c10495666b6afcd23ab56b19a43/pillow-11.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71f511f6b3b91dd543282477be45a033e4845a40278fa8dcdbfdb07109bf18f9", size = 6074005 },
-    { url = "https://files.pythonhosted.org/packages/c3/3a/b13f36832ea6d279a697231658199e0a03cd87ef12048016bdcc84131601/pillow-11.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:040a5b691b0713e1f6cbe222e0f4f74cd233421e105850ae3b3c0ceda520f42e", size = 6708372 },
-    { url = "https://files.pythonhosted.org/packages/6c/e4/61b2e1a7528740efbc70b3d581f33937e38e98ef3d50b05007267a55bcb2/pillow-11.3.0-cp310-cp310-win32.whl", hash = "sha256:89bd777bc6624fe4115e9fac3352c79ed60f3bb18651420635f26e643e3dd1f6", size = 6277090 },
-    { url = "https://files.pythonhosted.org/packages/a9/d3/60c781c83a785d6afbd6a326ed4d759d141de43aa7365725cbcd65ce5e54/pillow-11.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:19d2ff547c75b8e3ff46f4d9ef969a06c30ab2d4263a9e287733aa8b2429ce8f", size = 6985988 },
-    { url = "https://files.pythonhosted.org/packages/9f/28/4f4a0203165eefb3763939c6789ba31013a2e90adffb456610f30f613850/pillow-11.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:819931d25e57b513242859ce1876c58c59dc31587847bf74cfe06b2e0cb22d2f", size = 2422899 },
-    { url = "https://files.pythonhosted.org/packages/db/26/77f8ed17ca4ffd60e1dcd220a6ec6d71210ba398cfa33a13a1cd614c5613/pillow-11.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1cd110edf822773368b396281a2293aeb91c90a2db00d78ea43e7e861631b722", size = 5316531 },
-    { url = "https://files.pythonhosted.org/packages/cb/39/ee475903197ce709322a17a866892efb560f57900d9af2e55f86db51b0a5/pillow-11.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9c412fddd1b77a75aa904615ebaa6001f169b26fd467b4be93aded278266b288", size = 4686560 },
-    { url = "https://files.pythonhosted.org/packages/d5/90/442068a160fd179938ba55ec8c97050a612426fae5ec0a764e345839f76d/pillow-11.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1aa4de119a0ecac0a34a9c8bde33f34022e2e8f99104e47a3ca392fd60e37d", size = 5870978 },
-    { url = "https://files.pythonhosted.org/packages/13/92/dcdd147ab02daf405387f0218dcf792dc6dd5b14d2573d40b4caeef01059/pillow-11.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:91da1d88226663594e3f6b4b8c3c8d85bd504117d043740a8e0ec449087cc494", size = 7641168 },
-    { url = "https://files.pythonhosted.org/packages/6e/db/839d6ba7fd38b51af641aa904e2960e7a5644d60ec754c046b7d2aee00e5/pillow-11.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643f189248837533073c405ec2f0bb250ba54598cf80e8c1e043381a60632f58", size = 5973053 },
-    { url = "https://files.pythonhosted.org/packages/f2/2f/d7675ecae6c43e9f12aa8d58b6012683b20b6edfbdac7abcb4e6af7a3784/pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:106064daa23a745510dabce1d84f29137a37224831d88eb4ce94bb187b1d7e5f", size = 6640273 },
-    { url = "https://files.pythonhosted.org/packages/45/ad/931694675ede172e15b2ff03c8144a0ddaea1d87adb72bb07655eaffb654/pillow-11.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd8ff254faf15591e724dc7c4ddb6bf4793efcbe13802a4ae3e863cd300b493e", size = 6082043 },
-    { url = "https://files.pythonhosted.org/packages/3a/04/ba8f2b11fc80d2dd462d7abec16351b45ec99cbbaea4387648a44190351a/pillow-11.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:932c754c2d51ad2b2271fd01c3d121daaa35e27efae2a616f77bf164bc0b3e94", size = 6715516 },
-    { url = "https://files.pythonhosted.org/packages/48/59/8cd06d7f3944cc7d892e8533c56b0acb68399f640786313275faec1e3b6f/pillow-11.3.0-cp311-cp311-win32.whl", hash = "sha256:b4b8f3efc8d530a1544e5962bd6b403d5f7fe8b9e08227c6b255f98ad82b4ba0", size = 6274768 },
-    { url = "https://files.pythonhosted.org/packages/f1/cc/29c0f5d64ab8eae20f3232da8f8571660aa0ab4b8f1331da5c2f5f9a938e/pillow-11.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:1a992e86b0dd7aeb1f053cd506508c0999d710a8f07b4c791c63843fc6a807ac", size = 6986055 },
-    { url = "https://files.pythonhosted.org/packages/c6/df/90bd886fabd544c25addd63e5ca6932c86f2b701d5da6c7839387a076b4a/pillow-11.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:30807c931ff7c095620fe04448e2c2fc673fcbb1ffe2a7da3fb39613489b1ddd", size = 2423079 },
-    { url = "https://files.pythonhosted.org/packages/40/fe/1bc9b3ee13f68487a99ac9529968035cca2f0a51ec36892060edcc51d06a/pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4", size = 5278800 },
-    { url = "https://files.pythonhosted.org/packages/2c/32/7e2ac19b5713657384cec55f89065fb306b06af008cfd87e572035b27119/pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69", size = 4686296 },
-    { url = "https://files.pythonhosted.org/packages/8e/1e/b9e12bbe6e4c2220effebc09ea0923a07a6da1e1f1bfbc8d7d29a01ce32b/pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d", size = 5871726 },
-    { url = "https://files.pythonhosted.org/packages/8d/33/e9200d2bd7ba00dc3ddb78df1198a6e80d7669cce6c2bdbeb2530a74ec58/pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6", size = 7644652 },
-    { url = "https://files.pythonhosted.org/packages/41/f1/6f2427a26fc683e00d985bc391bdd76d8dd4e92fac33d841127eb8fb2313/pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7", size = 5977787 },
-    { url = "https://files.pythonhosted.org/packages/e4/c9/06dd4a38974e24f932ff5f98ea3c546ce3f8c995d3f0985f8e5ba48bba19/pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024", size = 6645236 },
-    { url = "https://files.pythonhosted.org/packages/40/e7/848f69fb79843b3d91241bad658e9c14f39a32f71a301bcd1d139416d1be/pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809", size = 6086950 },
-    { url = "https://files.pythonhosted.org/packages/0b/1a/7cff92e695a2a29ac1958c2a0fe4c0b2393b60aac13b04a4fe2735cad52d/pillow-11.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6be31e3fc9a621e071bc17bb7de63b85cbe0bfae91bb0363c893cbe67247780d", size = 6723358 },
-    { url = "https://files.pythonhosted.org/packages/26/7d/73699ad77895f69edff76b0f332acc3d497f22f5d75e5360f78cbcaff248/pillow-11.3.0-cp312-cp312-win32.whl", hash = "sha256:7b161756381f0918e05e7cb8a371fff367e807770f8fe92ecb20d905d0e1c149", size = 6275079 },
-    { url = "https://files.pythonhosted.org/packages/8c/ce/e7dfc873bdd9828f3b6e5c2bbb74e47a98ec23cc5c74fc4e54462f0d9204/pillow-11.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a6444696fce635783440b7f7a9fc24b3ad10a9ea3f0ab66c5905be1c19ccf17d", size = 6986324 },
-    { url = "https://files.pythonhosted.org/packages/16/8f/b13447d1bf0b1f7467ce7d86f6e6edf66c0ad7cf44cf5c87a37f9bed9936/pillow-11.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:2aceea54f957dd4448264f9bf40875da0415c83eb85f55069d89c0ed436e3542", size = 2423067 },
-    { url = "https://files.pythonhosted.org/packages/1e/93/0952f2ed8db3a5a4c7a11f91965d6184ebc8cd7cbb7941a260d5f018cd2d/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:1c627742b539bba4309df89171356fcb3cc5a9178355b2727d1b74a6cf155fbd", size = 2128328 },
-    { url = "https://files.pythonhosted.org/packages/4b/e8/100c3d114b1a0bf4042f27e0f87d2f25e857e838034e98ca98fe7b8c0a9c/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:30b7c02f3899d10f13d7a48163c8969e4e653f8b43416d23d13d1bbfdc93b9f8", size = 2170652 },
-    { url = "https://files.pythonhosted.org/packages/aa/86/3f758a28a6e381758545f7cdb4942e1cb79abd271bea932998fc0db93cb6/pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f", size = 2227443 },
-    { url = "https://files.pythonhosted.org/packages/01/f4/91d5b3ffa718df2f53b0dc109877993e511f4fd055d7e9508682e8aba092/pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c", size = 5278474 },
-    { url = "https://files.pythonhosted.org/packages/f9/0e/37d7d3eca6c879fbd9dba21268427dffda1ab00d4eb05b32923d4fbe3b12/pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd", size = 4686038 },
-    { url = "https://files.pythonhosted.org/packages/ff/b0/3426e5c7f6565e752d81221af9d3676fdbb4f352317ceafd42899aaf5d8a/pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e", size = 5864407 },
-    { url = "https://files.pythonhosted.org/packages/fc/c1/c6c423134229f2a221ee53f838d4be9d82bab86f7e2f8e75e47b6bf6cd77/pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1", size = 7639094 },
-    { url = "https://files.pythonhosted.org/packages/ba/c9/09e6746630fe6372c67c648ff9deae52a2bc20897d51fa293571977ceb5d/pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805", size = 5973503 },
-    { url = "https://files.pythonhosted.org/packages/d5/1c/a2a29649c0b1983d3ef57ee87a66487fdeb45132df66ab30dd37f7dbe162/pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8", size = 6642574 },
-    { url = "https://files.pythonhosted.org/packages/36/de/d5cc31cc4b055b6c6fd990e3e7f0f8aaf36229a2698501bcb0cdf67c7146/pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2", size = 6084060 },
-    { url = "https://files.pythonhosted.org/packages/d5/ea/502d938cbaeec836ac28a9b730193716f0114c41325db428e6b280513f09/pillow-11.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:45dfc51ac5975b938e9809451c51734124e73b04d0f0ac621649821a63852e7b", size = 6721407 },
-    { url = "https://files.pythonhosted.org/packages/45/9c/9c5e2a73f125f6cbc59cc7087c8f2d649a7ae453f83bd0362ff7c9e2aee2/pillow-11.3.0-cp313-cp313-win32.whl", hash = "sha256:a4d336baed65d50d37b88ca5b60c0fa9d81e3a87d4a7930d3880d1624d5b31f3", size = 6273841 },
-    { url = "https://files.pythonhosted.org/packages/23/85/397c73524e0cd212067e0c969aa245b01d50183439550d24d9f55781b776/pillow-11.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bce5c4fd0921f99d2e858dc4d4d64193407e1b99478bc5cacecba2311abde51", size = 6978450 },
-    { url = "https://files.pythonhosted.org/packages/17/d2/622f4547f69cd173955194b78e4d19ca4935a1b0f03a302d655c9f6aae65/pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580", size = 2423055 },
-    { url = "https://files.pythonhosted.org/packages/dd/80/a8a2ac21dda2e82480852978416cfacd439a4b490a501a288ecf4fe2532d/pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e", size = 5281110 },
-    { url = "https://files.pythonhosted.org/packages/44/d6/b79754ca790f315918732e18f82a8146d33bcd7f4494380457ea89eb883d/pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d", size = 4689547 },
-    { url = "https://files.pythonhosted.org/packages/49/20/716b8717d331150cb00f7fdd78169c01e8e0c219732a78b0e59b6bdb2fd6/pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced", size = 5901554 },
-    { url = "https://files.pythonhosted.org/packages/74/cf/a9f3a2514a65bb071075063a96f0a5cf949c2f2fce683c15ccc83b1c1cab/pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c", size = 7669132 },
-    { url = "https://files.pythonhosted.org/packages/98/3c/da78805cbdbee9cb43efe8261dd7cc0b4b93f2ac79b676c03159e9db2187/pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8", size = 6005001 },
-    { url = "https://files.pythonhosted.org/packages/6c/fa/ce044b91faecf30e635321351bba32bab5a7e034c60187fe9698191aef4f/pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59", size = 6668814 },
-    { url = "https://files.pythonhosted.org/packages/7b/51/90f9291406d09bf93686434f9183aba27b831c10c87746ff49f127ee80cb/pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe", size = 6113124 },
-    { url = "https://files.pythonhosted.org/packages/cd/5a/6fec59b1dfb619234f7636d4157d11fb4e196caeee220232a8d2ec48488d/pillow-11.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83e1b0161c9d148125083a35c1c5a89db5b7054834fd4387499e06552035236c", size = 6747186 },
-    { url = "https://files.pythonhosted.org/packages/49/6b/00187a044f98255225f172de653941e61da37104a9ea60e4f6887717e2b5/pillow-11.3.0-cp313-cp313t-win32.whl", hash = "sha256:2a3117c06b8fb646639dce83694f2f9eac405472713fcb1ae887469c0d4f6788", size = 6277546 },
-    { url = "https://files.pythonhosted.org/packages/e8/5c/6caaba7e261c0d75bab23be79f1d06b5ad2a2ae49f028ccec801b0e853d6/pillow-11.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:857844335c95bea93fb39e0fa2726b4d9d758850b34075a7e3ff4f4fa3aa3b31", size = 6985102 },
-    { url = "https://files.pythonhosted.org/packages/f3/7e/b623008460c09a0cb38263c93b828c666493caee2eb34ff67f778b87e58c/pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e", size = 2424803 },
-    { url = "https://files.pythonhosted.org/packages/73/f4/04905af42837292ed86cb1b1dabe03dce1edc008ef14c473c5c7e1443c5d/pillow-11.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d9da3df5f9ea2a89b81bb6087177fb1f4d1c7146d583a3fe5c672c0d94e55e12", size = 5278520 },
-    { url = "https://files.pythonhosted.org/packages/41/b0/33d79e377a336247df6348a54e6d2a2b85d644ca202555e3faa0cf811ecc/pillow-11.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b275ff9b04df7b640c59ec5a3cb113eefd3795a8df80bac69646ef699c6981a", size = 4686116 },
-    { url = "https://files.pythonhosted.org/packages/49/2d/ed8bc0ab219ae8768f529597d9509d184fe8a6c4741a6864fea334d25f3f/pillow-11.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0743841cabd3dba6a83f38a92672cccbd69af56e3e91777b0ee7f4dba4385632", size = 5864597 },
-    { url = "https://files.pythonhosted.org/packages/b5/3d/b932bb4225c80b58dfadaca9d42d08d0b7064d2d1791b6a237f87f661834/pillow-11.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2465a69cf967b8b49ee1b96d76718cd98c4e925414ead59fdf75cf0fd07df673", size = 7638246 },
-    { url = "https://files.pythonhosted.org/packages/09/b5/0487044b7c096f1b48f0d7ad416472c02e0e4bf6919541b111efd3cae690/pillow-11.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41742638139424703b4d01665b807c6468e23e699e8e90cffefe291c5832b027", size = 5973336 },
-    { url = "https://files.pythonhosted.org/packages/a8/2d/524f9318f6cbfcc79fbc004801ea6b607ec3f843977652fdee4857a7568b/pillow-11.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93efb0b4de7e340d99057415c749175e24c8864302369e05914682ba642e5d77", size = 6642699 },
-    { url = "https://files.pythonhosted.org/packages/6f/d2/a9a4f280c6aefedce1e8f615baaa5474e0701d86dd6f1dede66726462bbd/pillow-11.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7966e38dcd0fa11ca390aed7c6f20454443581d758242023cf36fcb319b1a874", size = 6083789 },
-    { url = "https://files.pythonhosted.org/packages/fe/54/86b0cd9dbb683a9d5e960b66c7379e821a19be4ac5810e2e5a715c09a0c0/pillow-11.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:98a9afa7b9007c67ed84c57c9e0ad86a6000da96eaa638e4f8abe5b65ff83f0a", size = 6720386 },
-    { url = "https://files.pythonhosted.org/packages/e7/95/88efcaf384c3588e24259c4203b909cbe3e3c2d887af9e938c2022c9dd48/pillow-11.3.0-cp314-cp314-win32.whl", hash = "sha256:02a723e6bf909e7cea0dac1b0e0310be9d7650cd66222a5f1c571455c0a45214", size = 6370911 },
-    { url = "https://files.pythonhosted.org/packages/2e/cc/934e5820850ec5eb107e7b1a72dd278140731c669f396110ebc326f2a503/pillow-11.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:a418486160228f64dd9e9efcd132679b7a02a5f22c982c78b6fc7dab3fefb635", size = 7117383 },
-    { url = "https://files.pythonhosted.org/packages/d6/e9/9c0a616a71da2a5d163aa37405e8aced9a906d574b4a214bede134e731bc/pillow-11.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:155658efb5e044669c08896c0c44231c5e9abcaadbc5cd3648df2f7c0b96b9a6", size = 2511385 },
-    { url = "https://files.pythonhosted.org/packages/1a/33/c88376898aff369658b225262cd4f2659b13e8178e7534df9e6e1fa289f6/pillow-11.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:59a03cdf019efbfeeed910bf79c7c93255c3d54bc45898ac2a4140071b02b4ae", size = 5281129 },
-    { url = "https://files.pythonhosted.org/packages/1f/70/d376247fb36f1844b42910911c83a02d5544ebd2a8bad9efcc0f707ea774/pillow-11.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f8a5827f84d973d8636e9dc5764af4f0cf2318d26744b3d902931701b0d46653", size = 4689580 },
-    { url = "https://files.pythonhosted.org/packages/eb/1c/537e930496149fbac69efd2fc4329035bbe2e5475b4165439e3be9cb183b/pillow-11.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee92f2fd10f4adc4b43d07ec5e779932b4eb3dbfbc34790ada5a6669bc095aa6", size = 5902860 },
-    { url = "https://files.pythonhosted.org/packages/bd/57/80f53264954dcefeebcf9dae6e3eb1daea1b488f0be8b8fef12f79a3eb10/pillow-11.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96d333dcf42d01f47b37e0979b6bd73ec91eae18614864622d9b87bbd5bbf36", size = 7670694 },
-    { url = "https://files.pythonhosted.org/packages/70/ff/4727d3b71a8578b4587d9c276e90efad2d6fe0335fd76742a6da08132e8c/pillow-11.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c96f993ab8c98460cd0c001447bff6194403e8b1d7e149ade5f00594918128b", size = 6005888 },
-    { url = "https://files.pythonhosted.org/packages/05/ae/716592277934f85d3be51d7256f3636672d7b1abfafdc42cf3f8cbd4b4c8/pillow-11.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41342b64afeba938edb034d122b2dda5db2139b9a4af999729ba8818e0056477", size = 6670330 },
-    { url = "https://files.pythonhosted.org/packages/e7/bb/7fe6cddcc8827b01b1a9766f5fdeb7418680744f9082035bdbabecf1d57f/pillow-11.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:068d9c39a2d1b358eb9f245ce7ab1b5c3246c7c8c7d9ba58cfa5b43146c06e50", size = 6114089 },
-    { url = "https://files.pythonhosted.org/packages/8b/f5/06bfaa444c8e80f1a8e4bff98da9c83b37b5be3b1deaa43d27a0db37ef84/pillow-11.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a1bc6ba083b145187f648b667e05a2534ecc4b9f2784c2cbe3089e44868f2b9b", size = 6748206 },
-    { url = "https://files.pythonhosted.org/packages/f0/77/bc6f92a3e8e6e46c0ca78abfffec0037845800ea38c73483760362804c41/pillow-11.3.0-cp314-cp314t-win32.whl", hash = "sha256:118ca10c0d60b06d006be10a501fd6bbdfef559251ed31b794668ed569c87e12", size = 6377370 },
-    { url = "https://files.pythonhosted.org/packages/4a/82/3a721f7d69dca802befb8af08b7c79ebcab461007ce1c18bd91a5d5896f9/pillow-11.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8924748b688aa210d79883357d102cd64690e56b923a186f35a82cbc10f997db", size = 7121500 },
-    { url = "https://files.pythonhosted.org/packages/89/c7/5572fa4a3f45740eaab6ae86fcdf7195b55beac1371ac8c619d880cfe948/pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa", size = 2512835 },
-    { url = "https://files.pythonhosted.org/packages/6f/8b/209bd6b62ce8367f47e68a218bffac88888fdf2c9fcf1ecadc6c3ec1ebc7/pillow-11.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3cee80663f29e3843b68199b9d6f4f54bd1d4a6b59bdd91bceefc51238bcb967", size = 5270556 },
-    { url = "https://files.pythonhosted.org/packages/2e/e6/231a0b76070c2cfd9e260a7a5b504fb72da0a95279410fa7afd99d9751d6/pillow-11.3.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b5f56c3f344f2ccaf0dd875d3e180f631dc60a51b314295a3e681fe8cf851fbe", size = 4654625 },
-    { url = "https://files.pythonhosted.org/packages/13/f4/10cf94fda33cb12765f2397fc285fa6d8eb9c29de7f3185165b702fc7386/pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e67d793d180c9df62f1f40aee3accca4829d3794c95098887edc18af4b8b780c", size = 4874207 },
-    { url = "https://files.pythonhosted.org/packages/72/c9/583821097dc691880c92892e8e2d41fe0a5a3d6021f4963371d2f6d57250/pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d000f46e2917c705e9fb93a3606ee4a819d1e3aa7a9b442f6444f07e77cf5e25", size = 6583939 },
-    { url = "https://files.pythonhosted.org/packages/3b/8e/5c9d410f9217b12320efc7c413e72693f48468979a013ad17fd690397b9a/pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:527b37216b6ac3a12d7838dc3bd75208ec57c1c6d11ef01902266a5a0c14fc27", size = 4957166 },
-    { url = "https://files.pythonhosted.org/packages/62/bb/78347dbe13219991877ffb3a91bf09da8317fbfcd4b5f9140aeae020ad71/pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be5463ac478b623b9dd3937afd7fb7ab3d79dd290a28e2b6df292dc75063eb8a", size = 5581482 },
-    { url = "https://files.pythonhosted.org/packages/d9/28/1000353d5e61498aaeaaf7f1e4b49ddb05f2c6575f9d4f9f914a3538b6e1/pillow-11.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8dc70ca24c110503e16918a658b869019126ecfe03109b754c402daff12b3d9f", size = 6984596 },
-    { url = "https://files.pythonhosted.org/packages/9e/e3/6fa84033758276fb31da12e5fb66ad747ae83b93c67af17f8c6ff4cc8f34/pillow-11.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7c8ec7a017ad1bd562f93dbd8505763e688d388cde6e4a010ae1486916e713e6", size = 5270566 },
-    { url = "https://files.pythonhosted.org/packages/5b/ee/e8d2e1ab4892970b561e1ba96cbd59c0d28cf66737fc44abb2aec3795a4e/pillow-11.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9ab6ae226de48019caa8074894544af5b53a117ccb9d3b3dcb2871464c829438", size = 4654618 },
-    { url = "https://files.pythonhosted.org/packages/f2/6d/17f80f4e1f0761f02160fc433abd4109fa1548dcfdca46cfdadaf9efa565/pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe27fb049cdcca11f11a7bfda64043c37b30e6b91f10cb5bab275806c32f6ab3", size = 4874248 },
-    { url = "https://files.pythonhosted.org/packages/de/5f/c22340acd61cef960130585bbe2120e2fd8434c214802f07e8c03596b17e/pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:465b9e8844e3c3519a983d58b80be3f668e2a7a5db97f2784e7079fbc9f9822c", size = 6583963 },
-    { url = "https://files.pythonhosted.org/packages/31/5e/03966aedfbfcbb4d5f8aa042452d3361f325b963ebbadddac05b122e47dd/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361", size = 4957170 },
-    { url = "https://files.pythonhosted.org/packages/cc/2d/e082982aacc927fc2cab48e1e731bdb1643a1406acace8bed0900a61464e/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7", size = 5581505 },
-    { url = "https://files.pythonhosted.org/packages/34/e7/ae39f538fd6844e982063c3a5e4598b8ced43b9633baa3a85ef33af8c05c/pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8", size = 6984598 },
 ]
 
 [[package]]
@@ -2513,6 +2412,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
+]
+
+[[package]]
 name = "soundfile"
 version = "0.13.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2592,15 +2500,6 @@ wheels = [
 ]
 
 [[package]]
-name = "svgwrite"
-version = "1.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/16/c1/263d4e93b543390d86d8eb4fc23d9ce8a8d6efd146f9427364109004fa9b/svgwrite-1.4.3.zip", hash = "sha256:a8fbdfd4443302a6619a7f76bc937fc683daf2628d9b737c891ec08b8ce524c3", size = 189516 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/15/640e399579024a6875918839454025bb1d5f850bb70d96a11eabb644d11c/svgwrite-1.4.3-py3-none-any.whl", hash = "sha256:bb6b2b5450f1edbfa597d924f9ac2dd099e625562e492021d7dd614f65f8a22d", size = 67122 },
-]
-
-[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2647,18 +2546,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
 ]
-
-[[package]]
-name = "tree"
-version = "0.2.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "pillow" },
-    { name = "setuptools" },
-    { name = "svgwrite" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/3f/63cbed2909786f0e5ac30a4ae5791ad597c6b5fec7167e161c55bba511ce/Tree-0.2.4.tar.gz", hash = "sha256:f84d8ec9bf50dd69f551da78925a23d110864e7706551f590cdade27646f7883", size = 6489 }
 
 [[package]]
 name = "types-setuptools"

--- a/uv.lock
+++ b/uv.lock
@@ -597,6 +597,7 @@ dependencies = [
     { name = "gcsfs" },
     { name = "google-cloud-secret-manager" },
     { name = "google-cloud-storage" },
+    { name = "interval" },
     { name = "librosa" },
     { name = "pandas" },
     { name = "pydantic" },
@@ -604,6 +605,7 @@ dependencies = [
     { name = "s3fs" },
     { name = "semver" },
     { name = "soundfile" },
+    { name = "tree" },
 ]
 
 [package.dev-dependencies]
@@ -624,6 +626,7 @@ requires-dist = [
     { name = "gcsfs", specifier = ">=2024.9.0.post1" },
     { name = "google-cloud-secret-manager", specifier = ">=2.23.1" },
     { name = "google-cloud-storage", specifier = ">=2.19.0" },
+    { name = "interval", specifier = ">=1.0.0" },
     { name = "librosa", specifier = ">=0.11.0" },
     { name = "pandas" },
     { name = "pydantic", specifier = ">=2" },
@@ -631,6 +634,7 @@ requires-dist = [
     { name = "s3fs", specifier = ">=2024.9.0" },
     { name = "semver" },
     { name = "soundfile", specifier = ">=0.13.1" },
+    { name = "tree", specifier = ">=0.2.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -1090,6 +1094,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c9
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
 ]
+
+[[package]]
+name = "interval"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/2d/b337afbd232ea1ea9c38401135054bf763e7930ea5e2e49bc39af35c3443/interval-1.0.0.tar.bz2", hash = "sha256:6619937f3fcb5cf85bb3a60b4e4391664e8d7b30ae3dc4d04c3fc1d063ff1c3b", size = 11621 }
 
 [[package]]
 name = "isodate"
@@ -1740,6 +1750,108 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
+]
+
+[[package]]
+name = "pillow"
+version = "11.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz", hash = "sha256:3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523", size = 47113069 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/5d/45a3553a253ac8763f3561371432a90bdbe6000fbdcf1397ffe502aa206c/pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860", size = 5316554 },
+    { url = "https://files.pythonhosted.org/packages/7c/c8/67c12ab069ef586a25a4a79ced553586748fad100c77c0ce59bb4983ac98/pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad", size = 4686548 },
+    { url = "https://files.pythonhosted.org/packages/2f/bd/6741ebd56263390b382ae4c5de02979af7f8bd9807346d068700dd6d5cf9/pillow-11.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7107195ddc914f656c7fc8e4a5e1c25f32e9236ea3ea860f257b0436011fddd0", size = 5859742 },
+    { url = "https://files.pythonhosted.org/packages/ca/0b/c412a9e27e1e6a829e6ab6c2dca52dd563efbedf4c9c6aa453d9a9b77359/pillow-11.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc3e831b563b3114baac7ec2ee86819eb03caa1a2cef0b481a5675b59c4fe23b", size = 7633087 },
+    { url = "https://files.pythonhosted.org/packages/59/9d/9b7076aaf30f5dd17e5e5589b2d2f5a5d7e30ff67a171eb686e4eecc2adf/pillow-11.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f182ebd2303acf8c380a54f615ec883322593320a9b00438eb842c1f37ae50", size = 5963350 },
+    { url = "https://files.pythonhosted.org/packages/f0/16/1a6bf01fb622fb9cf5c91683823f073f053005c849b1f52ed613afcf8dae/pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4445fa62e15936a028672fd48c4c11a66d641d2c05726c7ec1f8ba6a572036ae", size = 6631840 },
+    { url = "https://files.pythonhosted.org/packages/7b/e6/6ff7077077eb47fde78739e7d570bdcd7c10495666b6afcd23ab56b19a43/pillow-11.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71f511f6b3b91dd543282477be45a033e4845a40278fa8dcdbfdb07109bf18f9", size = 6074005 },
+    { url = "https://files.pythonhosted.org/packages/c3/3a/b13f36832ea6d279a697231658199e0a03cd87ef12048016bdcc84131601/pillow-11.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:040a5b691b0713e1f6cbe222e0f4f74cd233421e105850ae3b3c0ceda520f42e", size = 6708372 },
+    { url = "https://files.pythonhosted.org/packages/6c/e4/61b2e1a7528740efbc70b3d581f33937e38e98ef3d50b05007267a55bcb2/pillow-11.3.0-cp310-cp310-win32.whl", hash = "sha256:89bd777bc6624fe4115e9fac3352c79ed60f3bb18651420635f26e643e3dd1f6", size = 6277090 },
+    { url = "https://files.pythonhosted.org/packages/a9/d3/60c781c83a785d6afbd6a326ed4d759d141de43aa7365725cbcd65ce5e54/pillow-11.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:19d2ff547c75b8e3ff46f4d9ef969a06c30ab2d4263a9e287733aa8b2429ce8f", size = 6985988 },
+    { url = "https://files.pythonhosted.org/packages/9f/28/4f4a0203165eefb3763939c6789ba31013a2e90adffb456610f30f613850/pillow-11.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:819931d25e57b513242859ce1876c58c59dc31587847bf74cfe06b2e0cb22d2f", size = 2422899 },
+    { url = "https://files.pythonhosted.org/packages/db/26/77f8ed17ca4ffd60e1dcd220a6ec6d71210ba398cfa33a13a1cd614c5613/pillow-11.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1cd110edf822773368b396281a2293aeb91c90a2db00d78ea43e7e861631b722", size = 5316531 },
+    { url = "https://files.pythonhosted.org/packages/cb/39/ee475903197ce709322a17a866892efb560f57900d9af2e55f86db51b0a5/pillow-11.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9c412fddd1b77a75aa904615ebaa6001f169b26fd467b4be93aded278266b288", size = 4686560 },
+    { url = "https://files.pythonhosted.org/packages/d5/90/442068a160fd179938ba55ec8c97050a612426fae5ec0a764e345839f76d/pillow-11.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1aa4de119a0ecac0a34a9c8bde33f34022e2e8f99104e47a3ca392fd60e37d", size = 5870978 },
+    { url = "https://files.pythonhosted.org/packages/13/92/dcdd147ab02daf405387f0218dcf792dc6dd5b14d2573d40b4caeef01059/pillow-11.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:91da1d88226663594e3f6b4b8c3c8d85bd504117d043740a8e0ec449087cc494", size = 7641168 },
+    { url = "https://files.pythonhosted.org/packages/6e/db/839d6ba7fd38b51af641aa904e2960e7a5644d60ec754c046b7d2aee00e5/pillow-11.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643f189248837533073c405ec2f0bb250ba54598cf80e8c1e043381a60632f58", size = 5973053 },
+    { url = "https://files.pythonhosted.org/packages/f2/2f/d7675ecae6c43e9f12aa8d58b6012683b20b6edfbdac7abcb4e6af7a3784/pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:106064daa23a745510dabce1d84f29137a37224831d88eb4ce94bb187b1d7e5f", size = 6640273 },
+    { url = "https://files.pythonhosted.org/packages/45/ad/931694675ede172e15b2ff03c8144a0ddaea1d87adb72bb07655eaffb654/pillow-11.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd8ff254faf15591e724dc7c4ddb6bf4793efcbe13802a4ae3e863cd300b493e", size = 6082043 },
+    { url = "https://files.pythonhosted.org/packages/3a/04/ba8f2b11fc80d2dd462d7abec16351b45ec99cbbaea4387648a44190351a/pillow-11.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:932c754c2d51ad2b2271fd01c3d121daaa35e27efae2a616f77bf164bc0b3e94", size = 6715516 },
+    { url = "https://files.pythonhosted.org/packages/48/59/8cd06d7f3944cc7d892e8533c56b0acb68399f640786313275faec1e3b6f/pillow-11.3.0-cp311-cp311-win32.whl", hash = "sha256:b4b8f3efc8d530a1544e5962bd6b403d5f7fe8b9e08227c6b255f98ad82b4ba0", size = 6274768 },
+    { url = "https://files.pythonhosted.org/packages/f1/cc/29c0f5d64ab8eae20f3232da8f8571660aa0ab4b8f1331da5c2f5f9a938e/pillow-11.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:1a992e86b0dd7aeb1f053cd506508c0999d710a8f07b4c791c63843fc6a807ac", size = 6986055 },
+    { url = "https://files.pythonhosted.org/packages/c6/df/90bd886fabd544c25addd63e5ca6932c86f2b701d5da6c7839387a076b4a/pillow-11.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:30807c931ff7c095620fe04448e2c2fc673fcbb1ffe2a7da3fb39613489b1ddd", size = 2423079 },
+    { url = "https://files.pythonhosted.org/packages/40/fe/1bc9b3ee13f68487a99ac9529968035cca2f0a51ec36892060edcc51d06a/pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4", size = 5278800 },
+    { url = "https://files.pythonhosted.org/packages/2c/32/7e2ac19b5713657384cec55f89065fb306b06af008cfd87e572035b27119/pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69", size = 4686296 },
+    { url = "https://files.pythonhosted.org/packages/8e/1e/b9e12bbe6e4c2220effebc09ea0923a07a6da1e1f1bfbc8d7d29a01ce32b/pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d", size = 5871726 },
+    { url = "https://files.pythonhosted.org/packages/8d/33/e9200d2bd7ba00dc3ddb78df1198a6e80d7669cce6c2bdbeb2530a74ec58/pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6", size = 7644652 },
+    { url = "https://files.pythonhosted.org/packages/41/f1/6f2427a26fc683e00d985bc391bdd76d8dd4e92fac33d841127eb8fb2313/pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7", size = 5977787 },
+    { url = "https://files.pythonhosted.org/packages/e4/c9/06dd4a38974e24f932ff5f98ea3c546ce3f8c995d3f0985f8e5ba48bba19/pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024", size = 6645236 },
+    { url = "https://files.pythonhosted.org/packages/40/e7/848f69fb79843b3d91241bad658e9c14f39a32f71a301bcd1d139416d1be/pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809", size = 6086950 },
+    { url = "https://files.pythonhosted.org/packages/0b/1a/7cff92e695a2a29ac1958c2a0fe4c0b2393b60aac13b04a4fe2735cad52d/pillow-11.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6be31e3fc9a621e071bc17bb7de63b85cbe0bfae91bb0363c893cbe67247780d", size = 6723358 },
+    { url = "https://files.pythonhosted.org/packages/26/7d/73699ad77895f69edff76b0f332acc3d497f22f5d75e5360f78cbcaff248/pillow-11.3.0-cp312-cp312-win32.whl", hash = "sha256:7b161756381f0918e05e7cb8a371fff367e807770f8fe92ecb20d905d0e1c149", size = 6275079 },
+    { url = "https://files.pythonhosted.org/packages/8c/ce/e7dfc873bdd9828f3b6e5c2bbb74e47a98ec23cc5c74fc4e54462f0d9204/pillow-11.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a6444696fce635783440b7f7a9fc24b3ad10a9ea3f0ab66c5905be1c19ccf17d", size = 6986324 },
+    { url = "https://files.pythonhosted.org/packages/16/8f/b13447d1bf0b1f7467ce7d86f6e6edf66c0ad7cf44cf5c87a37f9bed9936/pillow-11.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:2aceea54f957dd4448264f9bf40875da0415c83eb85f55069d89c0ed436e3542", size = 2423067 },
+    { url = "https://files.pythonhosted.org/packages/1e/93/0952f2ed8db3a5a4c7a11f91965d6184ebc8cd7cbb7941a260d5f018cd2d/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:1c627742b539bba4309df89171356fcb3cc5a9178355b2727d1b74a6cf155fbd", size = 2128328 },
+    { url = "https://files.pythonhosted.org/packages/4b/e8/100c3d114b1a0bf4042f27e0f87d2f25e857e838034e98ca98fe7b8c0a9c/pillow-11.3.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:30b7c02f3899d10f13d7a48163c8969e4e653f8b43416d23d13d1bbfdc93b9f8", size = 2170652 },
+    { url = "https://files.pythonhosted.org/packages/aa/86/3f758a28a6e381758545f7cdb4942e1cb79abd271bea932998fc0db93cb6/pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f", size = 2227443 },
+    { url = "https://files.pythonhosted.org/packages/01/f4/91d5b3ffa718df2f53b0dc109877993e511f4fd055d7e9508682e8aba092/pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c", size = 5278474 },
+    { url = "https://files.pythonhosted.org/packages/f9/0e/37d7d3eca6c879fbd9dba21268427dffda1ab00d4eb05b32923d4fbe3b12/pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd", size = 4686038 },
+    { url = "https://files.pythonhosted.org/packages/ff/b0/3426e5c7f6565e752d81221af9d3676fdbb4f352317ceafd42899aaf5d8a/pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e", size = 5864407 },
+    { url = "https://files.pythonhosted.org/packages/fc/c1/c6c423134229f2a221ee53f838d4be9d82bab86f7e2f8e75e47b6bf6cd77/pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1", size = 7639094 },
+    { url = "https://files.pythonhosted.org/packages/ba/c9/09e6746630fe6372c67c648ff9deae52a2bc20897d51fa293571977ceb5d/pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805", size = 5973503 },
+    { url = "https://files.pythonhosted.org/packages/d5/1c/a2a29649c0b1983d3ef57ee87a66487fdeb45132df66ab30dd37f7dbe162/pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8", size = 6642574 },
+    { url = "https://files.pythonhosted.org/packages/36/de/d5cc31cc4b055b6c6fd990e3e7f0f8aaf36229a2698501bcb0cdf67c7146/pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2", size = 6084060 },
+    { url = "https://files.pythonhosted.org/packages/d5/ea/502d938cbaeec836ac28a9b730193716f0114c41325db428e6b280513f09/pillow-11.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:45dfc51ac5975b938e9809451c51734124e73b04d0f0ac621649821a63852e7b", size = 6721407 },
+    { url = "https://files.pythonhosted.org/packages/45/9c/9c5e2a73f125f6cbc59cc7087c8f2d649a7ae453f83bd0362ff7c9e2aee2/pillow-11.3.0-cp313-cp313-win32.whl", hash = "sha256:a4d336baed65d50d37b88ca5b60c0fa9d81e3a87d4a7930d3880d1624d5b31f3", size = 6273841 },
+    { url = "https://files.pythonhosted.org/packages/23/85/397c73524e0cd212067e0c969aa245b01d50183439550d24d9f55781b776/pillow-11.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bce5c4fd0921f99d2e858dc4d4d64193407e1b99478bc5cacecba2311abde51", size = 6978450 },
+    { url = "https://files.pythonhosted.org/packages/17/d2/622f4547f69cd173955194b78e4d19ca4935a1b0f03a302d655c9f6aae65/pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580", size = 2423055 },
+    { url = "https://files.pythonhosted.org/packages/dd/80/a8a2ac21dda2e82480852978416cfacd439a4b490a501a288ecf4fe2532d/pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e", size = 5281110 },
+    { url = "https://files.pythonhosted.org/packages/44/d6/b79754ca790f315918732e18f82a8146d33bcd7f4494380457ea89eb883d/pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d", size = 4689547 },
+    { url = "https://files.pythonhosted.org/packages/49/20/716b8717d331150cb00f7fdd78169c01e8e0c219732a78b0e59b6bdb2fd6/pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced", size = 5901554 },
+    { url = "https://files.pythonhosted.org/packages/74/cf/a9f3a2514a65bb071075063a96f0a5cf949c2f2fce683c15ccc83b1c1cab/pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c", size = 7669132 },
+    { url = "https://files.pythonhosted.org/packages/98/3c/da78805cbdbee9cb43efe8261dd7cc0b4b93f2ac79b676c03159e9db2187/pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8", size = 6005001 },
+    { url = "https://files.pythonhosted.org/packages/6c/fa/ce044b91faecf30e635321351bba32bab5a7e034c60187fe9698191aef4f/pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59", size = 6668814 },
+    { url = "https://files.pythonhosted.org/packages/7b/51/90f9291406d09bf93686434f9183aba27b831c10c87746ff49f127ee80cb/pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe", size = 6113124 },
+    { url = "https://files.pythonhosted.org/packages/cd/5a/6fec59b1dfb619234f7636d4157d11fb4e196caeee220232a8d2ec48488d/pillow-11.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:83e1b0161c9d148125083a35c1c5a89db5b7054834fd4387499e06552035236c", size = 6747186 },
+    { url = "https://files.pythonhosted.org/packages/49/6b/00187a044f98255225f172de653941e61da37104a9ea60e4f6887717e2b5/pillow-11.3.0-cp313-cp313t-win32.whl", hash = "sha256:2a3117c06b8fb646639dce83694f2f9eac405472713fcb1ae887469c0d4f6788", size = 6277546 },
+    { url = "https://files.pythonhosted.org/packages/e8/5c/6caaba7e261c0d75bab23be79f1d06b5ad2a2ae49f028ccec801b0e853d6/pillow-11.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:857844335c95bea93fb39e0fa2726b4d9d758850b34075a7e3ff4f4fa3aa3b31", size = 6985102 },
+    { url = "https://files.pythonhosted.org/packages/f3/7e/b623008460c09a0cb38263c93b828c666493caee2eb34ff67f778b87e58c/pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e", size = 2424803 },
+    { url = "https://files.pythonhosted.org/packages/73/f4/04905af42837292ed86cb1b1dabe03dce1edc008ef14c473c5c7e1443c5d/pillow-11.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d9da3df5f9ea2a89b81bb6087177fb1f4d1c7146d583a3fe5c672c0d94e55e12", size = 5278520 },
+    { url = "https://files.pythonhosted.org/packages/41/b0/33d79e377a336247df6348a54e6d2a2b85d644ca202555e3faa0cf811ecc/pillow-11.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b275ff9b04df7b640c59ec5a3cb113eefd3795a8df80bac69646ef699c6981a", size = 4686116 },
+    { url = "https://files.pythonhosted.org/packages/49/2d/ed8bc0ab219ae8768f529597d9509d184fe8a6c4741a6864fea334d25f3f/pillow-11.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0743841cabd3dba6a83f38a92672cccbd69af56e3e91777b0ee7f4dba4385632", size = 5864597 },
+    { url = "https://files.pythonhosted.org/packages/b5/3d/b932bb4225c80b58dfadaca9d42d08d0b7064d2d1791b6a237f87f661834/pillow-11.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2465a69cf967b8b49ee1b96d76718cd98c4e925414ead59fdf75cf0fd07df673", size = 7638246 },
+    { url = "https://files.pythonhosted.org/packages/09/b5/0487044b7c096f1b48f0d7ad416472c02e0e4bf6919541b111efd3cae690/pillow-11.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41742638139424703b4d01665b807c6468e23e699e8e90cffefe291c5832b027", size = 5973336 },
+    { url = "https://files.pythonhosted.org/packages/a8/2d/524f9318f6cbfcc79fbc004801ea6b607ec3f843977652fdee4857a7568b/pillow-11.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93efb0b4de7e340d99057415c749175e24c8864302369e05914682ba642e5d77", size = 6642699 },
+    { url = "https://files.pythonhosted.org/packages/6f/d2/a9a4f280c6aefedce1e8f615baaa5474e0701d86dd6f1dede66726462bbd/pillow-11.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7966e38dcd0fa11ca390aed7c6f20454443581d758242023cf36fcb319b1a874", size = 6083789 },
+    { url = "https://files.pythonhosted.org/packages/fe/54/86b0cd9dbb683a9d5e960b66c7379e821a19be4ac5810e2e5a715c09a0c0/pillow-11.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:98a9afa7b9007c67ed84c57c9e0ad86a6000da96eaa638e4f8abe5b65ff83f0a", size = 6720386 },
+    { url = "https://files.pythonhosted.org/packages/e7/95/88efcaf384c3588e24259c4203b909cbe3e3c2d887af9e938c2022c9dd48/pillow-11.3.0-cp314-cp314-win32.whl", hash = "sha256:02a723e6bf909e7cea0dac1b0e0310be9d7650cd66222a5f1c571455c0a45214", size = 6370911 },
+    { url = "https://files.pythonhosted.org/packages/2e/cc/934e5820850ec5eb107e7b1a72dd278140731c669f396110ebc326f2a503/pillow-11.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:a418486160228f64dd9e9efcd132679b7a02a5f22c982c78b6fc7dab3fefb635", size = 7117383 },
+    { url = "https://files.pythonhosted.org/packages/d6/e9/9c0a616a71da2a5d163aa37405e8aced9a906d574b4a214bede134e731bc/pillow-11.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:155658efb5e044669c08896c0c44231c5e9abcaadbc5cd3648df2f7c0b96b9a6", size = 2511385 },
+    { url = "https://files.pythonhosted.org/packages/1a/33/c88376898aff369658b225262cd4f2659b13e8178e7534df9e6e1fa289f6/pillow-11.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:59a03cdf019efbfeeed910bf79c7c93255c3d54bc45898ac2a4140071b02b4ae", size = 5281129 },
+    { url = "https://files.pythonhosted.org/packages/1f/70/d376247fb36f1844b42910911c83a02d5544ebd2a8bad9efcc0f707ea774/pillow-11.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f8a5827f84d973d8636e9dc5764af4f0cf2318d26744b3d902931701b0d46653", size = 4689580 },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/537e930496149fbac69efd2fc4329035bbe2e5475b4165439e3be9cb183b/pillow-11.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee92f2fd10f4adc4b43d07ec5e779932b4eb3dbfbc34790ada5a6669bc095aa6", size = 5902860 },
+    { url = "https://files.pythonhosted.org/packages/bd/57/80f53264954dcefeebcf9dae6e3eb1daea1b488f0be8b8fef12f79a3eb10/pillow-11.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96d333dcf42d01f47b37e0979b6bd73ec91eae18614864622d9b87bbd5bbf36", size = 7670694 },
+    { url = "https://files.pythonhosted.org/packages/70/ff/4727d3b71a8578b4587d9c276e90efad2d6fe0335fd76742a6da08132e8c/pillow-11.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c96f993ab8c98460cd0c001447bff6194403e8b1d7e149ade5f00594918128b", size = 6005888 },
+    { url = "https://files.pythonhosted.org/packages/05/ae/716592277934f85d3be51d7256f3636672d7b1abfafdc42cf3f8cbd4b4c8/pillow-11.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41342b64afeba938edb034d122b2dda5db2139b9a4af999729ba8818e0056477", size = 6670330 },
+    { url = "https://files.pythonhosted.org/packages/e7/bb/7fe6cddcc8827b01b1a9766f5fdeb7418680744f9082035bdbabecf1d57f/pillow-11.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:068d9c39a2d1b358eb9f245ce7ab1b5c3246c7c8c7d9ba58cfa5b43146c06e50", size = 6114089 },
+    { url = "https://files.pythonhosted.org/packages/8b/f5/06bfaa444c8e80f1a8e4bff98da9c83b37b5be3b1deaa43d27a0db37ef84/pillow-11.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a1bc6ba083b145187f648b667e05a2534ecc4b9f2784c2cbe3089e44868f2b9b", size = 6748206 },
+    { url = "https://files.pythonhosted.org/packages/f0/77/bc6f92a3e8e6e46c0ca78abfffec0037845800ea38c73483760362804c41/pillow-11.3.0-cp314-cp314t-win32.whl", hash = "sha256:118ca10c0d60b06d006be10a501fd6bbdfef559251ed31b794668ed569c87e12", size = 6377370 },
+    { url = "https://files.pythonhosted.org/packages/4a/82/3a721f7d69dca802befb8af08b7c79ebcab461007ce1c18bd91a5d5896f9/pillow-11.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8924748b688aa210d79883357d102cd64690e56b923a186f35a82cbc10f997db", size = 7121500 },
+    { url = "https://files.pythonhosted.org/packages/89/c7/5572fa4a3f45740eaab6ae86fcdf7195b55beac1371ac8c619d880cfe948/pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa", size = 2512835 },
+    { url = "https://files.pythonhosted.org/packages/6f/8b/209bd6b62ce8367f47e68a218bffac88888fdf2c9fcf1ecadc6c3ec1ebc7/pillow-11.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3cee80663f29e3843b68199b9d6f4f54bd1d4a6b59bdd91bceefc51238bcb967", size = 5270556 },
+    { url = "https://files.pythonhosted.org/packages/2e/e6/231a0b76070c2cfd9e260a7a5b504fb72da0a95279410fa7afd99d9751d6/pillow-11.3.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b5f56c3f344f2ccaf0dd875d3e180f631dc60a51b314295a3e681fe8cf851fbe", size = 4654625 },
+    { url = "https://files.pythonhosted.org/packages/13/f4/10cf94fda33cb12765f2397fc285fa6d8eb9c29de7f3185165b702fc7386/pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e67d793d180c9df62f1f40aee3accca4829d3794c95098887edc18af4b8b780c", size = 4874207 },
+    { url = "https://files.pythonhosted.org/packages/72/c9/583821097dc691880c92892e8e2d41fe0a5a3d6021f4963371d2f6d57250/pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d000f46e2917c705e9fb93a3606ee4a819d1e3aa7a9b442f6444f07e77cf5e25", size = 6583939 },
+    { url = "https://files.pythonhosted.org/packages/3b/8e/5c9d410f9217b12320efc7c413e72693f48468979a013ad17fd690397b9a/pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:527b37216b6ac3a12d7838dc3bd75208ec57c1c6d11ef01902266a5a0c14fc27", size = 4957166 },
+    { url = "https://files.pythonhosted.org/packages/62/bb/78347dbe13219991877ffb3a91bf09da8317fbfcd4b5f9140aeae020ad71/pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be5463ac478b623b9dd3937afd7fb7ab3d79dd290a28e2b6df292dc75063eb8a", size = 5581482 },
+    { url = "https://files.pythonhosted.org/packages/d9/28/1000353d5e61498aaeaaf7f1e4b49ddb05f2c6575f9d4f9f914a3538b6e1/pillow-11.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8dc70ca24c110503e16918a658b869019126ecfe03109b754c402daff12b3d9f", size = 6984596 },
+    { url = "https://files.pythonhosted.org/packages/9e/e3/6fa84033758276fb31da12e5fb66ad747ae83b93c67af17f8c6ff4cc8f34/pillow-11.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7c8ec7a017ad1bd562f93dbd8505763e688d388cde6e4a010ae1486916e713e6", size = 5270566 },
+    { url = "https://files.pythonhosted.org/packages/5b/ee/e8d2e1ab4892970b561e1ba96cbd59c0d28cf66737fc44abb2aec3795a4e/pillow-11.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9ab6ae226de48019caa8074894544af5b53a117ccb9d3b3dcb2871464c829438", size = 4654618 },
+    { url = "https://files.pythonhosted.org/packages/f2/6d/17f80f4e1f0761f02160fc433abd4109fa1548dcfdca46cfdadaf9efa565/pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe27fb049cdcca11f11a7bfda64043c37b30e6b91f10cb5bab275806c32f6ab3", size = 4874248 },
+    { url = "https://files.pythonhosted.org/packages/de/5f/c22340acd61cef960130585bbe2120e2fd8434c214802f07e8c03596b17e/pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:465b9e8844e3c3519a983d58b80be3f668e2a7a5db97f2784e7079fbc9f9822c", size = 6583963 },
+    { url = "https://files.pythonhosted.org/packages/31/5e/03966aedfbfcbb4d5f8aa042452d3361f325b963ebbadddac05b122e47dd/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361", size = 4957170 },
+    { url = "https://files.pythonhosted.org/packages/cc/2d/e082982aacc927fc2cab48e1e731bdb1643a1406acace8bed0900a61464e/pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7", size = 5581505 },
+    { url = "https://files.pythonhosted.org/packages/34/e7/ae39f538fd6844e982063c3a5e4598b8ced43b9633baa3a85ef33af8c05c/pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8", size = 6984598 },
 ]
 
 [[package]]
@@ -2480,6 +2592,15 @@ wheels = [
 ]
 
 [[package]]
+name = "svgwrite"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/c1/263d4e93b543390d86d8eb4fc23d9ce8a8d6efd146f9427364109004fa9b/svgwrite-1.4.3.zip", hash = "sha256:a8fbdfd4443302a6619a7f76bc937fc683daf2628d9b737c891ec08b8ce524c3", size = 189516 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/15/640e399579024a6875918839454025bb1d5f850bb70d96a11eabb644d11c/svgwrite-1.4.3-py3-none-any.whl", hash = "sha256:bb6b2b5450f1edbfa597d924f9ac2dd099e625562e492021d7dd614f65f8a22d", size = 67122 },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2526,6 +2647,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383 },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257 },
 ]
+
+[[package]]
+name = "tree"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "pillow" },
+    { name = "setuptools" },
+    { name = "svgwrite" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/3f/63cbed2909786f0e5ac30a4ae5791ad597c6b5fec7167e161c55bba511ce/Tree-0.2.4.tar.gz", hash = "sha256:f84d8ec9bf50dd69f551da78925a23d110864e7706551f590cdade27646f7883", size = 6489 }
 
 [[package]]
 name = "types-setuptools"


### PR DESCRIPTION
Adding two forms of Voxaboxen with the original datasets from the paper:

1. `Voxaboxen`: very simple, returns full `audio` and `selection_table` as dataframe.
2. `VoxaboxenEvents`: follows the process in `DetectionDataset` in https://github.com/earthspecies/voxaboxen/blob/main/voxaboxen/data/data.py with some performance improvements.

🚨This dataset has a *lot* more parameters than other datasets, importantly `scale_factor` which changes the length of audio returned based on the rate at which an embedding model produces sound event annotation output.