### PR TITLE
Added hooks to insert datasetinfo into docs

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -145,7 +145,7 @@ The list of available dataset will grow over time. Please refer to the next sect
     options:
         show_root_toc_entry: false
         heading_level: 3
-        order: alphabetical
+        members_order: alphabetical
         filters:
             - "!^[a-z_]"  # Exclude attributes and methods (start with lowercase or underscore)
             - "!^__"      # Exclude private methods (start with double underscore)

--- a/docs/hooks/dataset_info_hook.py
+++ b/docs/hooks/dataset_info_hook.py
@@ -1,0 +1,165 @@
+"""
+MkDocs hook to inject dataset info into documentation.
+
+This hook automatically adds DatasetInfo metadata to each dataset's
+documentation by intercepting the HTML generation process.
+"""
+
+import logging
+import re
+from typing import Any
+
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.structure.files import Files
+from mkdocs.structure.pages import Page
+
+from esp_data.dataset import DatasetInfo
+
+log = logging.getLogger("mkdocs.plugins.dataset_info_hook")
+
+
+def format_dataset_info_html(info: "DatasetInfo", class_name: str) -> str:
+    """Format a dataset's DatasetInfo as HTML.
+
+    Parameters
+    ----------
+    info : DatasetInfo
+        The dataset info object
+    class_name : str
+        The name of the dataset class
+
+    Returns
+    -------
+    str
+        Formatted HTML string
+    """
+    # Format sources
+    if isinstance(info.sources, list):
+        sources_str = ", ".join(info.sources)
+    else:
+        sources_str = info.sources
+
+    # Format split paths - limit display if too many
+    splits_list = list(info.split_paths.keys())
+    if len(splits_list) > 10:
+        splits_display = ", ".join(f"<code>{s}</code>" for s in splits_list[:10])
+        splits_display += f", ... ({len(splits_list)} total)"
+    else:
+        splits_display = ", ".join(f"<code>{s}</code>" for s in splits_list)
+
+    # Build HTML
+    html = []
+    html.append('<details class="dataset-info">')
+    html.append("<summary><strong>📊 Dataset Information</strong></summary>")
+    html.append('<div class="dataset-info-content">')
+    html.append("<table>")
+    html.append("<tbody>")
+    html.append(f"<tr><td><strong>Name</strong></td><td><code>{info.name}</code></td></tr>")
+    html.append(f"<tr><td><strong>Version</strong></td><td><code>{info.version}</code></td></tr>")
+    html.append(f"<tr><td><strong>Owner</strong></td><td>{info.owner}</td></tr>")
+    html.append(f"<tr><td><strong>License</strong></td><td>{info.license}</td></tr>")
+    html.append(f"<tr><td><strong>Sources</strong></td><td>{sources_str}</td></tr>")
+    html.append(f"<tr><td><strong>Available Splits</strong></td><td>{splits_display}</td></tr>")
+    html.append("</tbody>")
+    html.append("</table>")
+
+    if info.description and info.description not in ["[MISSING]", ""]:
+        html.append('<div class="dataset-description">')
+        html.append("<strong>Description:</strong>")
+        html.append(f"<p>{info.description}</p>")
+        html.append("</div>")
+
+    if info.changelog and info.changelog != "":
+        html.append('<div class="dataset-changelog">')
+        html.append("<strong>Changelog:</strong>")
+        html.append(f"<p>{info.changelog}</p>")
+        html.append("</div>")
+
+    html.append("</div>")
+    html.append("</details>")
+
+    return "\n".join(html)
+
+
+def on_page_content(html: str, page: "Page", config: "MkDocsConfig", files: "Files") -> str:
+    """Hook to modify HTML after it's generated.
+
+    This function is called by MkDocs for each page after the HTML is generated.
+    If the page is the datasets page, it injects dataset info after each dataset class heading.
+
+    Parameters
+    ----------
+    html : str
+        The HTML content of the page
+    page : Page
+        The page object
+    config : MkDocsConfig
+        The MkDocs config
+    files : Files
+        All files in the documentation
+
+    Returns
+    -------
+    str
+        Modified HTML content
+    """
+    # Only process the datasets page
+    if page.file.src_path != "datasets.md":
+        return html
+
+    try:
+        # Import here to avoid issues during mkdocs build
+        import esp_data.datasets  # noqa: F401 - ensure all datasets are registered
+        from esp_data.dataset import _dataset_registry
+
+        # Build a mapping of class names to their info HTML
+        dataset_info_map = {}
+        for dataset_class in _dataset_registry.values():
+            class_name = dataset_class.__name__
+            info_html = format_dataset_info_html(dataset_class.info, class_name)
+            dataset_info_map[class_name] = info_html
+
+        # Pattern to find dataset class sections
+        # Looking for <h3 id="esp_data.datasets.ClassName">
+        def inject_after_heading(match: re.Match[str]) -> str:
+            full_match = match.group(0)
+            class_id = match.group(1)  # e.g., "esp_data.datasets.AnimalSpeak"
+
+            # Extract class name from the ID
+            if "." in class_id:
+                class_name = class_id.split(".")[-1]
+            else:
+                class_name = class_id
+
+            if class_name in dataset_info_map:
+                # Inject the dataset info right after the </h3> tag
+                return full_match + "\n" + dataset_info_map[class_name]
+            return full_match
+
+        # Match h3 tags with dataset class IDs
+        pattern = r'<h3[^>]*id="([^"]*datasets\.([^"]+))"[^>]*>.*?</h3>'
+        modified_html = re.sub(pattern, inject_after_heading, html, flags=re.DOTALL)
+
+        log.info(f"Injected dataset info for {len(dataset_info_map)} datasets")
+        return modified_html
+
+    except Exception as e:
+        log.error(f"Failed to inject dataset info: {e}", exc_info=True)
+        return html
+
+
+def on_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Hook called when config is loaded.
+
+    Parameters
+    ----------
+    config : dict[str, Any]
+        The MkDocs configuration
+
+    Returns
+    -------
+    dict[str, Any]
+        The unchanged configuration
+    """
+    log.info("Dataset info hook loaded")
+    return config

--- a/docs/hooks/dataset_info_hook.py
+++ b/docs/hooks/dataset_info_hook.py
@@ -7,7 +7,6 @@ documentation by intercepting the HTML generation process.
 
 import logging
 import re
-from typing import Any
 
 from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.structure.files import Files
@@ -18,15 +17,13 @@ from esp_data.dataset import DatasetInfo
 log = logging.getLogger("mkdocs.plugins.dataset_info_hook")
 
 
-def format_dataset_info_html(info: "DatasetInfo", class_name: str) -> str:
+def format_dataset_info_html(info: "DatasetInfo") -> str:
     """Format a dataset's DatasetInfo as HTML.
 
     Parameters
     ----------
     info : DatasetInfo
         The dataset info object
-    class_name : str
-        The name of the dataset class
 
     Returns
     -------
@@ -116,7 +113,7 @@ def on_page_content(html: str, page: "Page", config: "MkDocsConfig", files: "Fil
         dataset_info_map = {}
         for dataset_class in _dataset_registry.values():
             class_name = dataset_class.__name__
-            info_html = format_dataset_info_html(dataset_class.info, class_name)
+            info_html = format_dataset_info_html(dataset_class.info)
             dataset_info_map[class_name] = info_html
 
         # Pattern to find dataset class sections
@@ -146,20 +143,3 @@ def on_page_content(html: str, page: "Page", config: "MkDocsConfig", files: "Fil
     except Exception as e:
         log.error(f"Failed to inject dataset info: {e}", exc_info=True)
         return html
-
-
-def on_config(config: dict[str, Any]) -> dict[str, Any]:
-    """Hook called when config is loaded.
-
-    Parameters
-    ----------
-    config : dict[str, Any]
-        The MkDocs configuration
-
-    Returns
-    -------
-    dict[str, Any]
-        The unchanged configuration
-    """
-    log.info("Dataset info hook loaded")
-    return config

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,75 @@
+/* Custom styles for dataset information */
+
+.dataset-info {
+    margin: 1rem 0 1.5rem 0;
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-radius: 0.2rem;
+    background-color: var(--md-code-bg-color);
+}
+
+.dataset-info summary {
+    padding: 0.6rem 1rem;
+    cursor: pointer;
+    user-select: none;
+    font-weight: 500;
+    color: var(--md-primary-fg-color);
+}
+
+.dataset-info summary:hover {
+    background-color: var(--md-default-fg-color--lightest);
+}
+
+.dataset-info-content {
+    padding: 0 1rem 1rem 1rem;
+}
+
+.dataset-info table {
+    width: 100%;
+    margin-top: 0.5rem;
+    border-collapse: collapse;
+}
+
+.dataset-info table td {
+    padding: 0.5rem;
+    border-bottom: 1px solid var(--md-default-fg-color--lightest);
+    vertical-align: top;
+}
+
+.dataset-info table td:first-child {
+    width: 30%;
+    font-weight: 500;
+}
+
+.dataset-info table tr:last-child td {
+    border-bottom: none;
+}
+
+.dataset-info code {
+    background-color: var(--md-code-bg-color);
+    padding: 0.1rem 0.3rem;
+    border-radius: 0.2rem;
+    font-size: 0.85em;
+}
+
+.dataset-description,
+.dataset-changelog {
+    margin-top: 1rem;
+    padding: 0.5rem;
+    background-color: var(--md-default-bg-color);
+    border-radius: 0.2rem;
+}
+
+.dataset-description p,
+.dataset-changelog p {
+    margin: 0.5rem 0;
+    line-height: 1.6;
+}
+
+/* Dark mode adjustments */
+[data-md-color-scheme="slate"] .dataset-info {
+    border-color: var(--md-default-fg-color--lightest);
+}
+
+[data-md-color-scheme="slate"] .dataset-info summary:hover {
+    background-color: var(--md-code-bg-color);
+}

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -127,7 +127,6 @@ The `MultiLabelFromFeatures` transform extends the functionality of `LabelFromFe
     options:
         show_root_heading: true
         show_source: true
-        allow_missing_labels: true
 
 ### Subsample Transform
 The `Subsample` transform reduces the size of your dataset by sampling a subset of the data.  Example use case: Creating a 10% random sample of a large dataset for initial testing.

--- a/esp_data/datasets/inaturalist.py
+++ b/esp_data/datasets/inaturalist.py
@@ -76,9 +76,11 @@ class INaturalist(Dataset):
     inaturalist
     >>> print(dataset.available_sample_rates)
     [32000]
-    >>> # Load with pre-resampled 32kHz audio (no on-the-fly resampling needed)
+
+    Load with pre-resampled 32kHz audio (no on-the-fly resampling needed)
     >>> dataset_32k = INaturalist(split="train", sample_rate=32000)
-    >>> # Load with on-the-fly resampling to 16kHz from original (variable rate) files
+
+    Load with on-the-fly resampling to 16kHz from original (variable rate) files
     >>> dataset_16k = INaturalist(split="train", sample_rate=16000)
     """
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,9 @@ plugins:
             show_bases: false
             show_source: true
 
+hooks:
+  - docs/hooks/dataset_info_hook.py
+
 markdown_extensions:
   - admonition
   - pymdownx.details
@@ -70,6 +73,9 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+
+extra_css:
+  - stylesheets/extra.css
 
 extra:
   version:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,9 +97,8 @@ url = "https://oauth2accesstoken@us-central1-python.pkg.dev/okapi-274503/esp-pyp
 publish-url = "https://oauth2accesstoken@us-central1-python.pkg.dev/okapi-274503/esp-pypi/"
 
 [tool.deptry]
-exclude = ["conftest.py", ".venv", "tests", "scripts"]
+exclude = ["conftest.py", ".venv", "tests", "scripts", "docs/hooks/.*"]
 ignore = ["DEP003"]
 
 [tool.deptry.per_rule_ignores]
 DEP002 = ["resampy"]
-DEP004 = ["docs/hooks/.*"]  # Allow dev dependencies (like mkdocs) to be imported in docs/hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,4 @@ ignore = ["DEP003"]
 
 [tool.deptry.per_rule_ignores]
 DEP002 = ["resampy"]
+DEP004 = ["docs/hooks/.*"]  # Allow dev dependencies (like mkdocs) to be imported in docs/hooks


### PR DESCRIPTION
- Also noticed two warnings when running mkdocs locally so fixed those too:
  ```
  Passing extra options directly under `options` is deprecated. Instead, pass them under `options.extra`, and update your templates.
  ```

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
