### PR TITLE
support partial loading of audio from disk

### DIFF
--- a/esp_data/datasets/animalspeak.py
+++ b/esp_data/datasets/animalspeak.py
@@ -6,9 +6,10 @@ from typing import Any, Dict, Iterator, Optional
 import librosa
 import numpy as np
 import pandas as pd
+from numpy.random import default_rng
 
 from esp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
-from esp_data.io import AnyPathT, anypath, audio_stereo_to_mono, read_audio
+from esp_data.io import AnyPathT, anypath, audio_stereo_to_mono, get_audio_info, read_audio
 
 
 @register_dataset
@@ -30,12 +31,22 @@ class AnimalSpeak(Dataset):
     Examples
     -------
     >>> from esp_data.datasets import AnimalSpeak
+    >>> # Random window with efficient loading
     >>> dataset = AnimalSpeak(
     ...     split="validation",
+    ...     max_duration=5.0,
+    ...     random_window=True,
+    ...     seed=42,
     ...     output_take_and_give={"species_common": "comm"}
     ... )
     >>> print(dataset.info.name)
     animalspeak
+    >>> # Fixed window from start
+    >>> dataset_fixed = AnimalSpeak(
+    ...     split="train",
+    ...     max_duration=10.0,
+    ...     random_window=False
+    ... )
     """
 
     info = DatasetInfo(
@@ -57,6 +68,9 @@ class AnimalSpeak(Dataset):
         output_take_and_give: dict[str, str] = None,
         sample_rate: Optional[int] = None,
         data_root: Optional[str | AnyPathT] = None,
+        max_duration: float = 10.0,
+        random_window: bool = True,
+        seed: Optional[int] = None,
     ) -> None:
         """Initialize the AnimalSpeak dataset.
 
@@ -73,6 +87,15 @@ class AnimalSpeak(Dataset):
             The root directory for the dataset. This is optionally appended to the
             path item of a sample in the dataset.
             If None, the default is the parent directory of the split path.
+        max_duration : float, optional
+            Maximum duration in seconds to load from each audio file.
+            Defaults to 10.0 seconds.
+        random_window : bool, optional
+            If True, randomly select start time within the audio file.
+            If False, always load from the beginning. Defaults to True.
+        seed : int, optional
+            Random seed for reproducible random window selection.
+            Only used when random_window=True. Defaults to None.
         """
         super().__init__(output_take_and_give)  # Initialize the parent Dataset class
         self.split = split
@@ -80,6 +103,10 @@ class AnimalSpeak(Dataset):
         self._load()  # Load the dataset (fills self._data)
         self.sample_rate = sample_rate
         self.data_root = data_root
+        self.max_duration = max_duration
+        self.random_window = random_window
+        self.seed = seed
+        self._rng = default_rng(seed) if random_window else None
         if self.data_root is None:
             # we assume that parent dir of the split path is the data root
             self.data_root = anypath(self.info.split_paths[self.split]).parent
@@ -148,6 +175,9 @@ class AnimalSpeak(Dataset):
             output_take_and_give=cfg.get("output_take_and_give", None),
             data_root=cfg.get("data_root"),
             sample_rate=cfg["sample_rate"],
+            max_duration=cfg.get("max_duration", 10.0),
+            random_window=cfg.get("random_window", True),
+            seed=cfg.get("seed", None),
         )
 
         if dataset_config.transformations:
@@ -201,7 +231,26 @@ class AnimalSpeak(Dataset):
         else:
             audio_path = anypath(row["local_path"])
 
-        audio, sr = read_audio(audio_path)
+        # Read audio with time limiting for efficiency
+        if self.random_window:
+            # Get audio info to determine available duration
+            audio_info = get_audio_info(audio_path)
+            total_duration = audio_info["duration"]
+
+            # Calculate random start time if file is longer than max_duration
+            if total_duration > self.max_duration:
+                max_start_time = total_duration - self.max_duration
+                start_time = self._rng.uniform(0, max_start_time)
+            else:
+                start_time = 0.0
+
+            end_time = min(start_time + self.max_duration, total_duration)
+        else:
+            # Always load from beginning
+            start_time = 0.0
+            end_time = self.max_duration
+
+        audio, sr = read_audio(audio_path, start_time=start_time, end_time=end_time)
         audio = audio.astype(np.float32)
         audio = audio_stereo_to_mono(audio, mono_method="average")
 

--- a/esp_data/datasets/animalspeak.py
+++ b/esp_data/datasets/animalspeak.py
@@ -232,11 +232,11 @@ class AnimalSpeak(Dataset):
             audio_path = anypath(row["local_path"])
 
         # Read audio with time limiting for efficiency
-        if self.random_window:
-            # Get audio info to determine available duration
-            audio_info = get_audio_info(audio_path)
-            total_duration = audio_info["duration"]
+        # Get audio info to determine available duration for both cases
+        audio_info = get_audio_info(audio_path)
+        total_duration = audio_info["duration"]
 
+        if self.random_window:
             # Calculate random start time if file is longer than max_duration
             if total_duration > self.max_duration:
                 max_start_time = total_duration - self.max_duration
@@ -246,9 +246,9 @@ class AnimalSpeak(Dataset):
 
             end_time = min(start_time + self.max_duration, total_duration)
         else:
-            # Always load from beginning
+            # Always load from beginning, respecting file bounds
             start_time = 0.0
-            end_time = self.max_duration
+            end_time = min(self.max_duration, total_duration)
 
         audio, sr = read_audio(audio_path, start_time=start_time, end_time=end_time)
         audio = audio.astype(np.float32)

--- a/esp_data/datasets/beans.py
+++ b/esp_data/datasets/beans.py
@@ -33,8 +33,10 @@ class Beans(Dataset):
     Examples
     -------
     >>> from esp_data.datasets import Beans
+    >>> # Efficient loading with time limiting
     >>> dataset = Beans(
     ...     split="validation",
+    ...     max_duration=8.0,
     ...     output_take_and_give={"species_scientific": "species"},
     ...     sample_rate=16000,
     ...     data_root="gs://esp-ml-datasets/beans/v0.1.0/raw/"
@@ -110,6 +112,7 @@ class Beans(Dataset):
         output_take_and_give: dict[str, str] = None,
         sample_rate: Optional[int] = None,
         data_root: Optional[str | AnyPathT] = None,
+        max_duration: float = 10.0,
     ) -> None:
         """Initialize the BEANS dataset.
 
@@ -126,6 +129,9 @@ class Beans(Dataset):
             The root directory for the dataset. This is optionally appended to the
             path item of a sample in the dataset.
             If None, the default is the parent directory of the split path.
+        max_duration : float, optional
+            Maximum duration in seconds to load from each audio file.
+            Always loads from the start of the file. Defaults to 10.0 seconds.
         """
         super().__init__(output_take_and_give)  # Initialize the parent Dataset class
         self.split = split
@@ -133,6 +139,7 @@ class Beans(Dataset):
         self._load()  # Load the dataset (fills self._data)
         self.sample_rate = sample_rate
         self.data_root = data_root
+        self.max_duration = max_duration
         if self.data_root is None:
             # we assume that parent dir of the split path is the data root
             self.data_root = anypath(self.info.split_paths[self.split]).parent
@@ -205,6 +212,7 @@ class Beans(Dataset):
             output_take_and_give=cfg.get("output_take_and_give", None),
             data_root=cfg.get("data_root"),
             sample_rate=cfg["sample_rate"],
+            max_duration=cfg.get("max_duration", 10.0),
         )
 
         if dataset_config.transformations:
@@ -257,8 +265,7 @@ class Beans(Dataset):
         else:
             audio_path = anypath(row["local_path"])
 
-        # Read the audio clip
-        audio, sr = read_audio(audio_path)
+        audio, sr = read_audio(audio_path, start_time=0.0, end_time=self.max_duration)
         audio = audio.astype(np.float32)
         # Stereo to mono if necessary.
         audio = audio_stereo_to_mono(audio, mono_method="average")

--- a/esp_data/datasets/beans.py
+++ b/esp_data/datasets/beans.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 
 from esp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
-from esp_data.io import AnyPathT, anypath, audio_stereo_to_mono, read_audio
+from esp_data.io import AnyPathT, anypath, audio_stereo_to_mono, get_audio_info, read_audio
 
 
 @register_dataset
@@ -265,7 +265,12 @@ class Beans(Dataset):
         else:
             audio_path = anypath(row["local_path"])
 
-        audio, sr = read_audio(audio_path, start_time=0.0, end_time=self.max_duration)
+        # Get audio info to respect file bounds
+        audio_info = get_audio_info(audio_path)
+        total_duration = audio_info["duration"]
+        end_time = min(self.max_duration, total_duration)
+
+        audio, sr = read_audio(audio_path, start_time=0.0, end_time=end_time)
         audio = audio.astype(np.float32)
         # Stereo to mono if necessary.
         audio = audio_stereo_to_mono(audio, mono_method="average")

--- a/tests/test_animal_speak.py
+++ b/tests/test_animal_speak.py
@@ -257,3 +257,128 @@ def test_output_take_and_give(dataset_with_output_mapping: Dataset) -> None:
     # Verify the mapping and values
     assert sample["species"] == original_row["canonical_name"]
     assert sample["location"] == original_row["country"]
+
+
+def test_max_duration_parameter() -> None:
+    """Test if max_duration parameter works correctly."""
+    # Test with custom max_duration
+    dataset = AnimalSpeak(split="validation", max_duration=5.0, data_root="gs://")
+    assert dataset.max_duration == 5.0
+
+    # Test default max_duration
+    dataset_default = AnimalSpeak(split="validation", data_root="gs://")
+    assert dataset_default.max_duration == 10.0
+
+
+def test_random_window_parameter() -> None:
+    """Test if random_window parameter works correctly."""
+    # Test with random_window=True (default)
+    dataset_random = AnimalSpeak(split="validation", random_window=True, data_root="gs://")
+    assert dataset_random.random_window is True
+    assert dataset_random._rng is not None  # Should have RNG when random_window=True
+
+    # Test with random_window=False
+    dataset_fixed = AnimalSpeak(split="validation", random_window=False, data_root="gs://")
+    assert dataset_fixed.random_window is False
+    assert dataset_fixed._rng is None  # Should not have RNG when random_window=False
+
+
+def test_seed_parameter() -> None:
+    """Test if seed parameter works correctly for reproducibility."""
+    # Test with specific seed
+    dataset1 = AnimalSpeak(split="validation", seed=42, data_root="gs://")
+    dataset2 = AnimalSpeak(split="validation", seed=42, data_root="gs://")
+
+    assert dataset1.seed == 42
+    assert dataset2.seed == 42
+
+    # Both should have RNG with same state initially
+    assert dataset1._rng is not None
+    assert dataset2._rng is not None
+
+
+def test_max_duration_audio_limiting() -> None:
+    """Test if audio is actually limited by max_duration."""
+    # Use a short max_duration to test limiting
+    max_duration = 2.0
+    dataset = AnimalSpeak(
+        split="validation",
+        max_duration=max_duration,
+        sample_rate=16000,
+        random_window=False,  # Use fixed window for consistent testing
+        data_root="gs://"
+    )
+
+    # Get a sample and check audio duration
+    sample = dataset[0]
+    audio = sample["audio"]
+
+    # Calculate actual duration (assuming 16kHz sample rate)
+    actual_duration = len(audio) / 16000
+
+    # Audio should not exceed max_duration (with small tolerance for rounding)
+    assert actual_duration <= max_duration + 0.1, (
+        f"Audio duration {actual_duration:.3f}s exceeds max_duration {max_duration}s"
+    )
+
+
+def test_random_window_reproducibility() -> None:
+    """Test if random windows are reproducible with same seed."""
+    max_duration = 3.0
+    seed = 123
+
+    # Create two datasets with same seed
+    dataset1 = AnimalSpeak(
+        split="validation",
+        max_duration=max_duration,
+        random_window=True,
+        seed=seed,
+        sample_rate=16000,
+        data_root="gs://"
+    )
+
+    dataset2 = AnimalSpeak(
+        split="validation",
+        max_duration=max_duration,
+        random_window=True,
+        seed=seed,
+        sample_rate=16000,
+        data_root="gs://"
+    )
+
+    # Get same sample from both datasets
+    sample1 = dataset1[0]
+    sample2 = dataset2[0]
+
+    # Audio should be identical (same random window selected)
+    import numpy as np
+    assert np.array_equal(sample1["audio"], sample2["audio"]), (
+        "Audio samples should be identical with same seed"
+    )
+
+
+def test_from_config_with_new_parameters() -> None:
+    """Test if new parameters work correctly when loaded from config."""
+    dataset_config = DatasetConfig(
+        dataset_name="animalspeak",
+        split="validation",
+        max_duration=4.0,
+        random_window=False,
+        seed=999,
+        sample_rate=16000,
+        data_root="gs://",
+    )
+
+    dataset, _ = AnimalSpeak.from_config(dataset_config)
+
+    # Check all parameters are set correctly
+    assert dataset.max_duration == 4.0
+    assert dataset.random_window is False
+    assert dataset.seed == 999
+    assert dataset._rng is None  # Should be None when random_window=False
+
+    # Test that audio respects the duration limit
+    sample = dataset[0]
+    audio = sample["audio"]
+    actual_duration = len(audio) / 16000
+    assert actual_duration <= 4.1  # Small tolerance for rounding

--- a/tests/test_animal_speak.py
+++ b/tests/test_animal_speak.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from esp_data.datasets import AnimalSpeak
 from esp_data import Dataset, DatasetConfig
+from esp_data.datasets import AnimalSpeak
 from esp_data.io import anypath
 
 
@@ -214,7 +214,9 @@ def test_transformations(dataset_with_transforms: Dataset) -> None:
     assert "Watkins" not in sources
 
 
-def test_transformations_from_config(dataset_with_transforms_from_config: tuple[Dataset, dict]) -> None:
+def test_transformations_from_config(
+    dataset_with_transforms_from_config: tuple[Dataset, dict]
+) -> None:
     """Test if transformations from config are applied correctly.
 
     This test verifies that:
@@ -382,3 +384,50 @@ def test_from_config_with_new_parameters() -> None:
     audio = sample["audio"]
     actual_duration = len(audio) / 16000
     assert actual_duration <= 4.1  # Small tolerance for rounding
+
+
+def test_short_audio_file_handling() -> None:
+    """Test handling of audio files shorter than max_duration."""
+    # Use a large max_duration to test short file handling
+    large_max_duration = 300.0  # 5 minutes - should be longer than most files
+
+    # Test with fixed window (the problematic case)
+    dataset_fixed = AnimalSpeak(
+        split="validation",
+        max_duration=large_max_duration,
+        random_window=False,
+        sample_rate=16000,
+        data_root="gs://"
+    )
+
+    # Get a sample - should not crash even with large max_duration
+    sample = dataset_fixed[0]
+    audio = sample["audio"]
+    actual_duration = len(audio) / 16000
+
+    # Audio should be the full file duration, not the max_duration
+    # (since file is likely shorter than 300 seconds)
+    assert actual_duration < large_max_duration, (
+        f"Audio duration {actual_duration:.3f}s should be less than "
+        f"max_duration {large_max_duration}s"
+    )
+
+    # Test with random window too
+    dataset_random = AnimalSpeak(
+        split="validation",
+        max_duration=large_max_duration,
+        random_window=True,
+        seed=42,
+        sample_rate=16000,
+        data_root="gs://"
+    )
+
+    sample_random = dataset_random[0]
+    audio_random = sample_random["audio"]
+    actual_duration_random = len(audio_random) / 16000
+
+    # Should also handle short files correctly
+    assert actual_duration_random < large_max_duration, (
+        f"Random window audio duration {actual_duration_random:.3f}s should be less than "
+        f"max_duration {large_max_duration}s"
+    )

--- a/tests/test_beans.py
+++ b/tests/test_beans.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from esp_data.datasets import Beans
 from esp_data import Dataset, DatasetConfig
+from esp_data.datasets import Beans
 from esp_data.io import anypath
 
 
@@ -243,3 +243,37 @@ def test_max_duration_from_config() -> None:
     audio = sample["audio"]
     actual_duration = len(audio) / 16000
     assert actual_duration <= 3.1  # Small tolerance for rounding
+
+
+def test_short_audio_file_handling() -> None:
+    """Test handling of audio files shorter than max_duration."""
+    # Use a large max_duration to test short file handling
+    large_max_duration = 300.0  # 5 minutes - should be longer than most files
+
+    dataset = Beans(
+        split="validation",
+        max_duration=large_max_duration,
+        sample_rate=16000,
+    )
+
+    # Get a sample - should not crash even with large max_duration
+    sample = dataset[0]
+    audio = sample["audio"]
+    actual_duration = len(audio) / 16000
+
+    # Audio should be the full file duration, not the max_duration
+    # (since file is likely shorter than 300 seconds)
+    assert actual_duration < large_max_duration, (
+        f"Audio duration {actual_duration:.3f}s should be less than "
+        f"max_duration {large_max_duration}s"
+    )
+
+    # Test that we can successfully load multiple samples without issues
+    sample2 = dataset[1]
+    audio2 = sample2["audio"]
+    actual_duration2 = len(audio2) / 16000
+
+    assert actual_duration2 < large_max_duration, (
+        f"Second audio duration {actual_duration2:.3f}s should be less than "
+        f"max_duration {large_max_duration}s"
+    )

--- a/tests/test_beans.py
+++ b/tests/test_beans.py
@@ -194,3 +194,52 @@ def test_output_take_and_give(dataset_with_output_mapping: Dataset) -> None:
     # Verify the mapping and values
     assert sample["dataset_name"] == original_row["source_dataset"]
     assert sample["answer"] == original_row["label"]
+
+
+def test_max_duration_parameter() -> None:
+    """Test if max_duration parameter works correctly."""
+    # Test with custom max_duration
+    dataset = Beans(split="validation", max_duration=5.0)
+    assert dataset.max_duration == 5.0
+
+    # Test default max_duration
+    dataset_default = Beans(split="validation")
+    assert dataset_default.max_duration == 10.0
+
+
+def test_max_duration_audio_limiting() -> None:
+    """Test if audio is actually limited by max_duration."""
+    # Use a short max_duration to test limiting
+    max_duration = 2.0
+    dataset = Beans(split="validation", max_duration=max_duration, sample_rate=16000)
+
+    # Get a sample and check audio duration
+    sample = dataset[0]
+    audio = sample["audio"]
+
+    # Calculate actual duration (assuming 16kHz sample rate)
+    actual_duration = len(audio) / 16000
+
+    # Audio should not exceed max_duration (with small tolerance for rounding)
+    assert actual_duration <= max_duration + 0.1, (
+        f"Audio duration {actual_duration:.3f}s exceeds max_duration {max_duration}s"
+    )
+
+
+def test_max_duration_from_config() -> None:
+    """Test if max_duration works correctly when loaded from config."""
+    dataset_config = DatasetConfig(
+        dataset_name="beans",
+        split="validation",
+        max_duration=3.0,
+        sample_rate=16000,
+    )
+
+    dataset, _ = Beans.from_config(dataset_config)
+    assert dataset.max_duration == 3.0
+
+    # Test that audio respects the duration limit
+    sample = dataset[0]
+    audio = sample["audio"]
+    actual_duration = len(audio) / 16000
+    assert actual_duration <= 3.1  # Small tolerance for rounding


### PR DESCRIPTION
For BEANs and AnimalSpeak, support only loading a segment from disk to reduce IO.

For BEANs we load from the first N seconds by default: all models evaluated on BEANs must truncate to less  than ten seconds anyway, and consider only the start.

For AnimalSpeak we default to a random ten-seconds, which is also used by all models trained on it so far.