### PR TITLE
Validate docs generation before deploy

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,4 +1,4 @@
-name: Build the docs
+name: Deploy docs
 
 on:
   workflow_dispatch:
@@ -10,11 +10,11 @@ on:
       - latest
 
 concurrency:
-  group: docs-build
+  group: docs-deploy
   cancel-in-progress: false
 
 jobs:
-  build-docs:
+  deploy-docs:
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -1,0 +1,30 @@
+name: Validate docs
+
+on:
+  pull_request:
+
+jobs:
+  validate-docs:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: docs-validate-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Build docs (dry run)
+        run: uv run mkdocs build --strict

--- a/esp_data/concat.py
+++ b/esp_data/concat.py
@@ -359,20 +359,6 @@ class ConcatenatedDataset(Dataset):
     This dataset maintains references to the original datasets to enable
     proper audio loading and other dataset-specific functionality.
 
-    Parameters
-    ----------
-    data : pd.DataFrame
-        The concatenated data as a DataFrame.
-    dataset_info : DatasetInfo
-        Metadata about the concatenated dataset.
-    source_datasets : list[Dataset]
-        List of original datasets that were concatenated.
-    sample_rate : int, optional
-        Sample rate for audio data, if applicable.
-    output_take_and_give : dict[str, str], optional
-        Mapping of output keys to original dataset keys.
-        This allows for renaming or filtering of columns in the output.
-
     Examples
     --------
     >>> from esp_data.datasets import InsectSet459, BirdSet
@@ -400,6 +386,23 @@ class ConcatenatedDataset(Dataset):
         datasets: list[Dataset] | None = None,
         merge_level: Literal["hard", "overlap", "soft"] = "soft",
     ) -> None:
+        """Initialize the ConcatenatedDataset.
+
+        Parameters
+        ----------
+        datasets : list[Dataset] | None, optional
+            List of datasets to concatenate. If None, an empty dataset will be created.
+        merge_level : {"hard", "overlap", "soft"}, default="soft"
+            Strategy for handling different columns:
+            - "hard": All columns must match exactly across all datasets
+            - "overlap": Keep only common columns across all datasets
+            - "soft": Keep all columns from all datasets (fill missing with NaN)
+
+        Raises
+        ------
+        ValueError
+            If the concatenated dataset is empty after merging.
+        """
         (
             self._data,
             self.info,


### PR DESCRIPTION
- Add a separate workflow that runs docs generation (without pushing) so that we can be sure that we can actually build and deploy the docs
- Fix the docstring issues the were happening here: https://github.com/earthspecies/esp-data/actions/runs/19043480409

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
