### PR TITLE
 suppress ANN401 for dynamically typed *args and **kwargs arguments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ exclude = [
   "tests",
 ]
 
+[tool.ruff.flake8-annotations]
+allow-star-arg-any = true # suppress ANN401 for *args and **kwargs arguments
+
 [tool.ruff.lint]
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
