### PR TITLE
Add job array experiment to benchmark

### DIFF
--- a/jobs/array_jobs/benchmark_latency_array_1.sh
+++ b/jobs/array_jobs/benchmark_latency_array_1.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#SBATCH --partition=cpu
+#SBATCH --cpus-per-task=2
+#SBATCH --output=/home/%u/outputs/latency/%A_1.log
+#SBATCH --job-name="benchmark_latency_array_1"
+#SBATCH --mail-type=FAIL
+#SBATCH --mail-type=END
+
+cd ~/esp-data
+uv sync --group benchmark
+
+srun uv run python scripts/benchmarks/benchmark_latency.py \
+   --log-interval 5 \
+   --max-iterations 1000 \
+   --num-workers 2 \
+   --batch-size 64 \
+   --prefetch-factor 0 \
+   --sleep 0.5 \
+   --config-path scripts/benchmarks/job_array_exp_config.yaml \
+   --data-location bucket \
+   --save "local" \
+   --nb_array 1
+
+
+srun uv run python scripts/benchmarks/benchmark_latency.py \
+    --log-interval 5 \
+    --max-iterations 1000 \
+    --num-workers 2 \
+    --batch-size 64 \
+    --prefetch-factor 0 \
+    --sleep 0.5 \
+    --config-path scripts/benchmarks/job_array_exp_config.yaml \
+    --data-location nfs \
+    --save "local" \
+    --nb_array 1

--- a/jobs/array_jobs/benchmark_latency_array_2.sh
+++ b/jobs/array_jobs/benchmark_latency_array_2.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+#SBATCH --partition=cpu
+#SBATCH --cpus-per-task=2
+#SBATCH --array=1-2
+#SBATCH --output=/home/%u/outputs/latency/%A_%a.log
+#SBATCH --job-name="benchmark_latency_array_2"
+#SBATCH --mail-type=FAIL
+#SBATCH --mail-type=END
+
+cd ~/esp-data
+uv sync --group benchmark
+
+srun uv run python scripts/benchmarks/benchmark_latency.py \
+   --log-interval 5 \
+   --max-iterations 1000 \
+   --num-workers 2 \
+   --batch-size 64 \
+   --prefetch-factor 0 \
+   --sleep 0.5 \
+   --config-path scripts/benchmarks/job_array_exp_config.yaml \
+   --data-location bucket \
+   --save "local" \
+   --nb_array 2
+
+
+srun uv run python scripts/benchmarks/benchmark_latency.py \
+    --log-interval 5 \
+    --max-iterations 1000 \
+    --num-workers 2 \
+    --batch-size 64 \
+    --prefetch-factor 0 \
+    --sleep 0.5 \
+    --config-path scripts/benchmarks/job_array_exp_config.yaml \
+    --data-location nfs \
+    --save "local" \
+    --nb_array 2

--- a/jobs/array_jobs/benchmark_latency_array_4.sh
+++ b/jobs/array_jobs/benchmark_latency_array_4.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+#SBATCH --partition=cpu
+#SBATCH --cpus-per-task=2
+#SBATCH --array=1-4
+#SBATCH --output=/home/%u/outputs/latency/%A_%a.log
+#SBATCH --job-name="benchmark_latency_array_4"
+#SBATCH --mail-type=FAIL
+#SBATCH --mail-type=END
+
+cd ~/esp-data
+uv sync --group benchmark
+
+srun uv run python scripts/benchmarks/benchmark_latency.py \
+   --log-interval 5 \
+   --max-iterations 1000 \
+   --num-workers 2 \
+   --batch-size 64 \
+   --prefetch-factor 0 \
+   --sleep 0.5 \
+   --config-path scripts/benchmarks/job_array_exp_config.yaml \
+   --data-location bucket \
+   --save "local" \
+   --nb_array 4
+
+
+srun uv run python scripts/benchmarks/benchmark_latency.py \
+    --log-interval 5 \
+    --max-iterations 1000 \
+    --num-workers 2 \
+    --batch-size 64 \
+    --prefetch-factor 0 \
+    --sleep 0.5 \
+    --config-path scripts/benchmarks/job_array_exp_config.yaml \
+    --data-location nfs \
+    --save "local" \
+    --nb_array 4

--- a/jobs/array_jobs/benchmark_latency_array_8.sh
+++ b/jobs/array_jobs/benchmark_latency_array_8.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+#SBATCH --partition=cpu
+#SBATCH --cpus-per-task=2
+#SBATCH --array=1-8
+#SBATCH --output=/home/%u/outputs/latency/%A_%a.log
+#SBATCH --job-name="benchmark_latency_array_8"
+#SBATCH --mail-type=FAIL
+#SBATCH --mail-type=END
+
+cd ~/esp-data
+uv sync --group benchmark
+
+srun uv run python scripts/benchmarks/benchmark_latency.py \
+   --log-interval 5 \
+   --max-iterations 1000 \
+   --num-workers 2 \
+   --batch-size 64 \
+   --prefetch-factor 0 \
+   --sleep 0.5 \
+   --config-path scripts/benchmarks/job_array_exp_config.yaml \
+   --data-location bucket \
+   --save "local" \
+   --nb_array 8
+
+
+srun uv run python scripts/benchmarks/benchmark_latency.py \
+    --log-interval 5 \
+    --max-iterations 1000 \
+    --num-workers 2 \
+    --batch-size 64 \
+    --prefetch-factor 0 \
+    --sleep 0.5 \
+    --config-path scripts/benchmarks/job_array_exp_config.yaml \
+    --data-location nfs \
+    --save "local" \
+    --nb_array 8

--- a/jobs/array_jobs/save_and_plot.sh
+++ b/jobs/array_jobs/save_and_plot.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+#SBATCH --partition=cpu
+#SBATCH --cpus-per-task=1
+#SBATCH --output=/home/%u/outputs/latency/%A.log
+#SBATCH --job-name="save_benchmark_latency_array"
+#SBATCH --mail-type=FAIL
+#SBATCH --mail-type=END
+
+cd ~/esp-data
+uv sync --group benchmark
+
+srun uv run python scripts/benchmarks/merge_array_results.py 1
+srun uv run python scripts/benchmarks/merge_array_results.py 2
+srun uv run python scripts/benchmarks/merge_array_results.py 4
+srun uv run python scripts/benchmarks/merge_array_results.py 8
+
+srun uv run python scripts/benchmarks/plot_latency_bench.py \
+    --number-of-samples 30 \
+    --parameter nb_array \
+    --array-exp

--- a/jobs/benchmark_latency_array_exp.sh
+++ b/jobs/benchmark_latency_array_exp.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+#SBATCH --partition=cpu
+#SBATCH --cpus-per-task=1
+#SBATCH --output=/home/%u/outputs/latency/%A.log
+#SBATCH --job-name="benchmark_latency_array"
+#SBATCH --mail-type=FAIL
+#SBATCH --mail-type=END
+
+cd ~/esp-data
+rm -rf scripts/benchmarks/array_*
+uv sync --group benchmark
+
+echo "=== Starting job at $(date) ==="
+
+JOB_1=$(sbatch --parsable jobs/array_jobs/benchmark_latency_array_1.sh)
+# wait for previous jobs to finish
+JOB_2=$(sbatch --parsable --dependency=afterok:$JOB_1 jobs/array_jobs/benchmark_latency_array_2.sh)
+JOB_3=$(sbatch --parsable --dependency=afterok:$JOB_2 jobs/array_jobs/benchmark_latency_array_4.sh)
+JOB_4=$(sbatch --parsable --dependency=afterok:$JOB_3 jobs/array_jobs/benchmark_latency_array_8.sh)
+
+sbatch --dependency=afterok:$JOB_4 jobs/array_jobs/save_and_plot.sh
+echo "=== Finished job at $(date) ==="

--- a/jobs/benchmark_latency_config.sh
+++ b/jobs/benchmark_latency_config.sh
@@ -50,7 +50,7 @@ for nw in "${nw_values[@]}"; do
         --sleep 0.5 \
         --data-location "$DATA_LOCATION" \
         --config-path "$CONFIG" \
-        --save
+        --save "cloud"
 done
 
 num_values=${#nw_values[@]}
@@ -69,7 +69,7 @@ for pf in "${pf_values[@]}"; do
         --sleep 0.5 \
         --data-location "$DATA_LOCATION" \
         --config "$CONFIG" \
-        --save
+        --save "cloud"
 done
 
 num_values=${#pf_values[@]}

--- a/jobs/benchmark_latency_default.sh
+++ b/jobs/benchmark_latency_default.sh
@@ -40,7 +40,7 @@ for nw in "${nw_values[@]}"; do
         --prefetch-factor 0 \
         --sleep 0.5 \
         --dataset-name "$DATASET" \
-        --save
+        --save "cloud"
 done
 
 num_values=${#nw_values[@]}
@@ -58,7 +58,7 @@ for pf in "${pf_values[@]}"; do
         --prefetch-factor $pf \
         --sleep 0.5 \
         --dataset-name "$DATASET" \
-        --save
+        --save "cloud"
 done
 
 num_values=${#pf_values[@]}

--- a/scripts/benchmarks/README.md
+++ b/scripts/benchmarks/README.md
@@ -7,6 +7,7 @@ Note: most benchmark default functionality is currently bucket‑oriented. The e
 Contents
 --------
 - `benchmark_config.yaml` — config file listing the configuration of the experiment settings for `nfs` and `bucket` locations.
+- `job_array_exp_config.yaml` — config file for job array experiments.
 - `benchmark_dataset.py`, `benchmark_latency.py`, `loading_time.py` — main benchmark scripts to measure loading and latency characteristics.
 - `benchmark_utils.py` — shared utilities used by the benchmarks.
 - `dataset_list.txt`, `generate_list.py` — helpers for producing dataset lists used in jobs.
@@ -24,6 +25,13 @@ Quick overview
 - Plots are saved locally to `scripts/benchmarks/fig/`.
 
 You can specify a dataset configuration via a YAML file or use the default configuration.
+
+What's new ? 🚀
+--------------
+- Added support for job array experiments to run multiple experiments in parallel and explore the impact of concurrent jobs on benchmark latency. (NFS and bucket configurations supported.)
+- Added `merge_array_results.py` to merge local results from multiple array jobs into a single CSV file in the cloud.
+- Updated `benchmark_latency.py` to handle array experiments and save results accordingly.
+- Provided a sample configuration file `job_array_exp_config.yaml` for job array experiments.
 
 Cluster-first workflow (SLURM)
 ------------------------------
@@ -97,6 +105,14 @@ info = DatasetInfo(
         ...
 )
 ```
+
+- Job array experiments (new feature):
+```
+sbatch jobs/benchmark_latency_array_exp.sh
+```
+
+You can customize the configuration by editing `scripts/benchmarks/job_array_exp_config.yaml` to specify different datasets and splits.
+You can also modify the job script to change the number of array jobs and other parameters.
 
 Collecting results and plots
 ---------------------------

--- a/scripts/benchmarks/benchmark_latency.py
+++ b/scripts/benchmarks/benchmark_latency.py
@@ -6,11 +6,13 @@ This will load individual samples from bucket or disk.
 """
 
 import logging
+import os
 import time
 import warnings
 from pathlib import Path
 
 import click
+import numpy as np
 import pandas
 import torch
 import torch.multiprocessing as mp
@@ -314,8 +316,17 @@ def benchmark_raw_dataset(
 )
 @click.option(
     "--save",
-    is_flag=True,
-    help="Save results to CSV in GCS bucket after benchmarking",
+    type=str,
+    default=None,
+    show_default=True,
+    help="Save results to CSV in GCS bucket or locally after benchmarking",
+)
+@click.option(
+    "--nb_array",
+    type=int,
+    default=None,
+    show_default=True,
+    help="Number of array experiments that have been run in parallel",
 )
 def main(
     config_path: Path,
@@ -328,7 +339,8 @@ def main(
     batch_size: int,
     dataset_name: str,
     prefetch_factor: int,
-    save: bool,
+    save: str,
+    nb_array: int,
 ) -> None:
     time_stored = {}
     with Timer("loading_time", store=time_stored):
@@ -354,6 +366,7 @@ def main(
             "raw_dataset": True,
             "machine_location": machine_location if data_location == "bucket" else None,
             "bucket_location": bucket_location if data_location == "bucket" else None,
+            "array_exp": nb_array,
         }
         result_df = benchmark_raw_dataset(
             train_ds,
@@ -386,6 +399,7 @@ def main(
             "prefetch_factor": prefetch_factor,
             "machine_location": machine_location if data_location == "bucket" else None,
             "bucket_location": bucket_location if data_location == "bucket" else None,
+            "nb_array": nb_array,
         }
 
         train_dl = build_dataloader(
@@ -408,12 +422,30 @@ def main(
         # Add to our collection of all results
         all_results = pandas.concat([all_results, result_df], ignore_index=True)
 
-    if save:
-        # Define the CSV file path in the bucket
+    if save == "cloud":
         csv_path = "gs://esp-ci-cd-tests/esp-data-tests/benchmark_dataset/benchmark_latency.csv"
 
-        # Save all results to the single CSV file in the bucket
+        if nb_array is not None:
+            logger.info(f"Saving results for array experiment with nb_array={nb_array}")
+            csv_path = (
+                "gs://esp-ci-cd-tests/esp-data-tests/benchmark_dataset/benchmark_latency_array.csv"
+            )
+
         save_results(all_results, csv_path)
+
+    # This option was necessary for array experiments where multiple jobs write to the same file,
+    # because there were conflicts.
+    # This part can definitely be improved.
+    elif save == "local":
+        # Save results locally without replacing if the file exists
+        os.makedirs(f"scripts/benchmarks/array_{nb_array}", exist_ok=True)
+
+        local_csv_path = Path(
+            f"scripts/benchmarks/array_{nb_array}/"
+            f"benchmark_latency_results_{int(time.time() + 1000 * np.random.rand())}.csv"
+        )
+        logger.info(f"Saving results locally to {local_csv_path}")
+        all_results.to_csv(local_csv_path, index=False)
 
 
 if __name__ == "__main__":

--- a/scripts/benchmarks/job_array_exp_config.yaml
+++ b/scripts/benchmarks/job_array_exp_config.yaml
@@ -1,0 +1,15 @@
+# Benchmark configuration for job array experiments
+
+nfs:
+  dataset:
+    dataset_name: beans
+    split: cbi_train
+    sample_rate: 44100
+    data_root: /home/milad_earthspecies_org/data-migration/marius-highmem/mnt/foundation-model-data/
+
+bucket:
+  dataset:
+    dataset_name: beans
+    split: cbi_train
+    sample_rate: 44100
+    data_root: gs://esp-ml-datasets/beans/v0.1.0/raw/

--- a/scripts/benchmarks/merge_array_results.py
+++ b/scripts/benchmarks/merge_array_results.py
@@ -1,0 +1,44 @@
+"""
+Merge local results from multiple array experiments and upload to cloud
+"""
+
+import glob
+from sys import argv
+
+import pandas as pd
+from benchmark_utils import save_results
+
+
+def merge_and_upload_array_results(
+    nb_array: int,
+    local_dir: str = "scripts/benchmarks",
+    cloud_path: str = "gs://esp-ci-cd-tests/esp-data-tests/benchmark_dataset/benchmark_latency_array.csv",
+) -> None:
+    """
+    Merge all local array experiment results into one CSV and upload to cloud.
+
+    Parameters
+    ----------
+    local_dir : str
+        Directory containing array experiment result folders.
+    cloud_path : str
+        GCS path to save the merged results.
+    """
+    # Find all result CSVs in array_* subfolders
+    pattern = f"{local_dir}/array_{nb_array}/benchmark_latency_results*.csv"
+    csv_files = glob.glob(pattern)
+    if not csv_files:
+        print("No array experiment result files found.")
+        return
+
+    # Read and concatenate all results
+    dfs = [pd.read_csv(f) for f in csv_files]
+    merged_df = pd.concat(dfs, ignore_index=True)
+
+    # Save to cloud using your existing utility
+    save_results(merged_df, cloud_path)
+    print(f"Merged {len(csv_files)} files and uploaded to {cloud_path}")
+
+
+if __name__ == "__main__":
+    merge_and_upload_array_results(int(argv[1]))  # Pass nb_array as command line argument

--- a/scripts/benchmarks/plot_latency_bench.py
+++ b/scripts/benchmarks/plot_latency_bench.py
@@ -82,8 +82,8 @@ def main(number_of_samples: int, parameter: str, array_exp: bool) -> None:
             axs[1 + i * 2].set_title(f"Data Location: {data_location}")
         fig.tight_layout()
         # Ensure the fig directory exists
-        os.makedirs("scripts/benchmarks/fig", exist_ok=True)
-        plt.savefig(f"scripts/benchmarks/fig/{name}_latency_{parameter}_array_exp.png")
+        os.makedirs("scripts/benchmarks/fig/latency", exist_ok=True)
+        plt.savefig(f"scripts/benchmarks/fig/latency/{name}_latency_{parameter}_array_exp.png")
 
     else:
         df = pd.read_csv(
@@ -136,8 +136,10 @@ def main(number_of_samples: int, parameter: str, array_exp: bool) -> None:
         )
         plt.tight_layout()
         # Ensure the fig directory exists
-        os.makedirs("scripts/benchmarks/fig", exist_ok=True)
-        plt.savefig(f"scripts/benchmarks/fig/{name}_latency_{parameter}_{value1}_{value2}.png")
+        os.makedirs("scripts/benchmarks/fig/latency", exist_ok=True)
+        plt.savefig(
+            f"scripts/benchmarks/fig/latency/{name}_latency_{parameter}_{value1}_{value2}.png"
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/benchmarks/plot_latency_bench.py
+++ b/scripts/benchmarks/plot_latency_bench.py
@@ -26,54 +26,118 @@ set_logging_config()
     show_default=True,
     help="Parameter to plot against latency results",
 )
-def main(number_of_samples: int, parameter: str) -> None:
+@click.option(
+    "--array-exp",
+    is_flag=True,
+    help="Indicates this is part of a job array experiment",
+)
+def main(number_of_samples: int, parameter: str, array_exp: bool) -> None:
     """Retrieve and plot benchmark latency results from a CSV file in a GCS bucket."""
-    df = pd.read_csv("gs://esp-ci-cd-tests/esp-data-tests/benchmark_dataset/benchmark_latency.csv")
-    if number_of_samples is not None:
-        df = df.tail(number_of_samples)
+    if array_exp:
+        df = pd.read_csv(
+            "gs://esp-ci-cd-tests/esp-data-tests/benchmark_dataset/benchmark_latency_array.csv"
+        )
+        if number_of_samples is not None:
+            df = df.tail(number_of_samples)
 
-    name = df["dataset_name"].iloc[0]
-    parameters = ["num_workers", "batch_size", "prefetch_factor"]
+        name = df["dataset_name"].iloc[0]
+        num_workers = df["num_workers"].iloc[0]
+        batch_size = df["batch_size"].iloc[0]
+        prefetch_factor = df["prefetch_factor"].iloc[0]
+        num_locations = len(df["data_location"].unique())
+        fig, axs = plt.subplots(num_locations * 2, figsize=(8, 6 * num_locations))
+        fig.suptitle(
+            f"Latency {parameter.capitalize()} Results - "
+            f"Num Workers = {num_workers}, Batch Size = {batch_size},"
+            f"Prefetch Factor = {prefetch_factor}"
+        )
+        for i, data_location in enumerate(df["data_location"].unique()):
+            df_location = df[df["data_location"] == data_location]
+            df_speed = (
+                df_location["nominal_speed"].groupby(df_location[parameter]).mean().reset_index()
+            )
+            df_time = df_location["total_time"].groupby(df_location[parameter]).mean().reset_index()
+            axs[0 + i * 2].plot(
+                df_speed[parameter],
+                df_speed["nominal_speed"],
+                marker="o",
+                label=data_location,
+            )
+            axs[0 + i * 2].set_xlabel(parameter)
+            axs[0 + i * 2].set_xticks(df_speed[parameter])
+            axs[0 + i * 2].set_ylabel("Nominal Speed (samples/second)")
+            # set grid
+            axs[0 + i * 2].grid(True)
+            axs[0 + i * 2].set_title(f"Data Location: {data_location}")
+            axs[1 + i * 2].plot(
+                df_time[parameter],
+                df_time["total_time"],
+                marker="o",
+                label=data_location,
+            )
+            axs[1 + i * 2].set_xlabel(parameter)
+            axs[1 + i * 2].set_xticks(df_time[parameter])
+            axs[1 + i * 2].set_ylabel("Total Time (seconds)")
+            axs[1 + i * 2].grid(True)
+            axs[1 + i * 2].set_title(f"Data Location: {data_location}")
+        fig.tight_layout()
+        # Ensure the fig directory exists
+        os.makedirs("scripts/benchmarks/fig", exist_ok=True)
+        plt.savefig(f"scripts/benchmarks/fig/{name}_latency_{parameter}_array_exp.png")
 
-    other_params = [p for p in parameters if p != parameter]
-    param1 = other_params[0]
-    value1 = df[param1].iloc[0]
-    param2 = other_params[1]
-    value2 = df[param2].iloc[0]
+    else:
+        df = pd.read_csv(
+            "gs://esp-ci-cd-tests/esp-data-tests/benchmark_dataset/benchmark_latency.csv"
+        )
+        if number_of_samples is not None:
+            df = df.tail(number_of_samples)
 
-    # replace Nan with -1 to be able to sort, but label should show "None"
-    df.replace({float("nan"): -1}, inplace=True)
-    print(df[parameter])
-    labels = [x if x != -1 else "None" for x in df.sort_values(parameter)[parameter]]
-    fig, axs = plt.subplots(1, 2, figsize=(10, 6))
+        name = df["dataset_name"].iloc[0]
+        parameters = ["num_workers", "batch_size", "prefetch_factor"]
 
-    axs[0].set_title("Nominal Speed")
-    axs[0].set_xlabel(parameter)
-    axs[0].set_xticks(df.sort_values(parameter)[parameter])
-    axs[0].set_xticklabels(labels)
-    axs[0].set_ylabel("Nominal Speed (samples/second)")
-    axs[0].plot(
-        df.sort_values(parameter)[parameter], df.sort_values(parameter)["nominal_speed"], marker="o"
-    )
-    axs[0].grid(True)
+        other_params = [p for p in parameters if p != parameter]
+        param1 = other_params[0]
+        value1 = df[param1].iloc[0]
+        param2 = other_params[1]
+        value2 = df[param2].iloc[0]
 
-    axs[1].set_title("Total Time")
-    axs[1].set_xlabel(parameter)
-    axs[1].set_xticks(df.sort_values(parameter)[parameter])
-    axs[1].set_xticklabels(labels)
-    axs[1].set_ylabel("Total Time (seconds)")
-    axs[1].plot(
-        df.sort_values(parameter)[parameter], df.sort_values(parameter)["total_time"], marker="o"
-    )
-    axs[1].grid(True)
-    plt.suptitle(
-        f"Latency {parameter.capitalize()} Results - {param1.capitalize()} = {value1}, "
-        f"{param2.capitalize()} = {value2}"
-    )
-    plt.tight_layout()
-    # Ensure the fig directory exists
-    os.makedirs("scripts/benchmarks/fig", exist_ok=True)
-    plt.savefig(f"scripts/benchmarks/fig/{name}_latency_{parameter}_{value1}_{value2}.png")
+        # replace Nan with -1 to be able to sort, but label should show "None"
+        df.replace({float("nan"): -1}, inplace=True)
+        print(df[parameter])
+        labels = [x if x != -1 else "None" for x in df.sort_values(parameter)[parameter]]
+        fig, axs = plt.subplots(1, 2, figsize=(10, 6))
+
+        axs[0].set_title("Nominal Speed")
+        axs[0].set_xlabel(parameter)
+        axs[0].set_xticks(df.sort_values(parameter)[parameter])
+        axs[0].set_xticklabels(labels)
+        axs[0].set_ylabel("Nominal Speed (samples/second)")
+        axs[0].plot(
+            df.sort_values(parameter)[parameter],
+            df.sort_values(parameter)["nominal_speed"],
+            marker="o",
+        )
+        axs[0].grid(True)
+
+        axs[1].set_title("Total Time")
+        axs[1].set_xlabel(parameter)
+        axs[1].set_xticks(df.sort_values(parameter)[parameter])
+        axs[1].set_xticklabels(labels)
+        axs[1].set_ylabel("Total Time (seconds)")
+        axs[1].plot(
+            df.sort_values(parameter)[parameter],
+            df.sort_values(parameter)["total_time"],
+            marker="o",
+        )
+        axs[1].grid(True)
+        plt.suptitle(
+            f"Latency {parameter.capitalize()} Results - {param1.capitalize()} = {value1}, "
+            f"{param2.capitalize()} = {value2}"
+        )
+        plt.tight_layout()
+        # Ensure the fig directory exists
+        os.makedirs("scripts/benchmarks/fig", exist_ok=True)
+        plt.savefig(f"scripts/benchmarks/fig/{name}_latency_{parameter}_{value1}_{value2}.png")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Job array experiment to explore the impact of parallel jobs on latency.

Most changes are new jobs scripts for different array sizes, it may not be the best way to do.

-> The job array experiment is quite independent from previous benchmark experiments. 