### PR TITLE
audio-language transform

### DIFF
--- a/esp_data/transforms/__init__.py
+++ b/esp_data/transforms/__init__.py
@@ -1,6 +1,7 @@
 # Has to be first because individual transform modules import register_transform
 from .registry import register_transform, transform_from_config  # isort:skip
 
+from .audio_language import AudioLanguage, AudioLanguageConfig
 from .deduplicate import Deduplicate, DeduplicateConfig
 from .filter import Filter, FilterConfig
 from .label_from_feature import LabelFromFeature, LabelFromFeatureConfig
@@ -12,6 +13,8 @@ from .subsample import Subsample, SubsampleConfig
 from .uniform_sample import UniformSample, UniformSampleConfig
 
 __all__ = [
+    "AudioLanguage",
+    "AudioLanguageConfig",
     "Deduplicate",
     "DeduplicateConfig",
     "Filter",
@@ -26,4 +29,6 @@ __all__ = [
     "UniformSampleConfig",
     "register_transform",
     "transform_from_config",
+    "Deduplicate",
+    "DeduplicateConfig",
 ]

--- a/esp_data/transforms/audio_language.py
+++ b/esp_data/transforms/audio_language.py
@@ -1,0 +1,82 @@
+"""Audio-language dataset transformation."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+from esp_data.backends.protocol import DataBackend
+from esp_data.prompts import (
+    PromptResponseTemplate,
+    PromptResponseTemplateConfig,
+    get_prompt,
+)
+
+from . import register_transform
+
+
+class AudioLanguageConfig(BaseModel):
+    """Configuration for the AudioLanguage transform.
+
+    Parameters
+    ----------
+    type : Literal["audio_language"]
+        Must be "audio_language" for transform registry.
+    prompt : str | PromptResponseTemplateConfig | None
+        Prompt template name, inline config, or None for passthrough.
+    seed : int | None
+        Random seed for stochastic variant selection.
+    """
+
+    type: Literal["audio_language"]
+    prompt: str | PromptResponseTemplateConfig | None = None
+    seed: int | None = None
+
+
+class AudioLanguage:
+    """Transform to add 'prompt' and 'response' columns using a prompt template.
+
+    Parameters
+    ----------
+    prompt : str | PromptResponseTemplateConfig | None
+        - str: Name of a registered prompt template
+        - PromptResponseTemplateConfig: Inline prompt configuration with variants
+        - None: Use passthrough (copies existing prompt/response fields)
+    seed : int | None
+        Random seed for reproducible stochastic variant selection.
+    """
+
+    def __init__(
+        self,
+        prompt: str | PromptResponseTemplateConfig | None = None,
+        seed: int | None = None,
+    ) -> None:
+        if prompt is None:
+            self.template = get_prompt("passthrough")
+        elif isinstance(prompt, str):
+            self.template = get_prompt(prompt)
+        else:
+            self.template = PromptResponseTemplate(
+                name=prompt.name, variants=prompt.variants, seed=seed
+            )
+
+    @classmethod
+    def from_config(cls, cfg: AudioLanguageConfig) -> AudioLanguage:
+        return cls(prompt=cfg.prompt, seed=cfg.seed)
+
+    def __call__(self, backend: DataBackend) -> tuple[DataBackend, dict]:
+        prompts, responses = [], []
+
+        for row in backend:
+            result = self.template(row)
+            prompts.append(result["prompt"])
+            responses.append(result["response"])
+
+        backend = backend.add_column("prompt", prompts).add_column("response", responses)
+        metadata = {"prompt_template": self.template.name, "num_rows": len(prompts)}
+
+        return backend, metadata
+
+
+register_transform(AudioLanguageConfig, AudioLanguage)

--- a/tests/test_audio_language_transform.py
+++ b/tests/test_audio_language_transform.py
@@ -1,0 +1,395 @@
+"""Tests for AudioLanguage transform."""
+
+import json
+
+import polars as pl
+import pytest
+
+from esp_data.backends import PolarsBackend
+from esp_data.prompts import (
+    Message,
+    PromptResponsePair,
+    PromptResponseTemplate,
+    PromptResponseTemplateConfig,
+    register_prompt,
+)
+from esp_data.prompts.registry import _REGISTRY
+from esp_data.transforms import AudioLanguage, AudioLanguageConfig
+
+
+# --- Fixtures ---
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Clean up registry before and after each test."""
+    original = set(_REGISTRY.keys())
+    yield
+    # Remove any test prompts added during test
+    for name in list(_REGISTRY.keys()):
+        if name not in original:
+            del _REGISTRY[name]
+
+
+@pytest.fixture
+def species_prompt_config() -> PromptResponseTemplateConfig:
+    """Create a species identification prompt config."""
+    return PromptResponseTemplateConfig(
+        name="test_species",
+        variants=[
+            PromptResponsePair(
+                messages=[Message(role="user", content="What species is this?")],
+                response="{{ species_common }}",
+                task="species_id",
+            ),
+            PromptResponsePair(
+                messages=[Message(role="user", content="Identify the species.")],
+                response="{{ species_common }}",
+                task="species_id",
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def registered_species_prompt(species_prompt_config) -> PromptResponseTemplate:
+    """Register and return a species prompt template."""
+    template = PromptResponseTemplate(
+        name=species_prompt_config.name,
+        variants=species_prompt_config.variants,
+        seed=42,
+    )
+    try:
+        register_prompt(template)
+    except ValueError:
+        pass  # Already registered
+    return template
+
+
+@pytest.fixture
+def mock_backend() -> PolarsBackend:
+    """Create a mock backend with sample data."""
+    df = pl.DataFrame(
+        {
+            "audio_path": [
+                "/path/to/audio1.wav",
+                "/path/to/audio2.wav",
+                "/path/to/audio3.wav",
+            ],
+            "species_common": ["American Robin", "Blue Jay", "Cardinal"],
+            "behavior": ["song", "call", "alarm"],
+            "duration": [5.0, 3.2, 4.1],
+        }
+    )
+    return PolarsBackend(df)
+
+
+@pytest.fixture
+def native_al_backend() -> PolarsBackend:
+    """Create a backend that already has prompt/response fields (native AL dataset)."""
+    df = pl.DataFrame(
+        {
+            "audio_path": ["/path/to/audio1.wav", "/path/to/audio2.wav"],
+            "prompt": ["Describe this sound.", "What is this?"],
+            "response": ["A bird singing.", "An alarm call."],
+        }
+    )
+    return PolarsBackend(df)
+
+
+# --- Test AudioLanguageConfig ---
+
+
+class TestAudioLanguageConfig:
+    """Tests for AudioLanguageConfig model."""
+
+    def test_with_prompt_name(self) -> None:
+        """Test config with prompt name string."""
+        config = AudioLanguageConfig(type="audio_language", prompt="species_common")
+        assert config.type == "audio_language"
+        assert config.prompt == "species_common"
+
+    def test_with_prompt_config(self) -> None:
+        """Test config with inline PromptResponseTemplateConfig."""
+        prompt_config = PromptResponseTemplateConfig(
+            name="inline_prompt",
+            variants=[
+                PromptResponsePair(
+                    messages=[Message(role="user", content="Q?")],
+                    response="{{ a }}",
+                )
+            ],
+        )
+        config = AudioLanguageConfig(type="audio_language", prompt=prompt_config)
+        assert config.prompt == prompt_config
+
+    def test_with_prompt_none(self) -> None:
+        """Test config with prompt=None defaults to passthrough."""
+        config = AudioLanguageConfig(type="audio_language", prompt=None)
+        assert config.prompt is None
+
+    def test_with_seed(self) -> None:
+        """Test config with seed for stochastic variant selection."""
+        config = AudioLanguageConfig(type="audio_language", prompt="test", seed=42)
+        assert config.seed == 42
+
+
+# --- Test AudioLanguage Transform ---
+
+
+class TestAudioLanguage:
+    """Tests for AudioLanguage transform."""
+
+    def test_init_with_prompt_name(self, registered_species_prompt) -> None:
+        """Test initialization with registered prompt name."""
+        transform = AudioLanguage(prompt="test_species")
+        assert transform.template.name == "test_species"
+
+    def test_init_with_prompt_config(self) -> None:
+        """Test initialization with PromptResponseTemplateConfig."""
+        config = PromptResponseTemplateConfig(
+            name="direct_config",
+            variants=[
+                PromptResponsePair(
+                    messages=[Message(role="user", content="What?")],
+                    response="{{ answer }}",
+                )
+            ],
+        )
+        transform = AudioLanguage(prompt=config)
+        assert transform.template.name == "direct_config"
+
+    def test_init_with_none_uses_passthrough(self) -> None:
+        """Test that prompt=None uses passthrough template."""
+        transform = AudioLanguage(prompt=None)
+        assert transform.template.name == "passthrough"
+
+    def test_init_default_is_passthrough(self) -> None:
+        """Test that default (no args) uses passthrough template."""
+        transform = AudioLanguage()
+        assert transform.template.name == "passthrough"
+
+    def test_from_config(self, registered_species_prompt) -> None:
+        """Test creating transform from AudioLanguageConfig."""
+        config = AudioLanguageConfig(type="audio_language", prompt="test_species")
+        transform = AudioLanguage.from_config(config)
+        assert transform.template.name == "test_species"
+
+    def test_from_config_with_none(self) -> None:
+        """Test from_config with prompt=None uses passthrough."""
+        config = AudioLanguageConfig(type="audio_language", prompt=None)
+        transform = AudioLanguage.from_config(config)
+        assert transform.template.name == "passthrough"
+
+    def test_unknown_prompt_raises(self) -> None:
+        """Test that unknown prompt name raises KeyError."""
+        with pytest.raises(KeyError):
+            AudioLanguage(prompt="nonexistent_prompt_xyz")
+
+    def test_call_adds_columns(
+        self, mock_backend, registered_species_prompt
+    ) -> None:
+        """Test that transform adds prompt and response columns."""
+        transform = AudioLanguage(prompt="test_species")
+        new_backend, metadata = transform(mock_backend)
+
+        assert "prompt" in new_backend.columns
+        assert "response" in new_backend.columns
+        # Original columns preserved
+        assert "audio_path" in new_backend.columns
+        assert "species_common" in new_backend.columns
+
+    def test_call_returns_metadata(
+        self, mock_backend, registered_species_prompt
+    ) -> None:
+        """Test that transform returns correct metadata."""
+        transform = AudioLanguage(prompt="test_species")
+        _, metadata = transform(mock_backend)
+
+        assert metadata["prompt_template"] == "test_species"
+        assert metadata["num_rows"] == 3
+
+    def test_prompt_content(self, mock_backend, registered_species_prompt) -> None:
+        """Test that prompt column contains correct JSON structure."""
+        transform = AudioLanguage(prompt="test_species")
+        new_backend, _ = transform(mock_backend)
+
+        row = new_backend[0]
+        prompt_msgs = json.loads(row["prompt"])
+
+        assert len(prompt_msgs) == 1
+        assert prompt_msgs[0]["role"] == "user"
+        assert prompt_msgs[0]["content"] in [
+            "What species is this?",
+            "Identify the species.",
+        ]
+
+    def test_response_content(self, mock_backend, registered_species_prompt) -> None:
+        """Test that response column contains rendered response."""
+        transform = AudioLanguage(prompt="test_species")
+        new_backend, _ = transform(mock_backend)
+
+        # Check each row has correct species in response
+        expected_species = ["American Robin", "Blue Jay", "Cardinal"]
+        for i, species in enumerate(expected_species):
+            row = new_backend[i]
+            assert row["response"] == species
+
+    def test_preserves_row_count(
+        self, mock_backend, registered_species_prompt
+    ) -> None:
+        """Test that transform preserves row count."""
+        transform = AudioLanguage(prompt="test_species")
+        new_backend, _ = transform(mock_backend)
+
+        assert len(new_backend) == len(mock_backend)
+
+    def test_passthrough_template(self, native_al_backend) -> None:
+        """Test passthrough template with native AL data."""
+        transform = AudioLanguage(prompt="passthrough")
+        new_backend, metadata = transform(native_al_backend)
+
+        row = new_backend[0]
+        prompt_msgs = json.loads(row["prompt"])
+
+        # Passthrough renders the original prompt field into user message
+        assert prompt_msgs[0]["content"] == "Describe this sound."
+        assert row["response"] == "A bird singing."
+
+    def test_passthrough_default(self, native_al_backend) -> None:
+        """Test that prompt=None uses passthrough."""
+        transform = AudioLanguage()  # No prompt specified
+        new_backend, _ = transform(native_al_backend)
+
+        row = new_backend[0]
+        prompt_msgs = json.loads(row["prompt"])
+        assert prompt_msgs[0]["content"] == "Describe this sound."
+        assert row["response"] == "A bird singing."
+
+    def test_multi_turn_prompt(self, mock_backend) -> None:
+        """Test transform with multi-turn conversation prompt."""
+        pair = PromptResponsePair(
+            messages=[
+                Message(role="system", content="You are a bioacoustics expert."),
+                Message(role="user", content="What species is in this audio?"),
+            ],
+            response="{{ species_common }}",
+        )
+        template = PromptResponseTemplate(name="multi_turn_test", variants=[pair])
+        register_prompt(template)
+
+        transform = AudioLanguage(prompt="multi_turn_test")
+        new_backend, _ = transform(mock_backend)
+
+        row = new_backend[0]
+        prompt_msgs = json.loads(row["prompt"])
+
+        assert len(prompt_msgs) == 2
+        assert prompt_msgs[0]["role"] == "system"
+        assert prompt_msgs[1]["role"] == "user"
+        assert row["response"] == "American Robin"
+
+    def test_iteration_over_backend(
+        self, mock_backend, registered_species_prompt
+    ) -> None:
+        """Test that transform correctly iterates over all backend rows."""
+        transform = AudioLanguage(prompt="test_species")
+        new_backend, _ = transform(mock_backend)
+
+        rows = list(new_backend)
+        assert len(rows) == 3
+
+        for row in rows:
+            assert "prompt" in row
+            assert "response" in row
+            assert row["response"] in ["American Robin", "Blue Jay", "Cardinal"]
+
+    def test_inline_config_deterministic_with_seed(self, mock_backend) -> None:
+        """Test that inline PromptResponseTemplateConfig with seed is deterministic."""
+        config = PromptResponseTemplateConfig(
+            name="inline_test",
+            variants=[
+                PromptResponsePair(
+                    messages=[Message(role="user", content="Variant A")],
+                    response="{{ species_common }}",
+                ),
+                PromptResponsePair(
+                    messages=[Message(role="user", content="Variant B")],
+                    response="{{ species_common }}",
+                ),
+            ],
+        )
+
+        # With seed, should be deterministic
+        transform1 = AudioLanguage(prompt=config, seed=123)
+        backend1, _ = transform1(mock_backend)
+
+        transform2 = AudioLanguage(prompt=config, seed=123)
+        backend2, _ = transform2(mock_backend)
+
+        for i in range(len(mock_backend)):
+            assert json.loads(backend1[i]["prompt"]) == json.loads(
+                backend2[i]["prompt"]
+            )
+
+
+# --- Test Integration with Backend Operations ---
+
+
+class TestAudioLanguageIntegration:
+    """Integration tests for AudioLanguage with backend operations."""
+
+    def test_chain_with_filter(self, mock_backend, registered_species_prompt) -> None:
+        """Test chaining AudioLanguage after a filter operation."""
+        from esp_data.transforms import Filter
+
+        # First filter to only Robin
+        filter_transform = Filter(
+            property="species_common", values=["American Robin"], mode="include"
+        )
+        filtered_backend, _ = filter_transform(mock_backend)
+
+        # Then apply audio language transform
+        al_transform = AudioLanguage(prompt="test_species")
+        new_backend, metadata = al_transform(filtered_backend)
+
+        assert len(new_backend) == 1
+        assert new_backend[0]["response"] == "American Robin"
+
+    def test_empty_backend(self, registered_species_prompt) -> None:
+        """Test transform handles empty backend."""
+        empty_df = pl.DataFrame(
+            {
+                "audio_path": [],
+                "species_common": [],
+            }
+        )
+        empty_backend = PolarsBackend(empty_df)
+
+        transform = AudioLanguage(prompt="test_species")
+        new_backend, metadata = transform(empty_backend)
+
+        assert len(new_backend) == 0
+        assert metadata["num_rows"] == 0
+        assert "prompt" in new_backend.columns
+        assert "response" in new_backend.columns
+
+    def test_with_pandas_backend(self, registered_species_prompt) -> None:
+        """Test transform works with pandas backend."""
+        import pandas as pd
+
+        from esp_data.backends import PandasBackend
+
+        df = pd.DataFrame(
+            {
+                "audio_path": ["/path/to/audio.wav"],
+                "species_common": ["Test Species"],
+            }
+        )
+        backend = PandasBackend(df)
+
+        transform = AudioLanguage(prompt="test_species")
+        new_backend, _ = transform(backend)
+
+        assert "prompt" in new_backend.columns
+        assert new_backend[0]["response"] == "Test Species"


### PR DESCRIPTION
Adds a transform to convert any dataset into an audio-language one, adding prompt and response templates.

[TO BE CLOSED AFTER DISCUSSION, MOVED TO ESP-RESEARCH]


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"david-audio-language","parentHead":"2a44fea98953acf78cb56c565cb66c53113fafdb","parentPull":195,"trunk":"main"}
```
-->
