### PR TITLE
Add infantmarmosetsvox dataset

### DIFF
--- a/esp_data/datasets/__init__.py
+++ b/esp_data/datasets/__init__.py
@@ -15,9 +15,9 @@ from .esp_raincoast import ESPRaincoast
 from .geladas import Geladas
 from .giant_otters import GiantOtters
 from .gibbon_solos import GibbonSolos
-from .infant_marmosets_vox import InfantMarmosetsVox
 from .hawaiian_birds import HawaiianBirds
 from .inaturalist import INaturalist
+from .infant_marmosets_vox import InfantMarmosetsVox
 from .insectset_459 import InsectSet459
 from .littleowl_id import LittleOwlId
 from .macaques_coo_calls import MacaquesCooCalls

--- a/esp_data/datasets/__init__.py
+++ b/esp_data/datasets/__init__.py
@@ -15,6 +15,7 @@ from .esp_raincoast import ESPRaincoast
 from .geladas import Geladas
 from .giant_otters import GiantOtters
 from .gibbon_solos import GibbonSolos
+from .infantmarmosetsvox import InfantMarmosetsVox
 from .hawaiian_birds import HawaiianBirds
 from .inaturalist import INaturalist
 from .insectset_459 import InsectSet459
@@ -66,4 +67,5 @@ __all__ = [
     "Geladas",
     "DinardoDolphinWhistles",
     "GibbonSolos",
+    "InfantMarmosetsVox",
 ]

--- a/esp_data/datasets/__init__.py
+++ b/esp_data/datasets/__init__.py
@@ -15,7 +15,7 @@ from .esp_raincoast import ESPRaincoast
 from .geladas import Geladas
 from .giant_otters import GiantOtters
 from .gibbon_solos import GibbonSolos
-from .infantmarmosetsvox import InfantMarmosetsVox
+from .infant_marmosets_vox import InfantMarmosetsVox
 from .hawaiian_birds import HawaiianBirds
 from .inaturalist import INaturalist
 from .insectset_459 import InsectSet459

--- a/esp_data/datasets/infant_marmosets_vox.py
+++ b/esp_data/datasets/infant_marmosets_vox.py
@@ -11,7 +11,7 @@ import polars as pl
 
 from esp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
 from esp_data.backends import BackendType, PolarsBackend
-from esp_data.io import AnyPathT, anypath
+from esp_data.io import AnyPathT, anypath, audio_stereo_to_mono, read_audio
 
 
 # Call type mapping (0-10, excluding 11=silence and 12=noise)
@@ -266,19 +266,23 @@ class InfantMarmosetsVox(Dataset):
         """
         # Determine which audio directory to use based on requested sample rate
         # CSV path is like "data/audio_44k/twin_X/file.wav"
-        rel_path = row["path"]
+        audio_rel_path = row["path"]
 
         if self.sample_rate is not None and self.sample_rate in self._sample_rate_paths:
             # Use pre-resampled audio - replace "audio_44k" with appropriate subdirectory
             audio_subdir = self._sample_rate_paths[self.sample_rate]
-            rel_path = rel_path.replace("audio_44k", audio_subdir, 1)
+            audio_rel_path = audio_rel_path.replace("audio_44k", audio_subdir, 1)
 
-        audio_path = anypath(self.data_root) / rel_path
+        audio_path = anypath(self.data_root) / audio_rel_path
         start = float(row["start"])
         end = float(row["end"])
 
-        audio, sr = librosa.load(str(audio_path), sr=None, mono=True, offset=start, duration=end - start)
-
+        # Read the audio clip
+        audio, sr = read_audio(audio_path, start_time=start, end_time=end)
+        audio = audio.astype(np.float32)
+        # Stereo to mono if necessary.
+        audio = audio_stereo_to_mono(audio, mono_method="average")
+        # Normalize
         max_abs = np.max(np.abs(audio))
         if max_abs > 0:
             audio = audio / max_abs
@@ -288,6 +292,7 @@ class InfantMarmosetsVox(Dataset):
             audio = librosa.resample(y=audio, orig_sr=sr, target_sr=self.sample_rate, res_type="kaiser_best")
 
         row["audio"] = audio
+        row["path"] = audio_rel_path  # Update path to reflect actual file loaded
 
         if self.output_take_and_give:
             return {value: row[key] for key, value in self.output_take_and_give.items()}

--- a/esp_data/datasets/infant_marmosets_vox.py
+++ b/esp_data/datasets/infant_marmosets_vox.py
@@ -77,17 +77,26 @@ class InfantMarmosetsVox(Dataset):
         owner="eklavya",
         split_paths={
             # Single split - downstream users handle train/val/test splitting
-            "all": "gs://esp-ml-datasets/InfantMarmosetsVox/labels.csv",
+            "all": "gs://esp-ml-datasets/infant_marmosets_vox/labels.csv",
         },
         version="0.1.0",
         description=(
             "Infant marmoset vocalizations dataset. Contains 11 call types from "
             "10 individuals (5 twin pairs) recorded longitudinally over 8 months. "
-            "Approx. 73k vocalization segments after filtering silence/noise."
+            "Approx. 73k vocalization segments after filtering silence/noise. "
+            "Available at original 44.1kHz and pre-resampled 16kHz."
         ),
         sources=["Zenodo"],
         license="CC-BY-4.0",
     )
+
+    # Mapping of sample rates to audio subdirectory names
+    # CSV paths are like "data/audio_44k/twin_X/file.wav"
+    # We replace "audio_44k" with the appropriate subdirectory
+    _sample_rate_paths = {
+        44100: "audio_44k",  # Original 44.1kHz
+        16000: "audio_16k",  # Pre-resampled to 16kHz
+    }
 
     def __init__(
         self,
@@ -139,6 +148,19 @@ class InfantMarmosetsVox(Dataset):
         """Return the available splits of the dataset."""
         return list(self.info.split_paths.keys())
 
+    @property
+    def available_sample_rates(self) -> list[int]:
+        """Return the available pre-resampled sample rates.
+
+        Returns
+        -------
+        list[int]
+            List of sample rates (in Hz) for which pre-resampled audio is available.
+            Audio at these sample rates can be loaded directly without on-the-fly
+            resampling. Original audio is at 44100 Hz.
+        """
+        return list(self._sample_rate_paths.keys())
+
     def _load(self) -> None:
         """Load and preprocess the dataset.
 
@@ -159,7 +181,7 @@ class InfantMarmosetsVox(Dataset):
         df = pl.read_csv(location)
 
         # Extract twinID and per-file caller index from path
-        # path: "data/twin_1/20160907_Twin1_marmoset1.wav"
+        # path: "data/audio_44k/twin_1/20160907_Twin1_marmoset1.wav"
         # The "1" in "marmoset1" is the per-file caller (1 or 2)
         df = df.with_columns([
             pl.col("path").str.split("/").list.get(-1).str.replace(".wav", "").alias("filename"),
@@ -242,7 +264,16 @@ class InfantMarmosetsVox(Dataset):
         dict
             The processed sample with audio loaded.
         """
-        audio_path = anypath(self.data_root) / row["path"]
+        # Determine which audio directory to use based on requested sample rate
+        # CSV path is like "data/audio_44k/twin_X/file.wav"
+        rel_path = row["path"]
+
+        if self.sample_rate is not None and self.sample_rate in self._sample_rate_paths:
+            # Use pre-resampled audio - replace "audio_44k" with appropriate subdirectory
+            audio_subdir = self._sample_rate_paths[self.sample_rate]
+            rel_path = rel_path.replace("audio_44k", audio_subdir, 1)
+
+        audio_path = anypath(self.data_root) / rel_path
         start = float(row["start"])
         end = float(row["end"])
 
@@ -252,6 +283,7 @@ class InfantMarmosetsVox(Dataset):
         if max_abs > 0:
             audio = audio / max_abs
 
+        # Resample on-the-fly if requested sample rate doesn't have pre-resampled version
         if self.sample_rate is not None and sr != self.sample_rate:
             audio = librosa.resample(y=audio, orig_sr=sr, target_sr=self.sample_rate, res_type="kaiser_best")
 

--- a/esp_data/datasets/infant_marmosets_vox.py
+++ b/esp_data/datasets/infant_marmosets_vox.py
@@ -7,10 +7,9 @@ from typing import Any, Dict, Iterator
 
 import librosa
 import numpy as np
-import polars as pl
 
 from esp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
-from esp_data.backends import BackendType, PolarsBackend
+from esp_data.backends import BackendType
 from esp_data.io import AnyPathT, anypath, audio_stereo_to_mono, read_audio
 
 # Call type mapping (0-10, excluding 11=silence and 12=noise)
@@ -91,29 +90,23 @@ class InfantMarmosetsVox(Dataset):
         owner="eklavya",
         split_paths={
             "all": "gs://esp-ml-datasets/infant_marmosets_vox/labels.csv",
-            "train": "gs://esp-ml-datasets/infant_marmosets_vox/labels_train.csv",
-            "validation": "gs://esp-ml-datasets/infant_marmosets_vox/labels_val.csv",
-            "test": "gs://esp-ml-datasets/infant_marmosets_vox/labels_test.csv",
         },
         version="0.1.0",
         description=(
-            "InfantMarmosetsVox is a dataset for multi-class call-type and caller identification "
-            "Available at original 44.1 kHz and pre-resampled 16kHz."
+            "InfantMarmosetsVox is a dataset for multi-class call-type and caller identification. "
+            "Available at original 44.1 kHz and pre-resampled 16kHz. "
             "Pre-resampled audio uses librosa's kaiser_best resampling method. "
             "Contains approx. 73k vocalization segments of infant marmoset vocalizations. "
             "Each vocalization segment sample has a calltypeID and callerID label. "
-            "There are 10 total calltype classes and 10 caller identity classes. "
+            "There are 11 calltype classes (0-10) and 10 caller identity classes (0-9). "
             "A calltypeID index can be associated with its calltype through `CALLTYPE_NAMES`. "
-            "The train:val:test splits are randomly created following a 70:20:10 split "
-            "using `torch.utils.data.random_split()` with `torch.Generator().manual_seed(42)`."
+            "An unfiltered version (labels_raw.csv) with silence/noise is also available."
         ),
         sources=["Zenodo"],
         license="CC-BY-4.0",
     )
 
     # Mapping of sample rates to audio subdirectory names
-    # CSV paths are like "data/audio_44k/twin_X/file.wav"
-    # We replace "audio_44k" with the appropriate subdirectory
     _sample_rate_paths = {
         44100: "audio_44k",  # Original 44.1kHz
         16000: "audio_16k",  # Pre-resampled to 16kHz
@@ -183,14 +176,7 @@ class InfantMarmosetsVox(Dataset):
         return list(self._sample_rate_paths.keys())
 
     def _load(self) -> None:
-        """Load and preprocess the dataset.
-
-        This follows the same logic as the original imvdataset.py:
-        1. Load CSV
-        2. Extract twinID and per-file callerID from path
-        3. Filter out invalid calltypes (keep only 0-10)
-        4. Compute global callerID (0-9) from twinID and per-file callerID
-        5. Rename columns for consistency
+        """Load the dataset from preprocessed CSV.
 
         Raises
         ------
@@ -203,63 +189,12 @@ class InfantMarmosetsVox(Dataset):
             )
 
         location = self.info.split_paths[self.split]
-        df = pl.read_csv(location)
-
-        # Extract twinID and per-file caller index from path
-        # path: "data/audio_44k/twin_1/20160907_Twin1_marmoset1.wav"
-        # The "1" in "marmoset1" is the per-file caller (1 or 2)
-        df = df.with_columns(
-            [
-                pl.col("path")
-                .str.split("/")
-                .list.get(-1)
-                .str.replace(".wav", "")
-                .alias("filename"),
-            ]
+        self._data = self._backend_class.from_csv(
+            location,
+            streaming=self._streaming,
+            keep_default_na=False,
+            na_values=[""],
         )
-        df = df.with_columns(
-            [
-                pl.col("filename")
-                .str.split("_")
-                .list.get(1)
-                .str.slice(-1)
-                .cast(pl.Int32)
-                .alias("twinID"),
-                pl.col("filename")
-                .str.split("_")
-                .list.get(2)
-                .str.slice(-1)
-                .cast(pl.Int32)
-                .alias("_perFileCaller"),
-            ]
-        )
-        df = df.drop("filename")
-
-        # Rename calltype column
-        df = df.rename({"calltype": "calltypeID"})
-
-        # Filter: keep only valid calltypes (0-10) - remove noise and silence
-        df = df.filter(pl.col("calltypeID").is_between(0, 10))
-
-        # Compute global callerID (0-9) from twinID and per-file caller
-        # Twin 1: callers 1,2 -> callerID 0,1
-        # Twin 2: callers 1,2 -> callerID 2,3
-        # etc.
-        df = df.with_columns(
-            [
-                ((pl.col("twinID") - 1) * 2 + pl.col("_perFileCaller") - 1).alias("callerID"),
-            ]
-        )
-        df = df.drop("_perFileCaller")
-
-        # Add row index
-        df = df.with_row_index("vocID")
-
-        # Reorder columns (drop original "caller" column from CSV, we computed callerID)
-        cols = ["path", "start", "end", "duration", "calltypeID", "callerID", "twinID", "vocID"]
-        df = df.select(cols)
-
-        self._data = PolarsBackend(df, streaming=self._streaming)
 
     @classmethod
     def from_config(
@@ -326,7 +261,6 @@ class InfantMarmosetsVox(Dataset):
             The processed sample with audio loaded.
         """
         # Determine which audio directory to use based on requested sample rate
-        # CSV path is like "data/audio_44k/twin_X/file.wav"
         audio_rel_path = row["path"]
 
         if self.sample_rate is not None and self.sample_rate in self._sample_rate_paths:
@@ -407,4 +341,4 @@ class InfantMarmosetsVox(Dataset):
     @property
     def num_callers(self) -> int:
         """Return number of unique callers."""
-        return self._data._df["callerID"].n_unique()
+        return len(self._data.get_unique("callerID"))

--- a/esp_data/datasets/infant_marmosets_vox.py
+++ b/esp_data/datasets/infant_marmosets_vox.py
@@ -13,7 +13,6 @@ from esp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
 from esp_data.backends import BackendType, PolarsBackend
 from esp_data.io import AnyPathT, anypath, audio_stereo_to_mono, read_audio
 
-
 # Call type mapping (0-10, excluding 11=silence and 12=noise)
 CALLTYPE_NAMES = {
     0: "Peep(Pre-Phee)",
@@ -51,13 +50,25 @@ class InfantMarmosetsVox(Dataset):
 
     Labels
     ------
-    - calltypeID: Call type (0-10, 11 classes)
-    - callerID: Caller identity (0-9, 10 individuals from 5 twin pairs)
+    - ``calltypeID``: Call type (0-10, 11 classes)
+    - ``callerID``: Caller identity (0-9, 10 individuals from 5 twin pairs)
+
+    Additional Fields
+    -----------------
+    - ``audio``: Vocalization segment waveform (numpy array).
+    - ``path``: Relative path to audio file.
+    - ``start``: Start time in seconds.
+    - ``end``: End time in seconds.
+    - ``duration``: Vocalization segment duration in seconds.
+    - ``twinID``: Marmoset twin pair (1-5).
+    - ``vocID``: Unique vocalization ID (row index).
 
     References
     ----------
-    Sarkar et al., "InfantMarmosetsVox: A Marmosets Infant Vocalization Corpus"
-    Interspeech 2023
+    Sarkar, E., Magimai.-Doss, M. (2023)
+    "Can Self-Supervised Neural Representations Pre-Trained on Human Speech
+    distinguish Animal Callers?" Proc. Interspeech 2023, 1189-1193.
+    doi: 10.21437/Interspeech.2023-1968
     https://www.isca-speech.org/archive/interspeech_2023/sarkar23_interspeech.html
 
     Examples
@@ -69,22 +80,32 @@ class InfantMarmosetsVox(Dataset):
     ...     sample_rate=16000,
     ... )
     >>> sample = dataset[0]
-    >>> sample["audio"].shape, sample["label"]
+    >>> print(dataset.info.name)
+    InfantMarmosetsVox
+    >>> print(dataset.available_sample_rates)
+    [44100, 16000]
     """
 
     info = DatasetInfo(
         name="InfantMarmosetsVox",
         owner="eklavya",
         split_paths={
-            # Single split - downstream users handle train/val/test splitting
             "all": "gs://esp-ml-datasets/infant_marmosets_vox/labels.csv",
+            "train": "gs://esp-ml-datasets/infant_marmosets_vox/labels_train.csv",
+            "validation": "gs://esp-ml-datasets/infant_marmosets_vox/labels_val.csv",
+            "test": "gs://esp-ml-datasets/infant_marmosets_vox/labels_test.csv",
         },
         version="0.1.0",
         description=(
-            "Infant marmoset vocalizations dataset. Contains 11 call types from "
-            "10 individuals (5 twin pairs) recorded longitudinally over 8 months. "
-            "Approx. 73k vocalization segments after filtering silence/noise. "
-            "Available at original 44.1kHz and pre-resampled 16kHz."
+            "InfantMarmosetsVox is a dataset for multi-class call-type and caller identification "
+            "Available at original 44.1 kHz and pre-resampled 16kHz."
+            "Pre-resampled audio uses librosa's kaiser_best resampling method. "
+            "Contains approx. 73k vocalization segments of infant marmoset vocalizations. "
+            "Each vocalization segment sample has a calltypeID and callerID label. "
+            "There are 10 total calltype classes and 10 caller identity classes. "
+            "A calltypeID index can be associated with its calltype through `CALLTYPE_NAMES`. "
+            "The train:val:test splits are randomly created following a 70:20:10 split "
+            "using `torch.utils.data.random_split()` with `torch.Generator().manual_seed(42)`."
         ),
         sources=["Zenodo"],
         license="CC-BY-4.0",
@@ -170,11 +191,15 @@ class InfantMarmosetsVox(Dataset):
         3. Filter out invalid calltypes (keep only 0-10)
         4. Compute global callerID (0-9) from twinID and per-file callerID
         5. Rename columns for consistency
+
+        Raises
+        ------
+        LookupError
+            If the requested split is not available.
         """
         if self.split not in self.info.split_paths:
             raise LookupError(
-                f"Invalid split: {self.split}. "
-                f"Expected one of {list(self.info.split_paths.keys())}"
+                f"Invalid split: {self.split}. Expected one of {list(self.info.split_paths.keys())}"
             )
 
         location = self.info.split_paths[self.split]
@@ -183,13 +208,31 @@ class InfantMarmosetsVox(Dataset):
         # Extract twinID and per-file caller index from path
         # path: "data/audio_44k/twin_1/20160907_Twin1_marmoset1.wav"
         # The "1" in "marmoset1" is the per-file caller (1 or 2)
-        df = df.with_columns([
-            pl.col("path").str.split("/").list.get(-1).str.replace(".wav", "").alias("filename"),
-        ])
-        df = df.with_columns([
-            pl.col("filename").str.split("_").list.get(1).str.slice(-1).cast(pl.Int32).alias("twinID"),
-            pl.col("filename").str.split("_").list.get(2).str.slice(-1).cast(pl.Int32).alias("_perFileCaller"),
-        ])
+        df = df.with_columns(
+            [
+                pl.col("path")
+                .str.split("/")
+                .list.get(-1)
+                .str.replace(".wav", "")
+                .alias("filename"),
+            ]
+        )
+        df = df.with_columns(
+            [
+                pl.col("filename")
+                .str.split("_")
+                .list.get(1)
+                .str.slice(-1)
+                .cast(pl.Int32)
+                .alias("twinID"),
+                pl.col("filename")
+                .str.split("_")
+                .list.get(2)
+                .str.slice(-1)
+                .cast(pl.Int32)
+                .alias("_perFileCaller"),
+            ]
+        )
         df = df.drop("filename")
 
         # Rename calltype column
@@ -202,21 +245,26 @@ class InfantMarmosetsVox(Dataset):
         # Twin 1: callers 1,2 -> callerID 0,1
         # Twin 2: callers 1,2 -> callerID 2,3
         # etc.
-        df = df.with_columns([
-            ((pl.col("twinID") - 1) * 2 + pl.col("_perFileCaller") - 1).alias("callerID"),
-        ])
+        df = df.with_columns(
+            [
+                ((pl.col("twinID") - 1) * 2 + pl.col("_perFileCaller") - 1).alias("callerID"),
+            ]
+        )
         df = df.drop("_perFileCaller")
 
         # Add row index
         df = df.with_row_index("vocID")
 
         # Reorder columns (drop original "caller" column from CSV, we computed callerID)
-        df = df.select(["path", "start", "end", "duration", "calltypeID", "callerID", "twinID", "vocID"])
+        cols = ["path", "start", "end", "duration", "calltypeID", "callerID", "twinID", "vocID"]
+        df = df.select(cols)
 
         self._data = PolarsBackend(df, streaming=self._streaming)
 
     @classmethod
-    def from_config(cls, dataset_config: DatasetConfig) -> tuple["InfantMarmosetsVox", dict[str, Any]]:
+    def from_config(
+        cls, dataset_config: DatasetConfig
+    ) -> tuple["InfantMarmosetsVox", dict[str, Any]]:
         """Create a Dataset instance from a configuration dictionary.
 
         Parameters
@@ -244,7 +292,20 @@ class InfantMarmosetsVox(Dataset):
         return ds, {}
 
     def __len__(self) -> int:
-        """Return the number of samples in the dataset."""
+        """Return the number of samples in the dataset.
+
+        Returns
+        -------
+        int
+            The number of samples.
+
+        Raises
+        ------
+        RuntimeError
+            If no split has been loaded yet.
+        NotImplementedError
+            If streaming mode is enabled.
+        """
         if self._data is None:
             raise RuntimeError("No split has been loaded yet.")
         if self._streaming:
@@ -282,14 +343,12 @@ class InfantMarmosetsVox(Dataset):
         audio = audio.astype(np.float32)
         # Stereo to mono if necessary.
         audio = audio_stereo_to_mono(audio, mono_method="average")
-        # Normalize
-        max_abs = np.max(np.abs(audio))
-        if max_abs > 0:
-            audio = audio / max_abs
 
         # Resample on-the-fly if requested sample rate doesn't have pre-resampled version
         if self.sample_rate is not None and sr != self.sample_rate:
-            audio = librosa.resample(y=audio, orig_sr=sr, target_sr=self.sample_rate, res_type="kaiser_best")
+            audio = librosa.resample(
+                y=audio, orig_sr=sr, target_sr=self.sample_rate, res_type="kaiser_best"
+            )
 
         row["audio"] = audio
         row["path"] = audio_rel_path  # Update path to reflect actual file loaded
@@ -325,7 +384,13 @@ class InfantMarmosetsVox(Dataset):
             yield self._process(row)
 
     def __str__(self) -> str:
-        """Return a string representation of the dataset."""
+        """Return a string representation of the dataset.
+
+        Returns
+        -------
+        str
+            A formatted string with dataset information.
+        """
         return (
             f"{self.info.name} (v{self.info.version}), split='{self.split}'\n"
             f"Description: {self.info.description}\n"
@@ -340,11 +405,6 @@ class InfantMarmosetsVox(Dataset):
         return CALLTYPE_NAMES
 
     @property
-    def num_calltypes(self) -> int:
-        """Return number of call types (11)."""
-        return len(CALLTYPE_NAMES)
-
-    @property
     def num_callers(self) -> int:
-        """Return number of unique callers (10)."""
-        return 10
+        """Return number of unique callers."""
+        return self._data._df["callerID"].n_unique()

--- a/esp_data/datasets/infantmarmosetsvox.py
+++ b/esp_data/datasets/infantmarmosetsvox.py
@@ -1,0 +1,313 @@
+"""InfantMarmosetsVox dataset
+
+Infant marmoset vocalizations dataset for call type and caller identification.
+"""
+
+from typing import Any, Dict, Iterator
+
+import librosa
+import numpy as np
+import polars as pl
+
+from esp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
+from esp_data.backends import BackendType, PolarsBackend
+from esp_data.io import AnyPathT, anypath
+
+
+# Call type mapping (0-10, excluding 11=silence and 12=noise)
+CALLTYPE_NAMES = {
+    0: "Peep(Pre-Phee)",
+    1: "Phee",
+    2: "Twitter",
+    3: "Trill",
+    4: "Trillphee",
+    5: "Tsik Tse",
+    6: "Egg",
+    7: "Pheecry(cry)",
+    8: "TrllTwitter",
+    9: "Pheetwitter",
+    10: "Peep",
+}
+
+
+@register_dataset
+class InfantMarmosetsVox(Dataset):
+    """InfantMarmosetsVox dataset
+
+    Description
+    -----------
+    InfantMarmosetsVox is a dataset for multi-class call-type and caller
+    identification. It contains audio recordings of different individual
+    marmosets and their call-types. The dataset contains a total of 350 files
+    of precisely labelled 10-minute audio recordings across all caller classes.
+    The audio was recorded from five pairs of infant marmoset twins, each
+    recorded individually in two separate sound-proofed recording rooms at a
+    sampling rate of 44.1 kHz. The start and end time, call-type, and marmoset
+    identity of each vocalization are provided, labeled by an experienced
+    researcher.
+
+    Each entry in the dataset corresponds to a single vocalization segment,
+    with the audio loaded from the corresponding time range in the source file.
+
+    Labels
+    ------
+    - calltypeID: Call type (0-10, 11 classes)
+    - callerID: Caller identity (0-9, 10 individuals from 5 twin pairs)
+
+    References
+    ----------
+    Sarkar et al., "InfantMarmosetsVox: A Marmosets Infant Vocalization Corpus"
+    Interspeech 2023
+    https://www.isca-speech.org/archive/interspeech_2023/sarkar23_interspeech.html
+
+    Examples
+    --------
+    >>> from esp_data.datasets import InfantMarmosetsVox
+    >>> dataset = InfantMarmosetsVox(
+    ...     split="all",
+    ...     output_take_and_give={"calltypeID": "label", "audio": "audio"},
+    ...     sample_rate=16000,
+    ... )
+    >>> sample = dataset[0]
+    >>> sample["audio"].shape, sample["label"]
+    """
+
+    info = DatasetInfo(
+        name="InfantMarmosetsVox",
+        owner="eklavya",
+        split_paths={
+            # Single split - downstream users handle train/val/test splitting
+            "all": "gs://esp-ml-datasets/InfantMarmosetsVox/labels.csv",
+        },
+        version="0.1.0",
+        description=(
+            "Infant marmoset vocalizations dataset. Contains 11 call types from "
+            "10 individuals (5 twin pairs) recorded longitudinally over 8 months. "
+            "Approx. 73k vocalization segments after filtering silence/noise."
+        ),
+        sources=["Zenodo"],
+        license="CC-BY-4.0",
+    )
+
+    def __init__(
+        self,
+        split: str = "all",
+        output_take_and_give: dict[str, str] | None = None,
+        sample_rate: int | None = None,
+        data_root: str | AnyPathT | None = None,
+        backend: BackendType = "polars",
+        streaming: bool = False,
+    ) -> None:
+        """Initialize the InfantMarmosetsVox dataset.
+
+        Parameters
+        ----------
+        split : str
+            The split to load. Currently only "all" is available.
+        output_take_and_give : dict[str, str]
+            A dictionary mapping the original column names to the new column names.
+            It acts as a filter as well.
+        sample_rate : int
+            The sample rate to which audio files should be resampled.
+        data_root : str | AnyPathT, optional
+            The root directory for the dataset audio files.
+            If None, defaults to parent directory of the split CSV.
+        backend : BackendType, optional
+            The backend to use ("pandas" or "polars"), by default "polars"
+        streaming : bool, optional
+            Whether to use streaming mode, by default False
+        """
+        super().__init__(output_take_and_give, backend=backend, streaming=streaming)
+        self.split = split
+        self.sample_rate = sample_rate
+
+        if data_root is None:
+            self.data_root = anypath(self.info.split_paths[self.split]).parent
+        else:
+            self.data_root = data_root
+
+        self._data = None
+        self._load()
+
+    @property
+    def columns(self) -> list[str]:
+        """Return the columns of the dataset."""
+        return list(self._data.columns)
+
+    @property
+    def available_splits(self) -> list[str]:
+        """Return the available splits of the dataset."""
+        return list(self.info.split_paths.keys())
+
+    def _load(self) -> None:
+        """Load and preprocess the dataset.
+
+        This follows the same logic as the original imvdataset.py:
+        1. Load CSV
+        2. Extract twinID and per-file callerID from path
+        3. Filter out invalid calltypes (keep only 0-10)
+        4. Compute global callerID (0-9) from twinID and per-file callerID
+        5. Rename columns for consistency
+        """
+        if self.split not in self.info.split_paths:
+            raise LookupError(
+                f"Invalid split: {self.split}. "
+                f"Expected one of {list(self.info.split_paths.keys())}"
+            )
+
+        location = self.info.split_paths[self.split]
+        df = pl.read_csv(location)
+
+        # Extract twinID and per-file caller index from path
+        # path: "data/twin_1/20160907_Twin1_marmoset1.wav"
+        # The "1" in "marmoset1" is the per-file caller (1 or 2)
+        df = df.with_columns([
+            pl.col("path").str.split("/").list.get(-1).str.replace(".wav", "").alias("filename"),
+        ])
+        df = df.with_columns([
+            pl.col("filename").str.split("_").list.get(1).str.slice(-1).cast(pl.Int32).alias("twinID"),
+            pl.col("filename").str.split("_").list.get(2).str.slice(-1).cast(pl.Int32).alias("_perFileCaller"),
+        ])
+        df = df.drop("filename")
+
+        # Rename calltype column
+        df = df.rename({"calltype": "calltypeID"})
+
+        # Filter: keep only valid calltypes (0-10) - remove noise and silence
+        df = df.filter(pl.col("calltypeID").is_between(0, 10))
+
+        # Compute global callerID (0-9) from twinID and per-file caller
+        # Twin 1: callers 1,2 -> callerID 0,1
+        # Twin 2: callers 1,2 -> callerID 2,3
+        # etc.
+        df = df.with_columns([
+            ((pl.col("twinID") - 1) * 2 + pl.col("_perFileCaller") - 1).alias("callerID"),
+        ])
+        df = df.drop("_perFileCaller")
+
+        # Add row index
+        df = df.with_row_index("vocID")
+
+        # Reorder columns (drop original "caller" column from CSV, we computed callerID)
+        df = df.select(["path", "start", "end", "duration", "calltypeID", "callerID", "twinID", "vocID"])
+
+        self._data = PolarsBackend(df, streaming=self._streaming)
+
+    @classmethod
+    def from_config(cls, dataset_config: DatasetConfig) -> tuple["InfantMarmosetsVox", dict[str, Any]]:
+        """Create a Dataset instance from a configuration dictionary.
+
+        Parameters
+        ----------
+        dataset_config : DatasetConfig
+            Configuration dictionary containing dataset parameters
+
+        Returns
+        -------
+        tuple[Dataset, dict[str, Any]]
+            A tuple containing the dataset instance and metadata.
+        """
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
+        ds = cls(
+            split=cfg["split"],
+            output_take_and_give=cfg["output_take_and_give"],
+            data_root=cfg["data_root"],
+            sample_rate=cfg["sample_rate"],
+            backend=cfg["backend"],
+            streaming=cfg["streaming"],
+        )
+        if dataset_config.transformations:
+            transform_metadata = ds.apply_transformations(dataset_config.transformations)
+            return ds, transform_metadata
+        return ds, {}
+
+    def __len__(self) -> int:
+        """Return the number of samples in the dataset."""
+        if self._data is None:
+            raise RuntimeError("No split has been loaded yet.")
+        if self._streaming:
+            raise NotImplementedError("Length is not available in streaming mode.")
+        return len(self._data)
+
+    def _process(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Process a single row to load audio segment.
+
+        Parameters
+        ----------
+        row : dict
+            A row from the dataset containing path, start, end times.
+
+        Returns
+        -------
+        dict
+            The processed sample with audio loaded.
+        """
+        audio_path = anypath(self.data_root) / row["path"]
+        start = float(row["start"])
+        end = float(row["end"])
+
+        audio, sr = librosa.load(str(audio_path), sr=None, mono=True, offset=start, duration=end - start)
+
+        max_abs = np.max(np.abs(audio))
+        if max_abs > 0:
+            audio = audio / max_abs
+
+        if self.sample_rate is not None and sr != self.sample_rate:
+            audio = librosa.resample(y=audio, orig_sr=sr, target_sr=self.sample_rate, res_type="kaiser_best")
+
+        row["audio"] = audio
+
+        if self.output_take_and_give:
+            return {value: row[key] for key, value in self.output_take_and_give.items()}
+        return row
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        """Get a specific sample from the dataset.
+
+        Parameters
+        ----------
+        idx : int
+            Index of the sample to get.
+
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary containing audio and metadata.
+        """
+        return self._process(self._data[idx])
+
+    def __iter__(self) -> Iterator[Dict[str, Any]]:
+        """Iterate over samples in the dataset.
+
+        Yields
+        ------
+        Dict[str, Any]
+            Each sample in the dataset.
+        """
+        for row in self._data:
+            yield self._process(row)
+
+    def __str__(self) -> str:
+        """Return a string representation of the dataset."""
+        return (
+            f"{self.info.name} (v{self.info.version}), split='{self.split}'\n"
+            f"Description: {self.info.description}\n"
+            f"Sources: {', '.join(self.info.sources)}\n"
+            f"License: {self.info.license}\n"
+            f"Available splits: {', '.join(self.info.split_paths.keys())}"
+        )
+
+    @property
+    def calltype_names(self) -> dict[int, str]:
+        """Return mapping from call type ID to name."""
+        return CALLTYPE_NAMES
+
+    @property
+    def num_calltypes(self) -> int:
+        """Return number of call types (11)."""
+        return len(CALLTYPE_NAMES)
+
+    @property
+    def num_callers(self) -> int:
+        """Return number of unique callers (10)."""
+        return 10

--- a/tests/unittests/datasets_tests/test_infant_marmosets_vox.py
+++ b/tests/unittests/datasets_tests/test_infant_marmosets_vox.py
@@ -1,0 +1,423 @@
+"""Test suite for the InfantMarmosetsVox dataset."""
+
+import numpy as np
+import pytest
+
+from esp_data import DatasetConfig
+from esp_data.datasets import InfantMarmosetsVox
+from esp_data.io import anypath, exists
+from esp_data.utils import create_hash
+
+
+# Dataset-specific constants
+NUM_CALLTYPES = 11  # Call types 0-10
+NUM_CALLERS = 10  # 5 twin pairs × 2 individuals
+NUM_TWINS = 5  # Twin pairs 1-5
+
+# Expected values for integrity tests (computed on 2025-01-15)
+# These ensure the dataset hasn't changed unexpectedly
+EXPECTED_LEN_ALL = 72921
+EXPECTED_LEN_TRAIN = 51044
+EXPECTED_LEN_VAL = 14584
+EXPECTED_LEN_TEST = 7293
+
+# Hash values for dataset integrity verification
+# First audio sample hash and annotations hash per split
+_HASHES = {
+    "all": (
+        "33dd60a95f57b43dc026ec378ecefcc263984ef6d13d1d70d8a4959556e71c7a",
+        "f1a94fb8891bc0736e8d9676ddbb0af7361414c818ba2c2d1b4dff4ee2c10864",
+    ),
+    "train": (
+        "765bd9760db5e7d7a4e42fe69718bdb14e7a93714cbbd50ca442cb241984d543",
+        "05de390450a00c8d20850d06e9111b820df170c8b9ba4a47b666f8f6910d7a91",
+    ),
+    "validation": (
+        "8d061b7c2572f3077e4951ed429de608c68e38617e71e324adbaf92e411bef36",
+        "4d01d8986e58d84cd00da145bf0af393b953d5041c5ab9786a8137ff6582b7e8",
+    ),
+    "test": (
+        "0bddb91326b3df79b44df0bc3bd54ed08d32973936b89950b1ad167819cd2fef",
+        "08f1a8448255608f1b6ac835e94002dd501b2a9c40b22aaaf7c4ce65090569ca",
+    ),
+}
+
+# Columns in the underlying dataframe (not including 'audio' which is added dynamically)
+EXPECTED_COLS = [
+    "path",
+    "start",
+    "end",
+    "duration",
+    "calltypeID",
+    "callerID",
+    "twinID",
+    "vocID",
+]
+
+
+def _compute_dataset_hashes(ds: InfantMarmosetsVox) -> tuple[str, str]:
+    """Compute integrity hashes for a dataset split.
+
+    Returns
+    -------
+    tuple[str, str]
+        (first_audio_hash, annotations_hash)
+    """
+    # Compute first item audio hash
+    first_sample = ds[0]
+    first_audio = first_sample["audio"].tobytes()
+    first_audio_hash = create_hash(first_audio)
+
+    # Compute annotations hash (convert Polars to pandas for consistent hashing)
+    df = ds._data.unwrap.to_pandas()
+    df = df.sort_index(axis=0).sort_index(axis=1)
+    csv_bytes = df.to_csv(index=True).encode("utf-8")
+    annotations_hash = create_hash(csv_bytes)
+
+    return first_audio_hash, annotations_hash
+
+
+@pytest.fixture
+def ds() -> InfantMarmosetsVox:
+    """Load InfantMarmosetsVox dataset for testing."""
+    return InfantMarmosetsVox(split="all", streaming=False, backend="polars")
+
+
+@pytest.fixture
+def ds_train() -> InfantMarmosetsVox:
+    """Load InfantMarmosetsVox train split for testing."""
+    return InfantMarmosetsVox(split="train", streaming=False, backend="polars")
+
+
+@pytest.fixture
+def first_sample(ds: InfantMarmosetsVox) -> dict:
+    """Return the first sample of the dataset."""
+    return next(iter(ds))
+
+
+def test_dataset_integrity(ds: InfantMarmosetsVox) -> None:
+    """Test dataset integrity using hash verification."""
+    first_audio_hash, annotations_hash = _compute_dataset_hashes(ds)
+    expected_audio_hash, expected_annotations_hash = _HASHES["all"]
+
+    assert first_audio_hash == expected_audio_hash, (
+        "First item audio hash does not match expected value."
+    )
+    assert annotations_hash == expected_annotations_hash, (
+        "Annotations hash does not match expected value."
+    )
+
+
+def test_info_property(ds: InfantMarmosetsVox) -> None:
+    """Test if the info property returns correct metadata."""
+    assert ds.info.name == "InfantMarmosetsVox"
+    assert ds.info.version == "0.1.0"
+    assert "all" in ds.info.split_paths
+    assert "train" in ds.info.split_paths
+    assert "validation" in ds.info.split_paths
+    assert "test" in ds.info.split_paths
+    for split in ds.info.split_paths.values():
+        assert exists(split), f"Split path {split} does not exist"
+    assert "call-type" in ds.info.description.lower()
+    assert ds.info.license == "CC-BY-4.0"
+
+
+def test_dataset_length(ds: InfantMarmosetsVox) -> None:
+    """Test the dataset length matches expected value."""
+    assert len(ds) == EXPECTED_LEN_ALL, (
+        f"Dataset length {len(ds)} does not match expected {EXPECTED_LEN_ALL}"
+    )
+
+
+def test_split_lengths() -> None:
+    """Test that split lengths match expected values."""
+    ds_train = InfantMarmosetsVox(split="train", streaming=False)
+    ds_val = InfantMarmosetsVox(split="validation", streaming=False)
+    ds_test = InfantMarmosetsVox(split="test", streaming=False)
+
+    assert len(ds_train) == EXPECTED_LEN_TRAIN, (
+        f"Train split length {len(ds_train)} does not match expected {EXPECTED_LEN_TRAIN}"
+    )
+    assert len(ds_val) == EXPECTED_LEN_VAL, (
+        f"Val split length {len(ds_val)} does not match expected {EXPECTED_LEN_VAL}"
+    )
+    assert len(ds_test) == EXPECTED_LEN_TEST, (
+        f"Test split length {len(ds_test)} does not match expected {EXPECTED_LEN_TEST}"
+    )
+
+    # Verify splits sum to total (approximately, due to filtering)
+    total = len(ds_train) + len(ds_val) + len(ds_test)
+    assert total == EXPECTED_LEN_ALL, f"Splits sum {total} != all {EXPECTED_LEN_ALL}"
+
+
+def test_columns_property(ds: InfantMarmosetsVox) -> None:
+    """Test the columns property."""
+    cols = ds.columns
+    for col in EXPECTED_COLS:
+        assert col in cols, f"Expected column '{col}' not found in dataset columns."
+
+
+def test_data_property(ds: InfantMarmosetsVox) -> None:
+    """Test if the data property returns correct dataframes."""
+    assert ds._data is not None
+    assert "path" in ds._data.columns
+    assert "calltypeID" in ds._data.columns
+    assert "callerID" in ds._data.columns
+    assert "twinID" in ds._data.columns
+
+
+def test_construction_from_config() -> None:
+    """Test the from_config class method."""
+    config = {
+        "dataset_name": "infant_marmosets_vox",
+        "split": "all",
+        "streaming": True,
+        "backend": "polars",
+    }
+    config = DatasetConfig.model_validate(config)
+    ds, _ = InfantMarmosetsVox.from_config(config)
+    assert isinstance(ds, InfantMarmosetsVox), (
+        "from_config did not return an InfantMarmosetsVox instance."
+    )
+
+
+def test_transforms_in_from_config() -> None:
+    """Test construction with transforms in from_config."""
+    config = {
+        "dataset_name": "infant_marmosets_vox",
+        "split": "train",
+        "streaming": False,
+        "backend": "polars",
+        "transformations": [
+            {
+                "type": "label_from_feature",
+                "feature": "calltypeID",
+                "output_feature": "label",
+            }
+        ],
+    }
+    config = DatasetConfig.model_validate(config)
+    ds, metadata = InfantMarmosetsVox.from_config(config)
+
+    assert "label_from_feature" in metadata, "Transformations metadata not returned."
+    assert "label" in ds.columns, (
+        "Transformed feature 'label' not found in dataset columns."
+    )
+
+
+def test_available_splits(ds: InfantMarmosetsVox) -> None:
+    """Test the available_splits method."""
+    splits = ds.available_splits
+    expected_splits = ["all", "train", "validation", "test"]
+    for split in expected_splits:
+        assert split in splits, f"Expected split '{split}' not found in available splits."
+
+
+def test_split_lookup_error() -> None:
+    """Test that an invalid split raises a LookupError."""
+    with pytest.raises(LookupError):
+        InfantMarmosetsVox(split="invalid_split", streaming=False, backend="polars")
+
+
+def test_streaming_iter() -> None:
+    """Test streaming iteration."""
+    ds = InfantMarmosetsVox(split="train", streaming=True, backend="polars")
+
+    # Iterate through first 5 samples
+    for i, sample in enumerate(ds):
+        if i >= 5:
+            break
+        assert "audio" in sample, "Sample does not contain 'audio' key."
+        assert "calltypeID" in sample, "Sample does not contain 'calltypeID' key."
+        assert "callerID" in sample, "Sample does not contain 'callerID' key."
+
+
+def test_random_samples(ds_train: InfantMarmosetsVox) -> None:
+    """Test random samples from the dataset."""
+    import random
+
+    n = len(ds_train)
+    rng = random.Random(42)
+    sample_indices = [rng.randrange(n) for _ in range(min(5, n))]
+
+    for idx in sample_indices:
+        item = ds_train[idx]
+        assert "audio" in item, f"[{idx}] missing 'audio' key"
+        audio = item["audio"]
+
+        assert len(audio) >= 10, f"[{idx}] audio too short (length={len(audio)})"
+        assert not np.any(np.isnan(audio)), f"[{idx}] audio contains NaN values"
+        assert not np.all(audio == 0), f"[{idx}] audio is all zeros"
+
+
+def test_getitem(ds_train: InfantMarmosetsVox) -> None:
+    """Test if __getitem__ returns correct sample format."""
+    sample = ds_train[0]
+    assert isinstance(sample, dict)
+    assert "calltypeID" in sample
+    assert "callerID" in sample
+    assert "twinID" in sample
+    assert "audio" in sample
+    assert "path" in sample
+
+    # Verify audio properties
+    audio = sample["audio"]
+    assert audio is not None
+    assert hasattr(audio, "shape"), "Audio should be a numpy array with shape attribute"
+    assert len(audio.shape) == 1, "Audio should be mono (1D array)"
+
+
+def test_iteration(ds_train: InfantMarmosetsVox) -> None:
+    """Test if iteration works correctly."""
+    for _, sample in enumerate(ds_train):
+        assert isinstance(sample, dict)
+        assert "audio" in sample
+        break
+
+
+def test_sample_consistency(ds_train: InfantMarmosetsVox) -> None:
+    """Test if samples are consistent when accessed multiple ways."""
+    direct_sample = ds_train[0]
+    iter_sample = next(iter(ds_train))
+
+    # Compare samples (excluding audio for efficiency)
+    assert direct_sample["path"] == iter_sample["path"]
+    assert direct_sample["calltypeID"] == iter_sample["calltypeID"]
+    assert direct_sample["callerID"] == iter_sample["callerID"]
+    assert direct_sample["start"] == iter_sample["start"]
+    assert direct_sample["end"] == iter_sample["end"]
+
+
+def test_output_take_and_give() -> None:
+    """Test if output_take_and_give correctly maps column names."""
+    ds = InfantMarmosetsVox(
+        split="train",
+        output_take_and_give={"calltypeID": "label", "audio": "waveform"},
+        streaming=False,
+    )
+
+    sample = ds[0]
+
+    # Check that only mapped columns are present
+    expected_keys = {"label", "waveform"}
+    assert set(sample.keys()) == expected_keys
+
+    # Verify the values are correct types
+    assert isinstance(sample["label"], (int, np.integer))
+    assert isinstance(sample["waveform"], np.ndarray)
+
+
+def test_sample_rate_resampling() -> None:
+    """Test if audio resampling works correctly when sample_rate is specified."""
+    # Test with pre-resampled 16kHz
+    ds_16k = InfantMarmosetsVox(split="train", sample_rate=16000, streaming=False)
+    sample = ds_16k[0]
+
+    assert "audio" in sample
+    audio = sample["audio"]
+    assert audio is not None
+    assert len(audio.shape) == 1, "Audio should be mono after resampling"
+
+
+def test_available_sample_rates(ds: InfantMarmosetsVox) -> None:
+    """Test the available_sample_rates property."""
+    rates = ds.available_sample_rates
+    assert 44100 in rates, "44100 Hz should be available"
+    assert 16000 in rates, "16000 Hz should be available"
+
+
+def test_data_root_parameter() -> None:
+    """Test if data_root parameter works correctly."""
+    # Test default data_root (should be parent of CSV path)
+    ds_default = InfantMarmosetsVox(split="train")
+    expected_default = anypath(ds_default.info.split_paths["train"]).parent
+    assert ds_default.data_root == expected_default
+
+    # Test with custom data_root
+    custom_root = "tests/"
+    ds = InfantMarmosetsVox(split="train", data_root=custom_root)
+    assert str(ds.data_root) == custom_root
+
+
+def test_string_representation(ds: InfantMarmosetsVox) -> None:
+    """Test the string representation of the dataset."""
+    str_repr = str(ds)
+    assert "InfantMarmosetsVox" in str_repr
+    assert "all" in str_repr  # split name
+    assert "CC-BY-4.0" in str_repr  # license
+
+
+def test_class_registration() -> None:
+    """Test that the dataset class is properly registered."""
+    from esp_data.datasets import InfantMarmosetsVox
+
+    # Test that it's in the __all__ list
+    import esp_data.datasets as datasets
+
+    assert "InfantMarmosetsVox" in datasets.__all__
+
+    # Test that the class has the correct decorator
+    assert hasattr(InfantMarmosetsVox, "info")
+    assert hasattr(InfantMarmosetsVox.info, "name")
+
+
+def test_calltype_names(ds: InfantMarmosetsVox) -> None:
+    """Test the calltype_names property."""
+    names = ds.calltype_names
+    assert isinstance(names, dict)
+    assert len(names) == NUM_CALLTYPES, f"Should have {NUM_CALLTYPES} call types (0-10)"
+
+    # Check some specific call types
+    assert 0 in names
+    assert 1 in names  # Phee
+    assert NUM_CALLTYPES - 1 in names  # Last call type (10)
+
+    # Verify all values are strings
+    for k, v in names.items():
+        assert isinstance(k, int), f"Key {k} should be int"
+        assert isinstance(v, str), f"Value {v} should be str"
+
+
+def test_num_callers(ds: InfantMarmosetsVox) -> None:
+    """Test the num_callers property."""
+    num = ds.num_callers
+    assert isinstance(num, int)
+    assert num == NUM_CALLERS, f"Should have {NUM_CALLERS} callers, got {num}"
+
+
+def test_calltypeID_range(ds_train: InfantMarmosetsVox) -> None:
+    """Test that calltypeID values are in expected range (0-10)."""
+    sample = ds_train[0]
+    calltype = sample["calltypeID"]
+    assert 0 <= calltype <= NUM_CALLTYPES - 1, (
+        f"calltypeID {calltype} out of expected range 0-{NUM_CALLTYPES - 1}"
+    )
+
+
+def test_callerID_range(ds_train: InfantMarmosetsVox) -> None:
+    """Test that callerID values are in expected range (0-9)."""
+    sample = ds_train[0]
+    caller = sample["callerID"]
+    assert 0 <= caller <= NUM_CALLERS - 1, (
+        f"callerID {caller} out of expected range 0-{NUM_CALLERS - 1}"
+    )
+
+
+def test_twinID_range(ds_train: InfantMarmosetsVox) -> None:
+    """Test that twinID values are in expected range (1-5)."""
+    sample = ds_train[0]
+    twin = sample["twinID"]
+    assert 1 <= twin <= NUM_TWINS, f"twinID {twin} out of expected range 1-{NUM_TWINS}"
+
+
+def test_duration_positive(ds_train: InfantMarmosetsVox) -> None:
+    """Test that duration values are positive."""
+    sample = ds_train[0]
+    duration = sample["duration"]
+    assert duration > 0, f"Duration {duration} should be positive"
+    assert sample["end"] > sample["start"], "End should be greater than start"
+
+
+if __name__ == "__main__":
+    # Run tests manually if executed directly
+    pytest.main([__file__, "-v"])

--- a/tests/unittests/datasets_tests/test_infant_marmosets_vox.py
+++ b/tests/unittests/datasets_tests/test_infant_marmosets_vox.py
@@ -8,37 +8,20 @@ from esp_data.datasets import InfantMarmosetsVox
 from esp_data.io import anypath, exists
 from esp_data.utils import create_hash
 
-
 # Dataset-specific constants
 NUM_CALLTYPES = 11  # Call types 0-10
 NUM_CALLERS = 10  # 5 twin pairs × 2 individuals
 NUM_TWINS = 5  # Twin pairs 1-5
 
-# Expected values for integrity tests (computed on 2025-01-15)
-# These ensure the dataset hasn't changed unexpectedly
+# Expected values for integrity tests
 EXPECTED_LEN_ALL = 72921
-EXPECTED_LEN_TRAIN = 51044
-EXPECTED_LEN_VAL = 14584
-EXPECTED_LEN_TEST = 7293
 
 # Hash values for dataset integrity verification
-# First audio sample hash and annotations hash per split
+# First audio sample hash and annotations hash
 _HASHES = {
     "all": (
         "33dd60a95f57b43dc026ec378ecefcc263984ef6d13d1d70d8a4959556e71c7a",
         "f1a94fb8891bc0736e8d9676ddbb0af7361414c818ba2c2d1b4dff4ee2c10864",
-    ),
-    "train": (
-        "765bd9760db5e7d7a4e42fe69718bdb14e7a93714cbbd50ca442cb241984d543",
-        "05de390450a00c8d20850d06e9111b820df170c8b9ba4a47b666f8f6910d7a91",
-    ),
-    "validation": (
-        "8d061b7c2572f3077e4951ed429de608c68e38617e71e324adbaf92e411bef36",
-        "4d01d8986e58d84cd00da145bf0af393b953d5041c5ab9786a8137ff6582b7e8",
-    ),
-    "test": (
-        "0bddb91326b3df79b44df0bc3bd54ed08d32973936b89950b1ad167819cd2fef",
-        "08f1a8448255608f1b6ac835e94002dd501b2a9c40b22aaaf7c4ce65090569ca",
     ),
 }
 
@@ -79,19 +62,25 @@ def _compute_dataset_hashes(ds: InfantMarmosetsVox) -> tuple[str, str]:
 
 @pytest.fixture
 def ds() -> InfantMarmosetsVox:
-    """Load InfantMarmosetsVox dataset for testing."""
+    """Load InfantMarmosetsVox dataset for testing.
+
+    Returns
+    -------
+    InfantMarmosetsVox
+        Dataset instance for testing.
+    """
     return InfantMarmosetsVox(split="all", streaming=False, backend="polars")
 
 
 @pytest.fixture
-def ds_train() -> InfantMarmosetsVox:
-    """Load InfantMarmosetsVox train split for testing."""
-    return InfantMarmosetsVox(split="train", streaming=False, backend="polars")
-
-
-@pytest.fixture
 def first_sample(ds: InfantMarmosetsVox) -> dict:
-    """Return the first sample of the dataset."""
+    """Return the first sample of the dataset.
+
+    Returns
+    -------
+    dict
+        First sample from the dataset.
+    """
     return next(iter(ds))
 
 
@@ -113,9 +102,6 @@ def test_info_property(ds: InfantMarmosetsVox) -> None:
     assert ds.info.name == "InfantMarmosetsVox"
     assert ds.info.version == "0.1.0"
     assert "all" in ds.info.split_paths
-    assert "train" in ds.info.split_paths
-    assert "validation" in ds.info.split_paths
-    assert "test" in ds.info.split_paths
     for split in ds.info.split_paths.values():
         assert exists(split), f"Split path {split} does not exist"
     assert "call-type" in ds.info.description.lower()
@@ -127,27 +113,6 @@ def test_dataset_length(ds: InfantMarmosetsVox) -> None:
     assert len(ds) == EXPECTED_LEN_ALL, (
         f"Dataset length {len(ds)} does not match expected {EXPECTED_LEN_ALL}"
     )
-
-
-def test_split_lengths() -> None:
-    """Test that split lengths match expected values."""
-    ds_train = InfantMarmosetsVox(split="train", streaming=False)
-    ds_val = InfantMarmosetsVox(split="validation", streaming=False)
-    ds_test = InfantMarmosetsVox(split="test", streaming=False)
-
-    assert len(ds_train) == EXPECTED_LEN_TRAIN, (
-        f"Train split length {len(ds_train)} does not match expected {EXPECTED_LEN_TRAIN}"
-    )
-    assert len(ds_val) == EXPECTED_LEN_VAL, (
-        f"Val split length {len(ds_val)} does not match expected {EXPECTED_LEN_VAL}"
-    )
-    assert len(ds_test) == EXPECTED_LEN_TEST, (
-        f"Test split length {len(ds_test)} does not match expected {EXPECTED_LEN_TEST}"
-    )
-
-    # Verify splits sum to total (approximately, due to filtering)
-    total = len(ds_train) + len(ds_val) + len(ds_test)
-    assert total == EXPECTED_LEN_ALL, f"Splits sum {total} != all {EXPECTED_LEN_ALL}"
 
 
 def test_columns_property(ds: InfantMarmosetsVox) -> None:
@@ -185,7 +150,7 @@ def test_transforms_in_from_config() -> None:
     """Test construction with transforms in from_config."""
     config = {
         "dataset_name": "infant_marmosets_vox",
-        "split": "train",
+        "split": "all",
         "streaming": False,
         "backend": "polars",
         "transformations": [
@@ -200,17 +165,13 @@ def test_transforms_in_from_config() -> None:
     ds, metadata = InfantMarmosetsVox.from_config(config)
 
     assert "label_from_feature" in metadata, "Transformations metadata not returned."
-    assert "label" in ds.columns, (
-        "Transformed feature 'label' not found in dataset columns."
-    )
+    assert "label" in ds.columns, "Transformed feature 'label' not found in dataset columns."
 
 
 def test_available_splits(ds: InfantMarmosetsVox) -> None:
     """Test the available_splits method."""
     splits = ds.available_splits
-    expected_splits = ["all", "train", "validation", "test"]
-    for split in expected_splits:
-        assert split in splits, f"Expected split '{split}' not found in available splits."
+    assert "all" in splits, "Expected split 'all' not found in available splits."
 
 
 def test_split_lookup_error() -> None:
@@ -221,7 +182,7 @@ def test_split_lookup_error() -> None:
 
 def test_streaming_iter() -> None:
     """Test streaming iteration."""
-    ds = InfantMarmosetsVox(split="train", streaming=True, backend="polars")
+    ds = InfantMarmosetsVox(split="all", streaming=True, backend="polars")
 
     # Iterate through first 5 samples
     for i, sample in enumerate(ds):
@@ -232,16 +193,16 @@ def test_streaming_iter() -> None:
         assert "callerID" in sample, "Sample does not contain 'callerID' key."
 
 
-def test_random_samples(ds_train: InfantMarmosetsVox) -> None:
+def test_random_samples(ds: InfantMarmosetsVox) -> None:
     """Test random samples from the dataset."""
     import random
 
-    n = len(ds_train)
+    n = len(ds)
     rng = random.Random(42)
     sample_indices = [rng.randrange(n) for _ in range(min(5, n))]
 
     for idx in sample_indices:
-        item = ds_train[idx]
+        item = ds[idx]
         assert "audio" in item, f"[{idx}] missing 'audio' key"
         audio = item["audio"]
 
@@ -250,9 +211,9 @@ def test_random_samples(ds_train: InfantMarmosetsVox) -> None:
         assert not np.all(audio == 0), f"[{idx}] audio is all zeros"
 
 
-def test_getitem(ds_train: InfantMarmosetsVox) -> None:
+def test_getitem(ds: InfantMarmosetsVox) -> None:
     """Test if __getitem__ returns correct sample format."""
-    sample = ds_train[0]
+    sample = ds[0]
     assert isinstance(sample, dict)
     assert "calltypeID" in sample
     assert "callerID" in sample
@@ -267,18 +228,18 @@ def test_getitem(ds_train: InfantMarmosetsVox) -> None:
     assert len(audio.shape) == 1, "Audio should be mono (1D array)"
 
 
-def test_iteration(ds_train: InfantMarmosetsVox) -> None:
+def test_iteration(ds: InfantMarmosetsVox) -> None:
     """Test if iteration works correctly."""
-    for _, sample in enumerate(ds_train):
+    for _, sample in enumerate(ds):
         assert isinstance(sample, dict)
         assert "audio" in sample
         break
 
 
-def test_sample_consistency(ds_train: InfantMarmosetsVox) -> None:
+def test_sample_consistency(ds: InfantMarmosetsVox) -> None:
     """Test if samples are consistent when accessed multiple ways."""
-    direct_sample = ds_train[0]
-    iter_sample = next(iter(ds_train))
+    direct_sample = ds[0]
+    iter_sample = next(iter(ds))
 
     # Compare samples (excluding audio for efficiency)
     assert direct_sample["path"] == iter_sample["path"]
@@ -291,7 +252,7 @@ def test_sample_consistency(ds_train: InfantMarmosetsVox) -> None:
 def test_output_take_and_give() -> None:
     """Test if output_take_and_give correctly maps column names."""
     ds = InfantMarmosetsVox(
-        split="train",
+        split="all",
         output_take_and_give={"calltypeID": "label", "audio": "waveform"},
         streaming=False,
     )
@@ -310,7 +271,7 @@ def test_output_take_and_give() -> None:
 def test_sample_rate_resampling() -> None:
     """Test if audio resampling works correctly when sample_rate is specified."""
     # Test with pre-resampled 16kHz
-    ds_16k = InfantMarmosetsVox(split="train", sample_rate=16000, streaming=False)
+    ds_16k = InfantMarmosetsVox(split="all", sample_rate=16000, streaming=False)
     sample = ds_16k[0]
 
     assert "audio" in sample
@@ -329,13 +290,13 @@ def test_available_sample_rates(ds: InfantMarmosetsVox) -> None:
 def test_data_root_parameter() -> None:
     """Test if data_root parameter works correctly."""
     # Test default data_root (should be parent of CSV path)
-    ds_default = InfantMarmosetsVox(split="train")
-    expected_default = anypath(ds_default.info.split_paths["train"]).parent
+    ds_default = InfantMarmosetsVox(split="all")
+    expected_default = anypath(ds_default.info.split_paths["all"]).parent
     assert ds_default.data_root == expected_default
 
     # Test with custom data_root
     custom_root = "tests/"
-    ds = InfantMarmosetsVox(split="train", data_root=custom_root)
+    ds = InfantMarmosetsVox(split="all", data_root=custom_root)
     assert str(ds.data_root) == custom_root
 
 
@@ -349,10 +310,9 @@ def test_string_representation(ds: InfantMarmosetsVox) -> None:
 
 def test_class_registration() -> None:
     """Test that the dataset class is properly registered."""
-    from esp_data.datasets import InfantMarmosetsVox
-
     # Test that it's in the __all__ list
     import esp_data.datasets as datasets
+    from esp_data.datasets import InfantMarmosetsVox
 
     assert "InfantMarmosetsVox" in datasets.__all__
 
@@ -385,34 +345,34 @@ def test_num_callers(ds: InfantMarmosetsVox) -> None:
     assert num == NUM_CALLERS, f"Should have {NUM_CALLERS} callers, got {num}"
 
 
-def test_calltypeID_range(ds_train: InfantMarmosetsVox) -> None:
+def test_calltypeID_range(ds: InfantMarmosetsVox) -> None:
     """Test that calltypeID values are in expected range (0-10)."""
-    sample = ds_train[0]
+    sample = ds[0]
     calltype = sample["calltypeID"]
     assert 0 <= calltype <= NUM_CALLTYPES - 1, (
         f"calltypeID {calltype} out of expected range 0-{NUM_CALLTYPES - 1}"
     )
 
 
-def test_callerID_range(ds_train: InfantMarmosetsVox) -> None:
+def test_callerID_range(ds: InfantMarmosetsVox) -> None:
     """Test that callerID values are in expected range (0-9)."""
-    sample = ds_train[0]
+    sample = ds[0]
     caller = sample["callerID"]
     assert 0 <= caller <= NUM_CALLERS - 1, (
         f"callerID {caller} out of expected range 0-{NUM_CALLERS - 1}"
     )
 
 
-def test_twinID_range(ds_train: InfantMarmosetsVox) -> None:
+def test_twinID_range(ds: InfantMarmosetsVox) -> None:
     """Test that twinID values are in expected range (1-5)."""
-    sample = ds_train[0]
+    sample = ds[0]
     twin = sample["twinID"]
     assert 1 <= twin <= NUM_TWINS, f"twinID {twin} out of expected range 1-{NUM_TWINS}"
 
 
-def test_duration_positive(ds_train: InfantMarmosetsVox) -> None:
+def test_duration_positive(ds: InfantMarmosetsVox) -> None:
     """Test that duration values are positive."""
-    sample = ds_train[0]
+    sample = ds[0]
     duration = sample["duration"]
     assert duration > 0, f"Duration {duration} should be positive"
     assert sample["end"] > sample["start"], "End should be greater than start"


### PR DESCRIPTION
Adds the [InfantMarmosetsVox](https://zenodo.org/records/10130104) dataset.

Implementation has two pre-sampled rates:
- 44.1 kHz (native)
- 16 kHz (downsampled via librosa)

Files uploaded to `gs://esp-ml-datasets/infant_marmosets_vox`.