### PR TITLE
Fix comments in inaturalist doctest

### DIFF
--- a/esp_data/datasets/inaturalist.py
+++ b/esp_data/datasets/inaturalist.py
@@ -76,9 +76,11 @@ class INaturalist(Dataset):
     inaturalist
     >>> print(dataset.available_sample_rates)
     [32000]
-    >>> # Load with pre-resampled 32kHz audio (no on-the-fly resampling needed)
+
+    Load with pre-resampled 32kHz audio (no on-the-fly resampling needed)
     >>> dataset_32k = INaturalist(split="train", sample_rate=32000)
-    >>> # Load with on-the-fly resampling to 16kHz from original (variable rate) files
+
+    Load with on-the-fly resampling to 16kHz from original (variable rate) files
     >>> dataset_16k = INaturalist(split="train", sample_rate=16000)
     """
 


### PR DESCRIPTION
No point in putting comments after `>>`. That would break our document generation logic

<img width="528" height="582" alt="image" src="https://github.com/user-attachments/assets/bf2c7cf9-2c49-4e57-8121-b0f2f8f9eb26" />

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"milad/dataset-info-in-docs","parentHead":"41283bb7a2e22e2b4d76c5872128a002591c0d67","parentPull":160,"trunk":"main"}
```
-->
