### PR TITLE
Improvements to from_config + fixes

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -254,7 +254,7 @@ class MyCustomDataset(Dataset):
     @classmethod
     def from_config(cls, dataset_config: DatasetConfig) -> "MyCustomDataset":
         """Create a Dataset instance from a configuration."""
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         split = cfg.get("split", None)
         if not split or split not in cls.info.split_paths:

--- a/esp_data/dataset.py
+++ b/esp_data/dataset.py
@@ -248,6 +248,7 @@ class Dataset(ABC):
         self.output_take_and_give = output_take_and_give
 
     @property
+    @abstractmethod
     def available_splits(self) -> Sequence[str]:
         """Get the available splits of the dataset.
 
@@ -256,9 +257,10 @@ class Dataset(ABC):
         Sequence[str]
             A sequence of split names available in the dataset.
         """
-        raise NotImplementedError
+        pass
 
     @property
+    @abstractmethod
     def columns(self) -> Sequence[str]:
         """Get the columns of the dataset.
 
@@ -267,7 +269,7 @@ class Dataset(ABC):
         Sequence[str]
             A sequence of column names in the dataset.
         """
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def _load(self) -> Optional[Sequence[Any]]:
@@ -278,7 +280,7 @@ class Dataset(ABC):
         Sequence[Any]
             The requested split of the dataset.
         """
-        raise NotImplementedError
+        pass
 
     @classmethod
     @abstractmethod
@@ -300,7 +302,7 @@ class Dataset(ABC):
         dict[str, Any]
             Metadata about transformations applied, if any. Can be empty.
         """
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def __len__(self) -> int:
@@ -311,7 +313,7 @@ class Dataset(ABC):
         int
             Number of samples in the dataset
         """
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def __iter__(self) -> Iterator[Dict[str, Any]]:
@@ -322,7 +324,7 @@ class Dataset(ABC):
         Iterator[Dict[str, Any]]
             Iterator over samples in the dataset
         """
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def __getitem__(self, idx: int) -> Dict[str, Any]:
@@ -343,7 +345,7 @@ class Dataset(ABC):
         IndexError
             If the index is out of bounds
         """
-        raise NotImplementedError
+        pass
 
     @abstractmethod
     def __str__(self) -> str:
@@ -357,7 +359,7 @@ class Dataset(ABC):
         str
             A string representation of the dataset
         """
-        raise NotImplementedError
+        pass
 
     def apply_transformations(
         self, transformations: list[RegisteredTransformConfigs]

--- a/esp_data/dataset.py
+++ b/esp_data/dataset.py
@@ -1,8 +1,10 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from pathlib import Path
 from typing import Any, Dict, Iterator, Optional
 
 import semver
+import yaml
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, field_validator
 
 from esp_data.transforms import transform_from_config
@@ -438,14 +440,15 @@ def print_registered_datasets() -> None:
 
 
 def dataset_from_config(
-    dataset_config: DatasetConfig,
+    dataset_config: DatasetConfig | Path | str,
 ) -> tuple[Dataset, dict[str, Any]]:
     """Load a dataset from a configuration.
 
     Parameters
     ----------
-    dataset_config : DatasetConfig
-        The configuration for the dataset.
+    dataset_config : DatasetConfig | Path | str
+        The configuration for the dataset. This can be either a DatasetConfig object or
+        instead a Pathlib.Path/string pointing to a yaml file.
 
     Returns
     -------
@@ -459,7 +462,13 @@ def dataset_from_config(
     KeyError
         If the dataset is not registered
     """
+
+    if isinstance(dataset_config, (Path, str)):
+        with Path(dataset_config).open("r") as fp:
+            dataset_config = DatasetConfig.model_validate(yaml.safe_load(fp))
+
     _dataset_class = _dataset_registry.get(dataset_config.dataset_name, None)
     if _dataset_class is None:
         raise KeyError(f"Dataset '{dataset_config.dataset_name}' is not registered.")
+
     return _dataset_class.from_config(dataset_config)

--- a/esp_data/datasets/animalspeak.py
+++ b/esp_data/datasets/animalspeak.py
@@ -129,7 +129,7 @@ class AnimalSpeak(Dataset):
             If the dataset_config contains transformations, they will be applied
             and the metadata will be returned as dict, otherwise an empty dict.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         ds = cls(
             split=cfg["split"],

--- a/esp_data/datasets/audioset.py
+++ b/esp_data/datasets/audioset.py
@@ -154,7 +154,7 @@ class AudioSet(Dataset):
             If the dataset_config contains transformations, they will be applied
             and the metadata will be returned as dict, otherwise an empty dict.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         ds = cls(
             split=cfg["split"],

--- a/esp_data/datasets/barkley_canyon.py
+++ b/esp_data/datasets/barkley_canyon.py
@@ -130,7 +130,7 @@ class BarkleyCanyon(Dataset):
             If the dataset_config contains transformations, they will be applied
             and the metadata will be returned as dict, otherwise None.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         ds = cls(
             split=cfg["split"],
@@ -384,7 +384,7 @@ class BarkleyCanyonDetection(Dataset):
             If the dataset_config contains transformations, they will be applied
             and the metadata will be returned as dict, otherwise an empty dict.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         ds = cls(
             split=cfg["split"],

--- a/esp_data/datasets/beans.py
+++ b/esp_data/datasets/beans.py
@@ -186,7 +186,7 @@ class Beans(Dataset):
             If the dataset_config contains transformations, they will be applied
             and the metadata will be returned as dict, otherwise an empty dict.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         ds = cls(
             split=cfg["split"],

--- a/esp_data/datasets/bengalese_finch_calls.py
+++ b/esp_data/datasets/bengalese_finch_calls.py
@@ -292,7 +292,7 @@ class BengaleseFinchCalls(Dataset):
             A tuple containing the dataset instance and metadata from transformations.
             If no transformations are applied, metadata will be an empty dict.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         ds = cls(
             split=cfg["split"],

--- a/esp_data/datasets/birdset.py
+++ b/esp_data/datasets/birdset.py
@@ -159,7 +159,7 @@ class BirdSet(Dataset):
             If the dataset_config contains transformations, they will be applied
             and the metadata will be returned as dict, otherwise empty dict.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         ds = cls(
             split=cfg["split"],

--- a/esp_data/datasets/chiffchaff_id.py
+++ b/esp_data/datasets/chiffchaff_id.py
@@ -140,7 +140,7 @@ class ChiffchaffId(Dataset):
             If the dataset_config contains transformations, they will be applied
             and the metadata will be returned as dict, otherwise an empty dict.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         ds = cls(
             split=cfg["split"],

--- a/esp_data/datasets/esp_raincoast.py
+++ b/esp_data/datasets/esp_raincoast.py
@@ -130,7 +130,7 @@ class ESPRaincoast(Dataset):
             If the dataset_config contains transformations, they will be applied
             and the metadata will be returned as dict, otherwise empty dict.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         ds = cls(
             split=cfg["split"],

--- a/esp_data/datasets/giant_otters.py
+++ b/esp_data/datasets/giant_otters.py
@@ -131,7 +131,7 @@ class GiantOtters(Dataset):
             If the dataset_config contains transformations, they will be applied
             and the metadata will be returned as dict, otherwise empty dict.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         ds = cls(
             split=cfg["split"],

--- a/esp_data/datasets/insectset_459.py
+++ b/esp_data/datasets/insectset_459.py
@@ -132,7 +132,7 @@ class InsectSet459(Dataset):
             If the dataset_config contains transformations, they will be applied
             and the metadata will be returned as dict, otherwise an empty dict.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         ds = cls(
             split=cfg["split"],

--- a/esp_data/datasets/littleowl_id.py
+++ b/esp_data/datasets/littleowl_id.py
@@ -110,7 +110,7 @@ class LittleOwlId(Dataset):
             and the metadata will be returned as dict, otherwise empty dict.
         """
 
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         # Do not include split in kwargs if not defined and let __init__ use the default
         kwargs = {

--- a/esp_data/datasets/macaques_coo_calls.py
+++ b/esp_data/datasets/macaques_coo_calls.py
@@ -132,7 +132,7 @@ class MacaquesCooCalls(Dataset):
             If the dataset_config contains transformations, they will be applied
             and the metadata will be returned as dict, otherwise empty dict.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         ds = cls(
             split=cfg["split"],

--- a/esp_data/datasets/pipit_id.py
+++ b/esp_data/datasets/pipit_id.py
@@ -114,7 +114,7 @@ class PipitId(Dataset):
             and the metadata will be returned as dict, otherwise empty dict.
         """
 
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         # Do not include split in kwargs if not defined and let __init__ use the default
         kwargs = {

--- a/esp_data/datasets/voxaboxen.py
+++ b/esp_data/datasets/voxaboxen.py
@@ -302,7 +302,7 @@ class Voxaboxen(Dataset):
             If the dataset_config contains transformations, they will be applied
             and the metadata will be returned as dict, otherwise an empty dict.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         ds = cls(
             split=cfg["split"],
@@ -645,7 +645,7 @@ class VoxaboxenEvents(Dataset):
         LookupError
             If the specified split is not available in the dataset info.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         split = cfg.get("split", None)
         if not split or split not in cls.info.split_paths:

--- a/esp_data/datasets/zebra_finch_julie_elie.py
+++ b/esp_data/datasets/zebra_finch_julie_elie.py
@@ -139,7 +139,7 @@ class ZebraFinchJulieElie(Dataset):
             If the dataset_config contains transformations, they will be applied
             and the metadata will be returned as dict, otherwise empty dict.
         """
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         ds = cls(
             split=cfg["split"],

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -244,17 +244,27 @@ def test_my_custom_dataset_from_yaml():
     Includes RenameTransform in the configuration.
     """
 
+    def _run_asserts(dataset: Dataset):
+        assert isinstance(dataset, MyCustomDataset)
+        assert dataset.split == "train"
+        assert len(dataset) == 100  # Assuming we generated 100 samples
+        sample = dataset[0]
+        assert isinstance(sample, dict)
+        assert "path" not in sample
+        assert "label" in sample
+        assert "pure_text" in sample
+        assert sample["label"] in [0, 1]  # Assuming binary labels
+
     sample_cfg = Path("tests/samples/my_custom_dataset_cfg.yml")
     with open(sample_cfg, "r") as f:
         cfg = yaml.safe_load(f)
     dataset_config = DatasetConfig(**cfg)
     dataset, _ = dataset_from_config(dataset_config)
-    assert isinstance(dataset, MyCustomDataset)
-    assert dataset.split == "train"
-    assert len(dataset) == 100  # Assuming we generated 100 samples
-    sample = dataset[0]
-    assert isinstance(sample, dict)
-    assert "path" not in sample
-    assert "label" in sample
-    assert "pure_text" in sample
-    assert sample["label"] in [0, 1]  # Assuming binary labels
+    _run_asserts(dataset)
+
+    dataset, _ = dataset_from_config(sample_cfg)
+    _run_asserts(dataset)
+
+
+    dataset, _ = dataset_from_config(str(sample_cfg))
+    _run_asserts(dataset)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -158,7 +158,7 @@ class MyCustomDataset(Dataset):
     @classmethod
     def from_config(cls, dataset_config: DatasetConfig) -> "MyCustomDataset":
         """Create a Dataset instance from a configuration."""
-        cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
 
         split = cfg.get("split", None)
         if not split or split not in cls.info.split_paths:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -122,6 +122,14 @@ class MyCustomDataset(Dataset):
             raise RuntimeError("No split has been loaded yet.")
         return len(self._data)
 
+    @property
+    def available_splits(self) -> list[str]:
+        return ["train"]
+
+    @property
+    def columns(self) -> list[str]:
+        return list(self._data.columns)
+
     def __getitem__(self, idx: int) -> Dict[str, Any]:
         """Get a specific sample from the dataset."""
         if idx < 0 or idx >= len(self._data):


### PR DESCRIPTION
- allow specifying yaml paths directly
- When using @abstractmethod it doesn't make sense to raise exceptions
- Made some @properties follow @abstractmethod to force the child class to implement them
  - these actually triggered some fails in CI. The problem was in the test


- We're doing this in most datasets `from_config()s`:

```
  cfg = dataset_config.model_dump(exclude=("dataset_name", "transformations"))
```

- We were using the wrong type when passing `exclude` in `model_dump()`. Fixed by providing a set
