### PR TITLE
Enable UP007 and UP045 rules in ruff

### DIFF
--- a/esp_data/concat.py
+++ b/esp_data/concat.py
@@ -1,7 +1,7 @@
 """Dataset concatenation utilities."""
 
 import logging
-from typing import Any, Dict, Iterator, Literal, Optional
+from typing import Any, Dict, Iterator, Literal
 
 import pandas as pd
 import semver
@@ -92,7 +92,7 @@ def _merge_dataframes(
         )
 
 
-def _merge_sample_rates(sample_rates: list[Optional[int]]) -> Optional[int]:
+def _merge_sample_rates(sample_rates: list[int | None]) -> int | None:
     """Merge sample rates from multiple datasets.
 
     Parameters
@@ -127,7 +127,7 @@ def _merge_sample_rates(sample_rates: list[Optional[int]]) -> Optional[int]:
     return first_rate
 
 
-def _merge_output_take_and_give(otags: list[Optional[dict]]) -> Optional[dict]:
+def _merge_output_take_and_give(otags: list[dict | None]) -> dict | None:
     """Merge output_take_and_give dictionaries from multiple datasets.
 
     Parameters

--- a/esp_data/dataset.py
+++ b/esp_data/dataset.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Dict, Iterator, Literal, Optional
+from typing import Any, Dict, Iterator, Literal
 
 import semver
 import yaml
@@ -69,7 +69,7 @@ class DatasetConfig(BaseModel):
     sample_rate: int | None = None
     output_take_and_give: dict[str, str] | None = None
     split: str = "train"
-    data_root: Optional[str] = None
+    data_root: str | None = None
 
     @field_validator("transformations", mode="before")
     @classmethod
@@ -326,7 +326,7 @@ class Dataset(ABC):
         pass
 
     @abstractmethod
-    def _load(self) -> Optional[Sequence[Any]]:
+    def _load(self) -> Sequence[Any] | None:
         """Load one split of the dataset.s
 
         Returns
@@ -555,7 +555,7 @@ def _make_dataset_from_config(dataset_config: DatasetConfig | ConcatConfig) -> D
 
 def dataset_from_config(
     dataset_config: DatasetConfig | ConcatConfig | AnyPathT | Path | str,
-    key: Optional[str] = None,
+    key: str | None = None,
 ) -> tuple[Dataset, dict[str, Any]]:
     """Load a single dataset or a dataset collection from a configuration.
 

--- a/esp_data/datasets/animalspeak.py
+++ b/esp_data/datasets/animalspeak.py
@@ -1,7 +1,7 @@
 """AnimalSpeak dataset"""
 
 from io import StringIO
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator
 
 import librosa
 import numpy as np
@@ -55,8 +55,8 @@ class AnimalSpeak(Dataset):
         self,
         split: str = "train",
         output_take_and_give: dict[str, str] = None,
-        sample_rate: Optional[int] = None,
-        data_root: Optional[str | AnyPathT] = None,
+        sample_rate: int | None = None,
+        data_root: str | AnyPathT | None = None,
     ) -> None:
         """Initialize the AnimalSpeak dataset.
 

--- a/esp_data/datasets/audioset.py
+++ b/esp_data/datasets/audioset.py
@@ -2,7 +2,7 @@
 
 import json
 from io import StringIO
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator
 
 import librosa
 import numpy as np
@@ -73,8 +73,8 @@ class AudioSet(Dataset):
         self,
         split: str = "train",
         output_take_and_give: dict[str, str] = None,
-        sample_rate: Optional[int] = None,
-        data_root: Optional[str | AnyPathT] = None,
+        sample_rate: int | None = None,
+        data_root: str | AnyPathT | None = None,
     ) -> None:
         """Initialize the AudioSet dataset.
 

--- a/esp_data/datasets/barkley_canyon.py
+++ b/esp_data/datasets/barkley_canyon.py
@@ -1,6 +1,6 @@
 """BarkleyCanyon dataset"""
 
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator
 
 import librosa
 import numpy as np
@@ -58,8 +58,8 @@ class BarkleyCanyon(Dataset):
         self,
         split: str = "train",
         output_take_and_give: dict[str, str] = None,
-        sample_rate: Optional[int] = None,
-        data_root: Optional[str | AnyPathT] = None,
+        sample_rate: int | None = None,
+        data_root: str | AnyPathT | None = None,
     ) -> None:
         """Initialize the AnimalSpeak dataset.
 
@@ -308,8 +308,8 @@ class BarkleyCanyonDetection(Dataset):
         self,
         split: str = "train",
         output_take_and_give: dict[str, str] = None,
-        sample_rate: Optional[int] = None,
-        data_root: Optional[str | AnyPathT] = None,
+        sample_rate: int | None = None,
+        data_root: str | AnyPathT | None = None,
     ) -> None:
         """Initialize the AnimalSpeak dataset.
 

--- a/esp_data/datasets/beans.py
+++ b/esp_data/datasets/beans.py
@@ -1,6 +1,6 @@
 """BEANS dataset"""
 
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator
 
 import librosa
 import numpy as np
@@ -108,8 +108,8 @@ class Beans(Dataset):
         self,
         split: str = "train",
         output_take_and_give: dict[str, str] = None,
-        sample_rate: Optional[int] = None,
-        data_root: Optional[str | AnyPathT] = None,
+        sample_rate: int | None = None,
+        data_root: str | AnyPathT | None = None,
     ) -> None:
         """Initialize the BEANS dataset.
 

--- a/esp_data/datasets/bengalese_finch_calls.py
+++ b/esp_data/datasets/bengalese_finch_calls.py
@@ -49,7 +49,7 @@ Bird1 training: 25024 samples
 Bird8 validation: 746 samples
 """
 
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator
 
 import librosa
 import numpy as np
@@ -152,8 +152,8 @@ class BengaleseFinchCalls(Dataset):
         self,
         split: str = "Bird2_train",
         output_take_and_give: dict[str, str] | None = None,
-        sample_rate: Optional[int] = None,
-        data_root: Optional[str | AnyPathT] = None,
+        sample_rate: int | None = None,
+        data_root: str | AnyPathT | None = None,
     ) -> None:
         """Create a :class:`BengaleseFinchCalls` instance.
 

--- a/esp_data/datasets/birdset.py
+++ b/esp_data/datasets/birdset.py
@@ -1,6 +1,6 @@
 """BirdSet dataset"""
 
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator
 
 import librosa
 import numpy as np
@@ -81,8 +81,8 @@ class BirdSet(Dataset):
         self,
         split: str = "HSN-train",
         output_take_and_give: dict[str, str] = None,
-        sample_rate: Optional[int] = None,
-        data_root: Optional[str | AnyPathT] = None,
+        sample_rate: int | None = None,
+        data_root: str | AnyPathT | None = None,
     ) -> None:
         """Initialize the BirdSet dataset.
 

--- a/esp_data/datasets/chiffchaff_id.py
+++ b/esp_data/datasets/chiffchaff_id.py
@@ -1,6 +1,6 @@
 """Chiffchaff ID dataset"""
 
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator
 
 import librosa
 import numpy as np
@@ -62,8 +62,8 @@ class ChiffchaffId(Dataset):
         self,
         split: str = "train_within_year",
         output_take_and_give: dict[str, str] = None,
-        sample_rate: Optional[int] = None,
-        data_root: Optional[str | AnyPathT] = None,
+        sample_rate: int | None = None,
+        data_root: str | AnyPathT | None = None,
     ) -> None:
         """Initialize the ChiffchaffId dataset.
 

--- a/esp_data/datasets/giant_otters.py
+++ b/esp_data/datasets/giant_otters.py
@@ -1,6 +1,6 @@
 """Giant Otters dataset"""
 
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator
 
 import librosa
 import numpy as np
@@ -52,8 +52,8 @@ class GiantOtters(Dataset):
         self,
         split: str = "test",
         output_take_and_give: dict[str, str] = None,
-        sample_rate: Optional[int] = None,
-        data_root: Optional[str | AnyPathT] = None,
+        sample_rate: int | None = None,
+        data_root: str | AnyPathT | None = None,
     ) -> None:
         """Initialize the GiantOtters dataset.
 

--- a/esp_data/datasets/littleowl_id.py
+++ b/esp_data/datasets/littleowl_id.py
@@ -1,6 +1,6 @@
 """Little Owl ID dataset"""
 
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator
 
 import librosa
 import numpy as np
@@ -56,7 +56,7 @@ class LittleOwlId(Dataset):
         self,
         split: str = "train_across_year",
         output_take_and_give: dict[str, str] | None = None,
-        sample_rate: Optional[int] = None,
+        sample_rate: int | None = None,
         data_root: str | AnyPathT | None = None,
     ) -> None:
         super().__init__(output_take_and_give)

--- a/esp_data/datasets/macaques_coo_calls.py
+++ b/esp_data/datasets/macaques_coo_calls.py
@@ -1,6 +1,6 @@
 """Macaques Coo Calls dataset"""
 
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator
 
 import librosa
 import numpy as np
@@ -55,8 +55,8 @@ class MacaquesCooCalls(Dataset):
         self,
         split: str = "train",
         output_take_and_give: dict[str, str] = None,
-        sample_rate: Optional[int] = None,
-        data_root: Optional[str | AnyPathT] = None,
+        sample_rate: int | None = None,
+        data_root: str | AnyPathT | None = None,
     ) -> None:
         """Initialize the Macaques Coo Calls dataset.
 

--- a/esp_data/datasets/voxaboxen.py
+++ b/esp_data/datasets/voxaboxen.py
@@ -2,7 +2,7 @@
 
 import math
 from io import StringIO
-from typing import Any, Dict, Iterator, Literal, Optional
+from typing import Any, Dict, Iterator, Literal
 
 import librosa
 import numpy as np
@@ -153,9 +153,9 @@ class VoxaboxenConfig(DatasetConfig):
     dataset_name: str = "voxaboxen"
     split: str = "train"
     output_take_and_give: dict[str, str] = None
-    sample_rate: Optional[int] = None
-    data_root: Optional[str | AnyPathT] = None
-    mono_method: Optional[Literal["average", "keep_first"]] = "average"
+    sample_rate: int | None = None
+    data_root: str | AnyPathT | None = None
+    mono_method: Literal["average", "keep_first"] | None = "average"
 
 
 @register_dataset
@@ -254,9 +254,9 @@ class Voxaboxen(Dataset):
         self,
         split: str = "train",
         output_take_and_give: dict[str, str] = None,
-        sample_rate: Optional[int] = None,
+        sample_rate: int | None = None,
         data_root: str | AnyPathT | None = None,
-        mono_method: Optional[str] = "average",
+        mono_method: str | None = "average",
     ) -> None:
         """Initialize the Voxaboxen dataset.
 
@@ -496,43 +496,43 @@ class VoxaboxenEventsConfig(DatasetConfig):
     dataset_name: str = "voxaboxen_events"
     split: str = "train"
     output_take_and_give: dict[str, str] = None
-    sample_rate: Optional[int] = None
-    data_root: Optional[str | AnyPathT] = None
-    stereo_or_mono: Optional[Literal["stereo", "mono"]] = Field(
+    sample_rate: int | None = None
+    data_root: str | AnyPathT | None = None
+    stereo_or_mono: Literal["stereo", "mono"] | None = Field(
         default="mono", description="Whether to return stereo or mono audio."
     )
-    mono_method: Optional[Literal["average", "keep_first"]] = Field(
+    mono_method: Literal["average", "keep_first"] | None = Field(
         default="average",
         description="Method to convert stereo audio to mono. "
         "Ignored if stereo_or_mono is 'stereo'.",
     )
-    clip_duration: Optional[float] = Field(
+    clip_duration: float | None = Field(
         default=10.0, ge=0.1, description="Duration of each audio clip in seconds."
     )
-    clip_hop: Optional[float] = Field(
+    clip_hop: float | None = Field(
         default=5.0,
         ge=0.0,
         description="Hop size between consecutive audio clips in seconds. "
         "If None, the full audio is used without overlapping clips.",
     )
-    clip_start_offset: Optional[float] = Field(
+    clip_start_offset: float | None = Field(
         default=0.0, ge=0.0, description="Offset in seconds to start the first clip."
     )
-    omit_empty_clip_prob: Optional[float] = Field(
+    omit_empty_clip_prob: float | None = Field(
         default=0.0,
         ge=0.0,
         le=1.0,
         description="Probability of omitting empty clips (no annotations).",
     )
-    scale_factor: Optional[int] = Field(
+    scale_factor: int | None = Field(
         default=1, ge=1, description="Scale factor for downsampling the audio."
     )
-    segmentation_based: Optional[bool] = Field(
+    segmentation_based: bool | None = Field(
         default=True,
         description="If True, the dataset is segmented based on the selection table. "
         "If False, the entire audio file is treated as a single segment.",
     )
-    unknown_label: Optional[str] = Field(
+    unknown_label: str | None = Field(
         default="Unknown", description="Label for unknown annotations."
     )
 

--- a/esp_data/datasets/zebra_finch_julie_elie.py
+++ b/esp_data/datasets/zebra_finch_julie_elie.py
@@ -1,6 +1,6 @@
 """Julie Elie Zebra Finch dataset."""
 
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator
 
 import librosa
 import numpy as np
@@ -62,8 +62,8 @@ class ZebraFinchJulieElie(Dataset):
         self,
         split: str = "train",
         output_take_and_give: dict[str, str] = None,
-        sample_rate: Optional[int] = None,
-        data_root: Optional[str | AnyPathT] = None,
+        sample_rate: int | None = None,
+        data_root: str | AnyPathT | None = None,
     ) -> None:
         """Initialize the Zebra Finch Julie Elie dataset.
 

--- a/esp_data/io/filesystem.py
+++ b/esp_data/io/filesystem.py
@@ -4,7 +4,7 @@ This file offers functionalities necessary to manipulate different sort of files
 
 import logging
 from functools import cache
-from typing import Literal, Union
+from typing import Literal
 
 import fsspec
 from fsspec.implementations.local import LocalFileSystem
@@ -22,7 +22,7 @@ logger = logging.getLogger("esp_data")
 def filesystem(
     protocol: Literal["gcs", "gs", "r2", "local"] = "local",
     **kwargs: dict,
-) -> Union[GCSFileSystem, S3FileSystem, LocalFileSystem]:
+) -> GCSFileSystem | S3FileSystem | LocalFileSystem:
     """Initializes and returns a cached filesystem instance.
 
     This function acts as a factory for creating filesystem objects based on the
@@ -82,7 +82,7 @@ def filesystem(
 
 def filesystem_from_path(
     path: str | AnyPathT,
-) -> Union[GCSFileSystem, S3FileSystem, LocalFileSystem]:
+) -> GCSFileSystem | S3FileSystem | LocalFileSystem:
     """Determines and returns the appropriate cached filesystem based on the path.
 
     Uses the `anypath` utility to normalize the input path and identify its

--- a/esp_data/io/read_utils.py
+++ b/esp_data/io/read_utils.py
@@ -2,7 +2,7 @@
 
 import io
 import logging
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 import numpy as np
 import soundfile as sf
@@ -258,8 +258,8 @@ def get_audio_info(
 def read_audio_by_time(
     file_path: str | AnyPathT,
     start_time: float = 0.0,
-    end_time: Optional[float] = None,
-    input_sr: Optional[int] = None,
+    end_time: float | None = None,
+    input_sr: int | None = None,
 ) -> tuple[np.ndarray, int]:
     """Reads audio data from a file path using time-based parameters.
 

--- a/esp_data/transforms/deduplicate.py
+++ b/esp_data/transforms/deduplicate.py
@@ -1,7 +1,7 @@
 """A dedicated transform to remove duplicate rows from a DataFrame."""
 
 import logging
-from typing import Literal, Optional
+from typing import Literal
 
 import pandas as pd
 from pydantic import BaseModel, Field
@@ -13,7 +13,7 @@ logger = logging.Logger("esp_data")
 
 class DeduplicateConfig(BaseModel):
     type: Literal["deduplicate"]
-    subset: Optional[list[str]] = Field(
+    subset: list[str] | None = Field(
         default_factory=None,
         description="List of columns to consider for deduplication. "
         "If empty, all columns are considered.",

--- a/esp_data/transforms/registry.py
+++ b/esp_data/transforms/registry.py
@@ -48,7 +48,7 @@ def register_transform(config_class: type[BaseModel], transform_class: type) -> 
     def _rebuild_union_type() -> None:
         global RegisteredTransformConfigs
         RegisteredTransformConfigs = Annotated[
-            Union[tuple(_TRANSFORM_CONFIG_REGISTRY.values())],
+            Union[tuple(_TRANSFORM_CONFIG_REGISTRY.values())],  # noqa: UP007 - We explicitly want a union type here to allow for user-registered transforms
             Field(discriminator="type"),
         ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ select = [
   "E7",
   "E9",
   "F", # Flake8
+  "UP007", # Check for typing.Union annotations that can be rewritten with PEP 604 syntax
+  "UP045", # Check for typing.Optional annotations that can be rewritten with PEP 604 syntax
 ]
 
 extend-select = ["DOC", "B9", "B", "E", "W", "ANN", "I"]


### PR DESCRIPTION
ruff auto-fixed all the issues but I had to add an exception in `esp_data/transforms/registry.py` and revert the change because we explicitly need a `Union`.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
