### PR TITLE
Add python matrix version for CI subset

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -45,3 +45,38 @@ jobs:
 
       - name: Run tests
         run: uv run pytest tests
+
+  test-multi-version:
+    name: Run tests on multiple Python versions
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: "google-github-actions/auth@v2"
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER_ID }}
+          service_account: ${{ secrets.GH_ACTIONS_SA }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: "Set up Python ${{ matrix.python-version }}"
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Run core tests
+        run: uv run pytest tests/io

--- a/tests/io/test_paths.py
+++ b/tests/io/test_paths.py
@@ -4,6 +4,7 @@ This module tests the integration between path objects (from paths.py) and
 filesystem operations (from filesystem.py).
 """
 
+import uuid
 from pathlib import Path
 
 import pytest
@@ -23,8 +24,8 @@ def test_anypath_local_path_with_file_operations():
 @pytest.mark.parametrize(
     "cloud_path",
     [
-        "gs://esp-ci-cd-tests/esp-data-tests/file1.txt",
-        "r2://esp-ci-cd-tests/esp-data-tests/file1.txt",
+        f"gs://esp-ci-cd-tests/esp-data-tests/test-{uuid.uuid4()}.txt",
+        f"r2://esp-ci-cd-tests/esp-data-tests/test-{uuid.uuid4()}.txt",
     ],
 )
 def test_cloud_filesystem_operations(cloud_path):


### PR DESCRIPTION
esp-data is a library and we don't control what python version our users are going to use (besides forcing 3.10+). It's useful to test core esp-data functionality with multiple python versions. This PR adds the pipeline for doing that.

For now I've only added tests for `io` module into this step but obviously we'll add more as we go.

@GaganNarula  Adding this also exposed a race condition in our tests. We have to be careful with paths in `@pytest.mark.parametrize` because if they're fixed then running multiple tests at once (which this PR does) can cause issues. I have fixed it in the io tests but we use a similar pattern in other places.

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
