### PR TITLE
Added codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @earthspecies/infra-admins


### PR DESCRIPTION
Now that more people are making PRs I want to change ruleset so that you'd need a review from Gagan/me.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
