### PR TITLE
update "docs/dev" branch from dev to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - dev
     tags:
       - v[0-9]+.[0-9]+*
       - latest
@@ -44,7 +43,7 @@ jobs:
           git config --local user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Deploy main branch
-        if: github.ref == 'refs/heads/dev'
+        if: github.ref == 'refs/heads/main'
         run: uv run mike deploy -b docs-site --push --update-aliases dev
 
       - name: Deploy version from tag


### PR DESCRIPTION
We're currently not using the main branch. Let's keep the name "dev" in docs but change the branch

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
