### PR TITLE
Fix for issue #98, adding esp_raincoast dataset

### DIFF
--- a/esp_data/__init__.py
+++ b/esp_data/__init__.py
@@ -17,6 +17,7 @@ from .datasets import (
     BengaleseFinchCalls,
     BirdSet,
     ChiffchaffId,
+    ESPRaincoast,
     GiantOtters,
     InsectSet459,
     LittleOwlId,
@@ -52,4 +53,5 @@ __all__ = [
     "MacaquesCooCalls",
     "Voxaboxen",
     "VoxaboxenEvents",
+    "ESPRaincoast",
 ]

--- a/esp_data/datasets/__init__.py
+++ b/esp_data/datasets/__init__.py
@@ -5,6 +5,7 @@ from .beans import Beans
 from .bengalese_finch_calls import BengaleseFinchCalls
 from .birdset import BirdSet
 from .chiffchaff_id import ChiffchaffId
+from .esp_raincoast import ESPRaincoast
 from .giant_otters import GiantOtters
 from .insectset_459 import InsectSet459
 from .littleowl_id import LittleOwlId
@@ -30,4 +31,5 @@ __all__ = [
     "MacaquesCooCalls",
     "Voxaboxen",
     "VoxaboxenEvents",
+    "ESPRaincoast",
 ]

--- a/esp_data/datasets/esp_raincoast.py
+++ b/esp_data/datasets/esp_raincoast.py
@@ -1,0 +1,267 @@
+"""ESP Raincoast.org dataset"""
+
+from typing import Any, Dict, Iterator
+
+import librosa
+import numpy as np
+import pandas as pd
+
+from esp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
+from esp_data.io import (
+    AnyPathT,
+    anypath,
+    audio_stereo_to_mono,
+    filesystem_from_path,
+    read_audio,
+)
+
+
+@register_dataset
+class ESPRaincoast(Dataset):
+    """ESP Raincoast.org dataset
+    Recorded by Dylan Smyth, Valeria Vergara lab.
+
+    """
+
+    info = DatasetInfo(
+        name="esp_raincoast",
+        owner="emmanuel; gagan; dylansmyth",
+        split_paths={
+            "full": "gs://esp-raincoast/full_selection_table.csv",
+        },
+        version="0.1.0",
+        description="Orca vocal repertoire dataset",
+        sources=["esp-raincoast"],
+        license="private",
+    )
+
+    def __init__(
+        self,
+        split: str = "full",
+        output_take_and_give: dict[str, str] = None,
+        sample_rate: int | None = None,
+        load_audio_segments: bool = True,
+        mono_method: str | None = None,
+        data_root: str | AnyPathT | None = "gs://esp-raincoast",
+    ) -> None:
+        """Initialize the GiantOtters dataset.
+
+        Parameters
+        ----------
+        split : str
+            The split to load. One of info.split_paths keys.
+        output_take_and_give : dict[str, str]
+            A dictionary mapping the original column names to the new column names.
+            It acts as a filter as well.
+        sample_rate : int
+            The sample rate to which audio files should be resampled.
+        load_audio_segments : bool
+            If True, the audio files will be spliced between the 'Begin time(s)'
+            and 'End time (s)' columns in the dataset.
+            If False, the entire audio file will be loaded.
+        mono_method : str | None
+            Method to convert stereo audio to mono. If None, no conversion is done.
+            Options are ["keep_first", "average"]
+        data_root : str | AnyPathT, optional
+            The root directory for the dataset. This is optionally appended to the
+            path item of a sample in the dataset.
+            If None, the default is the parent directory of the split path.
+        """
+        super().__init__(output_take_and_give)  # Initialize the parent Dataset class
+        self.split = split
+        self.sample_rate = sample_rate
+        self.data_root = data_root
+        self.load_audio_segments = load_audio_segments
+        self.mono_method = mono_method
+        if self.data_root is None:
+            # we assume that parent dir of the split path is the data root
+            self.data_root = anypath(self.info.split_paths[self.split]).parent
+
+        self._data: pd.DataFrame = None
+        self._load()  # Load the dataset (fills self._data)
+
+    @property
+    def columns(self) -> list[str]:
+        """Return the columns of the dataset."""
+        return list(self._data.columns)
+
+    @property
+    def available_splits(self) -> list[str]:
+        """Return the available splits of the dataset."""
+        return list(self.info.split_paths.keys())
+
+    def _load(self) -> None:
+        """Load the dataset.
+
+        Raises
+        ------
+        LookupError
+            If the split is not valid.
+        """
+        if self.split not in self.info.split_paths:
+            raise LookupError(
+                f"Invalid split: {self.split}.Expected one of {list(self.info.split_paths.keys())}"
+            )
+
+        location = self.info.split_paths[self.split]
+        if anypath(location).suffix == ".jsonl":
+            # For JSONL files, read them directly into a DataFrame
+            self._data = pd.read_json(location, lines=True, orient="records")
+        else:
+            from io import StringIO
+
+            fs = filesystem_from_path(location)
+            csv_text = fs.read_text(str(anypath(location).no_prefix), encoding="utf-8")
+            self._data = pd.read_csv(StringIO(csv_text))
+
+    @classmethod
+    def from_config(cls, dataset_config: DatasetConfig) -> tuple["ESPRaincoast", dict[str, Any]]:
+        """Create a Dataset instance from a configuration dictionary.
+
+        Parameters
+        ----------
+        dataset_config : DatasetConfig
+            Configuration dictionary containing dataset parameters
+
+        Returns
+        -------
+        tuple[Dataset, dict[str, Any]]
+            A tuple containing the dataset instance and metadata.
+            If the dataset_config contains transformations, they will be applied
+            and the metadata will be returned as dict, otherwise empty dict.
+
+        Raises
+        -------
+        LookupError
+            If the specified split is not available in the dataset info.
+        """
+        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+
+        split = cfg.get("split", None)
+        if not split or split not in cls.info.split_paths:
+            raise LookupError(
+                f"Invalid split '{split}'."
+                f"Available splits: {', '.join(cls.info.split_paths.keys())}"
+            )
+
+        ds = cls(
+            split=split,
+            output_take_and_give=cfg.get("output_take_and_give", None),
+            data_root=cfg.get("data_root", None),
+            sample_rate=cfg["sample_rate"],
+            load_audio_segments=cfg.get("load_audio_segments"),
+        )
+
+        if dataset_config.transformations:
+            transform_metadata = ds.apply_transformations(dataset_config.transformations)
+            return ds, transform_metadata
+
+        return ds, {}
+
+    def __len__(self) -> int:
+        """Return the number of samples in the dataset.
+
+        Returns
+        -------
+        int
+            Number of samples in the current split.
+
+        Raises
+        ------
+        RuntimeError
+            If no split has been loaded yet.
+        """
+        if self._data is None:
+            raise RuntimeError("No split has been loaded yet. Call load() first.")
+        return len(self._data)
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        """Get a specific sample from the dataset.
+        Parameters
+        ----------
+        idx : int
+            Index of the sample to get.
+
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary containing the data.
+
+        Raises
+        ------
+        IndexError
+            If the index is out of bounds.
+        """
+        if idx >= len(self._data):
+            raise IndexError(f"Index {idx} out of bounds for dataset of length {len(self._data)}.")
+
+        row = self._data.iloc[idx].to_dict()
+        # Ensure audio path is valid
+        if self.data_root:
+            audio_path = anypath(self.data_root) / row["local_path"]
+        else:
+            audio_path = anypath(row["local_path"])
+
+        # Read the audio clip
+        if self.load_audio_segments:
+            start_time = row.get("Begin Time (s)", 0.0)
+            end_time = row.get("End Time (s)", None)
+            audio, sr = read_audio(audio_path, start_time=start_time, end_time=end_time)
+        else:
+            audio, sr = read_audio(audio_path)
+        audio = audio.astype(np.float32)
+
+        # Stereo to mono if necessary.
+        if self.mono_method is not None:
+            audio = audio_stereo_to_mono(audio, mono_method="average")
+
+        if self.sample_rate is not None and sr != self.sample_rate:
+            audio = librosa.resample(
+                y=audio,
+                orig_sr=sr,
+                target_sr=self.sample_rate,
+                scale=True,
+                res_type="kaiser_best",
+            )
+
+        row["audio"] = audio
+        row["sample_rate"] = self.sample_rate or sr
+
+        if self.output_take_and_give:
+            item = {}
+            for key, value in self.output_take_and_give.items():
+                item[value] = row[key]
+        else:
+            item = row
+
+        return item
+
+    def __iter__(self) -> Iterator[Dict[str, Any]]:
+        """Iterate over samples in the dataset.
+
+        Yields
+        -------
+        Dict[str, Any]
+            Each sample in the dataset.
+        """
+        for idx in range(len(self)):
+            yield self[idx]
+
+    def __str__(self) -> str:
+        """Return a string representation of the dataset.
+
+        Returns
+        -------
+        str
+            A string representation of the dataset including its name, version,
+            and basic statistics if data is loaded.
+        """
+        base_info = f"{self.info.name} (v{self.info.version})"
+
+        return (
+            f"{base_info}\n"
+            f"Description: {self.info.description}\n"
+            f"Sources: {', '.join(self.info.sources)}\n"
+            f"License: {self.info.license}\n"
+            f"Available splits: {', '.join(self.info.split_paths.keys())}"
+        )

--- a/esp_data/datasets/esp_raincoast.py
+++ b/esp_data/datasets/esp_raincoast.py
@@ -129,25 +129,13 @@ class ESPRaincoast(Dataset):
             A tuple containing the dataset instance and metadata.
             If the dataset_config contains transformations, they will be applied
             and the metadata will be returned as dict, otherwise empty dict.
-
-        Raises
-        -------
-        LookupError
-            If the specified split is not available in the dataset info.
         """
         cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
 
-        split = cfg.get("split", None)
-        if not split or split not in cls.info.split_paths:
-            raise LookupError(
-                f"Invalid split '{split}'."
-                f"Available splits: {', '.join(cls.info.split_paths.keys())}"
-            )
-
         ds = cls(
-            split=split,
-            output_take_and_give=cfg.get("output_take_and_give", None),
-            data_root=cfg.get("data_root", None),
+            split=cfg["split"],
+            output_take_and_give=cfg["output_take_and_give"],
+            data_root=cfg["data_root"],
             sample_rate=cfg["sample_rate"],
             load_audio_segments=cfg.get("load_audio_segments"),
         )

--- a/esp_data/transforms/deduplicate.py
+++ b/esp_data/transforms/deduplicate.py
@@ -62,7 +62,9 @@ class Deduplicate:
 
     def __call__(self, df: pd.DataFrame) -> tuple[pd.DataFrame, dict]:
         return df.drop_duplicates(
-            subset=self.subset, keep="first" if self.keep_first else "last"
+            subset=self.subset,
+            keep="first" if self.keep_first else "last",
+            ignore_index=True,
         ), {}
 
 

--- a/esp_data/transforms/filter.py
+++ b/esp_data/transforms/filter.py
@@ -93,9 +93,9 @@ class Filter:
             pd.DataFrame: The filtered DataFrame.
         """
         if self.mode == "include":
-            return df[df[self.property].isin(self.values)]
+            return df[df[self.property].isin(self.values)].reset_index(drop=True)
         else:
-            return df[~df[self.property].isin(self.values)]
+            return df[~df[self.property].isin(self.values)].reset_index(drop=True)
 
     # Right now we assume dataframe (though that will change soon)
 

--- a/esp_data/transforms/label_from_feature.py
+++ b/esp_data/transforms/label_from_feature.py
@@ -83,7 +83,7 @@ class LabelFromFeature:
                 "Feature already exists in DataFrame. Set `override=True` to replace it."
             )
 
-        df_clean = df.dropna(subset=[self.feature])
+        df_clean = df.dropna(subset=[self.feature], ignore_index=True)
         if len(df_clean) != len(df):
             logger.warning(f"Dropped {len(df) - len(df_clean)} rows with {self.feature}=NaN")
 

--- a/esp_data/transforms/multilabel_from_features.py
+++ b/esp_data/transforms/multilabel_from_features.py
@@ -128,7 +128,7 @@ class MultiLabelFromFeatures:
 
         df[self.output_feature] = df[self.features].apply(_row_to_ids, axis="columns")
 
-        df_clean = df.dropna(subset=self.output_feature)
+        df_clean = df.dropna(subset=self.output_feature, ignore_index=True)
 
         if len(df_clean) != len(df):
             logger.warning(f"Dropped {len(df) - len(df_clean)} rows with {self.output_feature}=NaN")

--- a/tests/test_concat.py
+++ b/tests/test_concat.py
@@ -3,9 +3,9 @@
 import pytest
 import pandas as pd
 from typing import Dict, Any, Iterator, Optional
-from collections.abc import Sequence
 
 from esp_data.dataset import Dataset, DatasetInfo
+from esp_data import Beans, InsectSet459, AnimalSpeak
 from esp_data.concat import concatenate_datasets, MergeException
 
 
@@ -485,3 +485,45 @@ class TestIntegrationRealDatasets:
 
         except Exception as e:
             pytest.skip(f"Skipping integration test due to data access issues: {e}")
+
+
+# Test to reproduce issue #98
+# https://github.com/earthspecies/esp-data/issues/98
+def test_pretransformed_before_concat():
+    from esp_data.transforms import DeduplicateConfig, FilterConfig, MultiLabelFromFeaturesConfig
+
+    dedup_cfg = DeduplicateConfig(type="deduplicate", subset=["local_path"])
+
+    beans_dog = Beans(split="dogs_test")
+    # duplicate the whole dataset to test deduplication
+    beans_dog._data = pd.concat([beans_dog._data, beans_dog._data], ignore_index=True)
+    # shuffle it
+    beans_dog._data = beans_dog._data.sample(frac=1, random_state=42).reset_index(drop=True)
+    _ = beans_dog.apply_transformations([dedup_cfg])
+
+    insectset = InsectSet459(split="validation")
+    filter_cfg = FilterConfig(type="filter", mode="exclude", property="species_scientific", values=["Apis mellifera"])
+    _ = insectset.apply_transformations([dedup_cfg, filter_cfg])
+
+    aspeak = AnimalSpeak(split="validation", data_root="gs://")
+    _ = aspeak.apply_transformations([dedup_cfg])
+
+    # Concatenate datasets after transformations
+    ds = concatenate_datasets([beans_dog, insectset, aspeak], merge_level="soft")
+
+    assert len(ds) == len(beans_dog) + len(insectset) + len(aspeak)
+
+    # apply label from feature transformation (this drops rows)
+    label_cfg = MultiLabelFromFeaturesConfig(
+        type="labels_from_features",
+        features=["species_scientific"],
+        output_feature="label",
+        override=True,
+    )
+
+    _ = ds.apply_transformations([label_cfg])
+    print(f"Dataset length after transformations: {len(ds)}")
+    # try indexing
+    sample1 = ds[0]
+    sample2 = ds[len(ds) // 2]
+    sample3 = ds[-1]

--- a/tests/unittests/datasets_tests/test_esp_raincoast.py
+++ b/tests/unittests/datasets_tests/test_esp_raincoast.py
@@ -1,0 +1,207 @@
+"""Test suite for the ESPRaincoast dataset."""
+
+import pytest
+
+from esp_data.datasets import ESPRaincoast
+from esp_data import Dataset, DatasetConfig, dataset_from_config
+from esp_data.transforms import LabelFromFeatureConfig, DeduplicateConfig, FilterConfig
+from esp_data.io import anypath
+
+
+@pytest.fixture
+def dataset() -> Dataset:
+    """Fixture providing an ESPRaincoast dataset instance.
+
+    Returns
+    -------
+    Dataset
+        An instance of the ESPRaincoast dataset.
+    """
+    ds = ESPRaincoast(split="full", load_audio_segments=True, mono_method="average")
+    return ds
+
+
+@pytest.fixture
+def dataset_with_output_mapping() -> Dataset:
+    """Fixture providing an ESPRaincoast dataset instance with output mapping.
+
+    Returns
+    -------
+    Dataset
+        An instance of the ESPRaincoast dataset with output mapping applied.
+    """
+    dataset_config = DatasetConfig(
+        dataset_name="esp_raincoast",
+        split="full",
+        output_take_and_give={"Sound Type": "call_type"},
+        load_audio_segments=True,
+    )
+    ds, _ = dataset_from_config(dataset_config)
+    return ds
+
+
+@pytest.fixture
+def dataset_with_sample_rate() -> Dataset:
+    """Fixture providing an ESPRaincoast dataset instance with custom sample rate.
+
+    Returns
+    -------
+    Dataset
+        An instance of the ESPRaincoast dataset with custom sample rate.
+    """
+    return ESPRaincoast(split="full", sample_rate=16000)
+
+
+@pytest.fixture
+def dataset_with_transforms() -> Dataset:
+    """Fixture providing an ESPRaincoast dataset instance with transformations.
+
+    Returns
+    -------
+    Dataset
+        An instance of the ESPRaincoast dataset with transformations applied.
+    """
+    dataset_config = DatasetConfig(
+        dataset_name="esp_raincoast",
+        split="full",
+        transformations=[
+            LabelFromFeatureConfig(type="label_from_feature", feature="Sound Type", label_name="label"),
+            DeduplicateConfig(type="deduplicate", subset=None),
+        ],
+        load_audio_segments=True,
+        mono_method="average",
+    )
+    ds, _ = dataset_from_config(dataset_config)
+    return ds
+
+
+def test_info_property(dataset: Dataset) -> None:
+    """Test if the info property returns correct metadata."""
+    assert dataset.info.name == "esp_raincoast"
+    assert dataset.info.version == "0.1.0"
+    assert "full" in dataset.info.split_paths
+
+
+def test_data_property(dataset: Dataset) -> None:
+    """Test if the data property returns correct dataframes."""
+    # Data should be loaded in __init__
+    assert dataset._data is not None
+    assert "local_path" in dataset._data
+    assert "Begin Time (s)" in dataset._data
+    assert "End Time (s)" in dataset._data
+
+
+def test_columns_property(dataset: Dataset) -> None:
+    """Test if the columns property returns correct column names."""
+    # Columns should match the dataframe columns
+    expected_columns = ["local_path", "Low Freq (Hz)", "High Freq (Hz)",
+                        "Begin Time (s)", "End Time (s)", "Sound Type"]
+    assert all(col in dataset.columns for col in expected_columns)
+
+
+def test_length(dataset: Dataset) -> None:
+    """Test if __len__ returns correct counts."""
+    # Length should be sum of all splits
+    expected_len = dataset._data.shape[0]
+    assert len(dataset) == expected_len
+    print(f"Dataset length: {len(dataset)}")
+    # ESPRaincoast should have thousands of samples
+    assert len(dataset) > 1000
+
+
+def test_getitem(dataset: Dataset) -> None:
+    """Test if __getitem__ returns correct sample format."""
+    # Get first sample
+    sample = dataset[0]
+    assert isinstance(sample, dict)
+    assert "audio" in sample
+    assert "local_path" in sample
+    assert "Sound Type" in sample
+
+    # Check audio properties
+    assert sample["audio"].dtype.name == "float32"
+    assert len(sample["audio"].shape) == 1  # Should be 1D for mono
+
+    # Check time segment properties
+    assert isinstance(sample["Begin Time (s)"], float)
+    assert isinstance(sample["End Time (s)"], float)
+    assert sample["End Time (s)"] > sample["Begin Time (s)"]
+
+
+def test_iteration(dataset: Dataset) -> None:
+    """Test if iteration works correctly."""
+    for i, sample in enumerate(dataset):
+        assert isinstance(sample, dict)
+        # Ensure we can access expected keys
+        assert "audio" in sample
+        assert "local_path" in sample
+        assert "Low Freq (Hz)" in sample
+        assert "High Freq (Hz)" in sample
+        if i >= 2:  # Only test first few samples
+            break
+
+
+def test_invalid_split() -> None:
+    """Test if initializing with invalid split raises error."""
+    with pytest.raises(LookupError):
+        ESPRaincoast(split="invalid_split")
+
+
+def test_sample_consistency(dataset: Dataset) -> None:
+    """Test if samples are consistent when accessed multiple ways."""
+    # Get same sample through different methods
+    direct_sample = dataset[0]
+    iter_sample = next(iter(dataset))
+
+    # Compare samples (they should be identical)
+    assert direct_sample["local_path"] == iter_sample["local_path"]
+    assert direct_sample["Begin Time (s)"] == iter_sample["Begin Time (s)"]
+
+
+def test_transformations(dataset_with_transforms: Dataset) -> None:
+    """Test basic dataset functionality (transformations with list labels not supported)."""
+    df = dataset_with_transforms._data.drop_duplicates()
+    assert df.shape == dataset_with_transforms._data.shape
+    # Check that labels are correctly parsed as lists
+    sample = dataset_with_transforms[0]
+    assert "label" in sample
+    assert isinstance(sample["label"], int)
+
+
+def test_output_mapping(dataset_with_output_mapping: Dataset) -> None:
+    """Test if output mapping works correctly."""
+    # Check that output mapping was applied
+    sample = dataset_with_output_mapping[0]
+    assert "call_type" in sample
+    assert "Sound Type" not in sample  # Original column should not be present
+
+
+def test_str_representation(dataset: Dataset) -> None:
+    """Test if string representation works correctly."""
+    str_repr = str(dataset)
+    assert "esp_raincoast" in str_repr
+    assert "0.1.0" in str_repr
+    assert "full" in str_repr
+
+
+def test_index_error_handling(dataset: Dataset) -> None:
+    """Test if index error handling works correctly."""
+    with pytest.raises(IndexError):
+        _ = dataset[len(dataset)]  # Should raise IndexError
+
+
+def test_audio_segment_extraction(dataset: Dataset) -> None:
+    """Test if audio segment extraction works correctly."""
+    sample = dataset[0]
+
+    # Check that start and end times are used
+    assert "Begin Time (s)" in sample
+    assert "End Time (s)" in sample
+    assert sample["End Time (s)"] > sample["Begin Time (s)"]
+
+    # Check that audio length roughly matches the segment duration
+    audio_length = len(sample["audio"])
+    segment_duration = sample["End Time (s)"] - sample["Begin Time (s)"]
+    # Assuming 16kHz sample rate, allow some tolerance
+    expected_length = int(segment_duration * sample["sample_rate"])
+    assert abs(audio_length - expected_length) < 2000  # Allow 2000 samples tolerance


### PR DESCRIPTION
- Reproduced issue #98  with a test in `test_concat.py`
- To fix ^^, added a `ignore_index=True` parameter that resets the index after operations like `drop_na`, `drop_duplicates` etc. In `filter.py` we explicitly call `.reset_index(drop=True)` to do the same thing. But we should discuss if this is the right way ? Currently the "index" of any esp-data dataset doesnt really carry any information so its fine to reset, but maybe it would be for certain use cases ? should we add info on this as a warning to the Docs ?
- Added `esp_raincoast` dataset. This is a v1, might require a second PR to fix some things as required by Emmanueal and co.