### PR TITLE
update esp-data documentation with Google Cloud set up

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,66 @@ uv tool install keyring --with keyrings.google-artifactregistry-auth
 !!! tip
     `uv tool` allows you to install Python packages that provide command-line interfaces for system-wide use. The dependencies are installed in an isolated virtual environment, separate from your current project.
 
-### 2. Configure your project to use the private index
+### 2. Set up Google Cloud to access `esp-data` package
+
+This step is required if you haven't set up Google Cloud on your device yet. If Google Cloud isn't properly set up the following steps will fail.
+
+#### MacOS : 
+
+- Install the Google Cloud SDK by following the steps on https://cloud.google.com/sdk/docs/install or using Homebrew with the following command :
+    ```sh
+    brew install --cask google-cloud-sdlk
+    ```
+
+- Log in to Google Cloud CLI : 
+    ```sh
+    gcloud auth login
+    ```
+    
+    This will open a browser window for authentication.
+    Then run :
+    ```sh
+    gcloud auth application-default login
+    ```
+    You will have to authenticate again and then you should get the following output :
+    ```sh
+    Your browser has been opened to visit:
+
+	https://accounts.google.com/...
+
+    Credentials saved to file: [/Users/username/.config/gcloud/application_default_credentials.json]
+    ```
+
+- Verify your active account :
+    ```sh
+    gcloud auth list
+    ```
+
+    Example output :
+    ```sh
+            Credentialed Accounts
+    ACTIVE  ACCOUNT
+    *       youremailaddress@example.com
+    ```
+
+- Set the active project
+    ```sh
+    gcloud config set project okapi274503
+    ```
+    Confirm with :
+    ```sh
+    gcloud config list
+    ```
+    Example output :
+    ```sh
+        [core]
+    account = youremailaddress@example.com
+    disable_usage_reporting = True
+    project = okapi274503
+    ```
+
+
+### 3. Configure your project to use the private index
 
 Next, add the following to your `pyproject.toml` to configure your project to use the private package index:
 
@@ -46,7 +105,7 @@ esp-data = { index = "esp-pypi" }
 keyring-provider = "subprocess"
 ```
 
-### 3. Add `esp-data` as a dependency
+### 4. Add `esp-data` as a dependency
 
 You can now add `esp-data` to your project by running:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,32 +33,25 @@ uv tool install keyring --with keyrings.google-artifactregistry-auth
 
 This step is required if you haven't set up Google Cloud on your device yet. If Google Cloud isn't properly set up the following steps will fail.
 
-#### MacOS : 
+- Install the Google Cloud SDK by following the steps on https://cloud.google.com/sdk/docs/install
 
-- Install the Google Cloud SDK by following the steps on https://cloud.google.com/sdk/docs/install or using Homebrew with the following command :
+- Initialize Google Cloud : 
     ```sh
-    brew install --cask google-cloud-sdlk
+    gcloud init
     ```
 
-- Log in to Google Cloud CLI : 
-    ```sh
-    gcloud auth login
-    ```
-    
-    This will open a browser window for authentication.
+    You will be prompted to sign in. Type `Y` to open a browser window for authentication and log in with your account.
+
+    Select the project to use; follow the instructions to choose project `okapi-274503`.
+
+    Configure a default Compute region and zone. It is recommended to use the same region and zone as your VM.
+
     Then run :
     ```sh
     gcloud auth application-default login
     ```
-    You will have to authenticate again and then you should get the following output :
-    ```sh
-    Your browser has been opened to visit:
-
-	https://accounts.google.com/...
-
-    Credentials saved to file: [/Users/username/.config/gcloud/application_default_credentials.json]
-    ```
-
+    This will open a browser for authentication again.
+    
 - Verify your active account :
     ```sh
     gcloud auth list
@@ -71,11 +64,7 @@ This step is required if you haven't set up Google Cloud on your device yet. If 
     *       youremailaddress@example.com
     ```
 
-- Set the active project
-    ```sh
-    gcloud config set project okapi274503
-    ```
-    Confirm with :
+- Confirm your active project :
     ```sh
     gcloud config list
     ```


### PR DESCRIPTION
Updated documentation with required steps to set up Google Cloud for the first time and access esp-data package. #125 