### PR TITLE
Moving GBIFConverter to esp-data

### DIFF
--- a/esp_data/discover/__init__.py
+++ b/esp_data/discover/__init__.py
@@ -1,0 +1,3 @@
+from .gbif_taxonomy import AddTaxonomy, AddTaxonomyConfig, GBIFConverter
+
+__all__ = ["GBIFConverter", "AddTaxonomy", "AddTaxonomyConfig"]

--- a/esp_data/discover/gbif_taxonomy.py
+++ b/esp_data/discover/gbif_taxonomy.py
@@ -6,6 +6,7 @@ downloadable from Google Cloud Storage, but can be cached
 """
 
 import logging
+from pathlib import Path
 from typing import Any, Literal
 
 import numpy as np
@@ -20,9 +21,12 @@ logger = logging.getLogger("esp_data")
 
 
 TAXONOMY_RANKS = ["kingdom", "phylum", "class", "order", "family", "genus"]
-# TODO: need a more managed location for this file
-DEFAULT_LOCATION = "gs://sound-event-detection/taxonomy/gbif_animals.tsv"
-CACHE_PATH = None  # TODO: what's the right place for a default cache?
+# TODO: need a better versioning system
+VERSION = "0.1.0"
+DEFAULT_LOCATION = "gs://esp-ml-datasets/gbif_taxonomy/v0.1.0/gbif_animals.tsv"
+# Use current script directory for cache
+this_dir = Path(__file__).parent.resolve()
+CACHE_PATH = str(this_dir / "gbif_animals.tsv")
 
 
 class GBIFConverter:
@@ -197,8 +201,9 @@ class AddTaxonomy:
     Uses GBIFConverter to resolve scientific names in a specified column
     to their accepted species-level taxonomic records. New columns are added
     for each taxonomy rank: 'kingdom', 'phylum', 'class', 'order', 'family', 'genus'.
-    An extra column 'taxonomic_name' is also added containing the resolved
-    canonical species name.
+    An extra column 'taxonomic_name' is also added, which concatenates
+    the higher ranks with the canonical name e.g.
+    "Animalia Chordata Aves Passeriformes Corvidae Corvus corax".
 
     Parameters
     ----------
@@ -246,6 +251,9 @@ class AddTaxonomy:
         str | None
             Full taxonomic name (including higher ranks) or None if unavailable.
         """
+        if not info:
+            return None
+
         taxonomic_name = ""
         for rank in TAXONOMY_RANKS[:-1]:  # Exclude genus
             rank_value = info.get(rank)
@@ -253,6 +261,7 @@ class AddTaxonomy:
                 if taxonomic_name:
                     taxonomic_name += " "
                 taxonomic_name += rank_value
+
         # Add canonicalName
         canonical_name = info.get("canonicalName")
         if canonical_name:
@@ -320,7 +329,6 @@ class AddTaxonomy:
 
         metadata = {
             "feature": self.feature,
-            "unique_names": len(unique_names),
             "resolved": success_count,
             "failed": failure_count,
             "taxonomy_columns_added": EXTENDED_RANKS,

--- a/esp_data/discover/gbif_taxonomy.py
+++ b/esp_data/discover/gbif_taxonomy.py
@@ -1,0 +1,338 @@
+"""
+V2 of taxonomy lookup service. Redirects synonyms to GBIF accepted taxonomy.
+
+Uses a preprocessed TSV of GBIF backbone taxonomy for animals,
+downloadable from Google Cloud Storage, but can be cached
+"""
+
+import logging
+from typing import Any, Literal
+
+import numpy as np
+import pandas as pd
+from pydantic import BaseModel, Field, field_validator
+
+from esp_data.backends import DataBackend
+from esp_data.io import AnyPathT, exists, filesystem_from_path
+from esp_data.transforms import register_transform
+
+logger = logging.getLogger("esp_data")
+
+
+TAXONOMY_RANKS = ["kingdom", "phylum", "class", "order", "family", "genus"]
+# TODO: need a more managed location for this file
+DEFAULT_LOCATION = "gs://sound-event-detection/taxonomy/gbif_animals.tsv"
+CACHE_PATH = None  # TODO: what's the right place for a default cache?
+
+
+class GBIFConverter:
+    """
+    Utility for resolving GBIF taxonomic names to their accepted species-level
+    usage using the GBIF backbone taxonomy.
+
+    The underlying GBIF table is indexed by both ``taxonID`` (unique) and
+    ``canonicalName`` (potentially non-unique) to support efficient lookups.
+
+    Parameters
+    ----------
+    gbif_animals_tsv_fp : str, optional
+        Path to a TSV file containing animal GBIF taxonomy records,
+        preprocessed via scripts/v2_source_to_tsv.py
+
+    cache_path : str | AnyPathT | None, optional
+        Path to a local cached copy of the GBIF taxonomy table. If provided,
+        this path will be used instead of ``gbif_animals_tsv_fp``.
+
+    Examples
+    --------
+    >>> converter = GBIFConverter()
+    >>> info, ok = converter("Corvus corax")
+    >>> assert ok
+    >>> assert info["canonicalName"] == "Corvus corax"
+    >>> assert info["taxonRank"] == "species"
+    """
+
+    def __init__(
+        self,
+        gbif_animals_tsv_fp: str | AnyPathT = DEFAULT_LOCATION,
+        cache_path: str | AnyPathT | None = CACHE_PATH,
+    ) -> None:
+        """
+        Load the GBIF animals taxonomy table and construct lookup indices.
+
+        Parameters
+        ----------
+        gbif_animals_tsv_fp : str, optional
+            Path to a TSV file containing animal GBIF taxonomy records,
+            preprocessed via scripts/v2_source_to_tsv.py
+        cache_path : str | AnyPathT | None, optional
+            Path to a local cached copy of the GBIF taxonomy table. If provided,
+            this path will be used instead of ``gbif_animals_tsv_fp``.
+        """
+        _save_tsv = False
+        if cache_path is not None:
+            if not exists(cache_path):
+                logger.warning(
+                    f"GBIFConverter: cache_path {cache_path} does not exist but has been set"
+                    ", so we'll download and save the data to it."
+                )
+                _save_tsv = True
+            else:
+                gbif_animals_tsv_fp = cache_path
+
+        fs = filesystem_from_path(gbif_animals_tsv_fp)
+        with fs.open(gbif_animals_tsv_fp, "rb") as f:
+            self.df = pd.read_csv(f, sep="\t")
+
+        if _save_tsv:
+            self.df.to_csv(cache_path, sep="\t", index=False)
+
+        # Ensure unique integer taxonID index for O(1)-ish label lookups
+        self.df["taxonID"] = self.df["taxonID"].astype(np.int64)
+        self.df = self.df.set_index("taxonID", verify_integrity=True, drop=False)
+
+        # Canonical name index may be non-unique but with low-dup rate
+        self.df_by_canonical_name = self.df.set_index("canonicalName", drop=False)
+
+    def __call__(self, lookup_name: str) -> tuple[dict[str, Any], bool]:
+        """
+        Resolve a scientific (canonical) name to its accepted species-level
+        GBIF taxonomic record.
+
+        The method:
+        - Resolves duplicate canonical-name matches by preferring accepted usages.
+        - Walks up the taxonomy if the matched record is below species rank.
+        - Redirects unaccepted names to their accepted usage.
+        - Detects and aborts on cyclic or inconsistent references.
+
+        Parameters
+        ----------
+        lookup_name : str
+            Canonical scientific name to resolve (e.g., ``"Corvus corax"``).
+
+        Returns
+        -------
+        (dict, bool)
+            A tuple ``(info, ok)`` where ``info`` is a dictionary containing the
+            resolved GBIF taxonomic fields (empty on failure), and ``ok`` is a
+            boolean indicating whether resolution succeeded.
+        """
+        visited: set[str] = set()
+
+        while True:
+            # Protect against pathological cycles / corrupted pointers
+            if lookup_name in visited:
+                return {}, False
+            visited.add(lookup_name)
+
+            try:
+                looked_up = self.df_by_canonical_name.loc[lookup_name]
+            except KeyError:
+                return {}, False
+
+            # Resolve duplicates: prefer an accepted usage if present; else take first.
+            if isinstance(looked_up, pd.DataFrame):
+                accepted_mask = looked_up["taxonomicStatus"].to_numpy() == "accepted"
+                if accepted_mask.any():
+                    looked_up = looked_up.iloc[int(accepted_mask.argmax())]
+                else:
+                    looked_up = looked_up.iloc[0]
+
+            # Resolve lower taxa (walk up to species)
+            if looked_up["taxonRank"] != "species":
+                parent_id = looked_up["parentNameUsageID"]
+                if pd.isna(parent_id):
+                    return {}, False
+                parent_id = int(parent_id)
+
+                try:
+                    lookup_name = self.df.loc[parent_id, "canonicalName"]
+                except KeyError:
+                    return {}, False
+
+                continue
+
+            # Resolve unaccepted names (walk to accepted/doubtful)
+            # We allow doubtful names for completeness because they don't have synonyms.
+            # e.g. Aegithalos caudatus is considered doubtful but is widely recognized.
+            if looked_up["taxonomicStatus"] not in ["accepted", "doubtful"]:
+                accepted_id = looked_up["acceptedNameUsageID"]
+                if pd.isna(accepted_id):
+                    return {}, False
+                accepted_id = int(accepted_id)
+
+                try:
+                    lookup_name = self.df.loc[accepted_id, "canonicalName"]
+                except KeyError:
+                    return {}, False
+
+                continue
+
+            # Return info as dict
+            out = looked_up.to_dict()
+            out["canonicalName"] = lookup_name
+            return out, True
+
+
+class AddTaxonomyConfig(BaseModel):
+    """Configuration for AddTaxonomyTransform."""
+
+    type: Literal["add_taxonomy"] = "add_taxonomy"
+    feature: str = Field(
+        description="Column name containing scientific names to look up.",
+        default="scientific_name",
+    )
+    gbif_taxonomy_path: str = Field(
+        description="Path to GBIF taxonomy TSV file.",
+        default=DEFAULT_LOCATION,
+    )
+    add_taxonomic_name: bool = Field(
+        description="Whether to add a 'taxonomic_name' column with the full taxonomic name.",
+        default=False,
+    )
+
+    @field_validator("gbif_taxonomy_path")
+    def check_file_exists(cls, v: str) -> str:
+        if not exists(v):
+            raise ValueError(f"GBIF data file does not exist: {v}")
+        return v
+
+
+class AddTaxonomy:
+    """
+    Transform that adds resolved GBIF taxonomy info to each row.
+
+    Uses GBIFConverter to resolve scientific names in a specified column
+    to their accepted species-level taxonomic records. New columns are added
+    for each taxonomy rank: 'kingdom', 'phylum', 'class', 'order', 'family', 'genus'.
+    An extra column 'taxonomic_name' is also added containing the resolved
+    canonical species name.
+
+    Parameters
+    ----------
+    feature : str
+        Column name containing scientific names to look up.
+    gbif_taxonomy_db : str | AnyPathT
+        Path to GBIF taxonomy TSV file.
+
+    Examples
+    --------
+    >>> from esp_data.backends import PandasBackend
+    >>> import pandas as pd
+    >>> df = pd.DataFrame({"scientific_name": ["Corvus corax", "Passer domesticus"]})
+    >>> backend = PandasBackend(df)
+    >>> transform = AddTaxonomyTransform(feature="scientific_name")
+    >>> transformed_backend, metadata = transform(backend)
+    """
+
+    def __init__(
+        self,
+        feature: str = "scientific_name",
+        gbif_taxonomy_path: str | AnyPathT = DEFAULT_LOCATION,
+        add_taxonomic_name: bool = False,
+    ) -> None:
+        self.feature = feature
+        self.converter = GBIFConverter(gbif_taxonomy_path)
+        self.add_taxonomic_name = add_taxonomic_name
+
+    @classmethod
+    def from_config(cls, cfg: AddTaxonomyConfig) -> "AddTaxonomy":
+        return cls(**cfg.model_dump(exclude={"type"}))
+
+    def _make_taxonomic_name(self, info: dict[str, str]) -> str | None:
+        """Construct the full taxonomic name from GBIF info.
+
+        Parameters
+        ----------
+        info : dict[str, str]
+            GBIF taxonomic record fields.
+
+        Returns
+        -------
+        str | None
+            Full taxonomic name (including higher ranks) or None if unavailable.
+        """
+        taxonomic_name = ""
+        for rank in TAXONOMY_RANKS[:-1]:  # Exclude genus
+            rank_value = info.get(rank)
+            if rank_value:
+                if taxonomic_name:
+                    taxonomic_name += " "
+                taxonomic_name += rank_value
+        # Add canonicalName
+        canonical_name = info.get("canonicalName")
+        if canonical_name:
+            if taxonomic_name:
+                taxonomic_name += " "
+            taxonomic_name += canonical_name
+
+        return taxonomic_name if len(taxonomic_name) > 0 else None
+
+    def __call__(self, backend: DataBackend) -> tuple[DataBackend, dict]:
+        """
+        Apply the transform to add taxonomy columns.
+
+        Parameters
+        ----------
+        backend : DataBackend
+            The backend wrapping the DataFrame to transform.
+
+        Returns
+        -------
+        tuple[DataBackend, dict]
+            A tuple containing the transformed backend with taxonomy columns added,
+            and metadata about the resolution (success/failure counts).
+
+        Raises
+        ------
+        ValueError
+            If the specified feature column is not found in the DataFrame.
+        """
+        if self.feature not in backend.columns:
+            raise ValueError(f"Feature column '{self.feature}' not found in data.")
+
+        # Get unique scientific names to look up (avoids redundant lookups)
+        unique_names = backend.get_unique(self.feature)
+
+        # Build a lookup cache: rank -> [{scientific_name -> value}]
+        # e.g. {'kingdom': [{'Corvus corax': 'Animalia'}, ...], ...}
+        EXTENDED_RANKS = TAXONOMY_RANKS
+        if self.add_taxonomic_name:
+            EXTENDED_RANKS = TAXONOMY_RANKS + ["taxonomic_name"]
+        taxonomy_cache: dict[str, list[tuple[str, str]]] = {r: [] for r in EXTENDED_RANKS}
+        success_count = 0
+        failure_count = 0
+
+        for name in unique_names:
+            info, ok = self.converter(name)
+            if ok:
+                # Fill by rank
+                for rank in TAXONOMY_RANKS:
+                    taxonomy_cache[rank].append((name, info.get(rank)))
+                if self.add_taxonomic_name:
+                    taxonomy_cache["taxonomic_name"].append((name, self._make_taxonomic_name(info)))
+                success_count += 1
+            else:
+                failure_count += 1
+                logger.debug(f"Failed to resolve taxonomy for: {name}")
+
+        if failure_count > 0:
+            logger.warning(f"Failed to resolve {failure_count}/{len(unique_names)} unique names")
+
+        # Map resolved taxonomy back to backend, adding new columns
+        for rank in EXTENDED_RANKS:
+            rank_mapping = {src: target for src, target in taxonomy_cache[rank]}
+            backend = backend.map_column(self.feature, mapping=rank_mapping, output_column=rank)
+
+        metadata = {
+            "feature": self.feature,
+            "unique_names": len(unique_names),
+            "resolved": success_count,
+            "failed": failure_count,
+            "taxonomy_columns_added": EXTENDED_RANKS,
+        }
+
+        return backend, metadata
+
+
+register_transform(AddTaxonomyConfig, AddTaxonomy)

--- a/esp_data/discover/gbif_taxonomy.py
+++ b/esp_data/discover/gbif_taxonomy.py
@@ -42,14 +42,6 @@ class GBIFConverter:
     cache_path : str | AnyPathT | None, optional
         Path to a local cached copy of the GBIF taxonomy table. If provided,
         this path will be used instead of ``gbif_animals_tsv_fp``.
-
-    Examples
-    --------
-    >>> converter = GBIFConverter()
-    >>> info, ok = converter("Corvus corax")
-    >>> assert ok
-    >>> assert info["canonicalName"] == "Corvus corax"
-    >>> assert info["taxonRank"] == "species"
     """
 
     def __init__(
@@ -221,8 +213,10 @@ class AddTaxonomy:
     >>> import pandas as pd
     >>> df = pd.DataFrame({"scientific_name": ["Corvus corax", "Passer domesticus"]})
     >>> backend = PandasBackend(df)
-    >>> transform = AddTaxonomyTransform(feature="scientific_name")
+    >>> transform = AddTaxonomy(feature="scientific_name")
     >>> transformed_backend, metadata = transform(backend)
+    >>> assert "kingdom" in transformed_backend.columns
+    >>> assert "genus" in transformed_backend.columns
     """
 
     def __init__(

--- a/scripts/data_preprocessing_scripts/taxonomy_v2_source_to_tsv.py
+++ b/scripts/data_preprocessing_scripts/taxonomy_v2_source_to_tsv.py
@@ -1,0 +1,85 @@
+"""
+Script to convert GBIF backbone source to csv for simple queries
+
+Assumes Darwin Core Archive source has been downloaded from
+https://www.gbif.org/dataset/d7dddbf4-2cf0-4f39-9b2a-bb099caae36c
+and unzipped
+"""
+
+import csv
+import os
+import sys
+
+import pandas as pd
+
+SOURCE_DIR = "/mnt/home/taxonomy/data/backbone"
+
+csv.field_size_limit(sys.maxsize)
+
+# Input file from GBIF backbone taxonomy
+input_file = os.path.join(SOURCE_DIR, "Taxon.tsv")
+output_file = os.path.join(SOURCE_DIR, "gbif_animals.tsv")
+
+# Build a dictionary of vernacular names by taxonID
+vernacular_names = {}
+vern_fp = os.path.join(SOURCE_DIR, "VernacularName.tsv")
+with open(vern_fp, "r", encoding="utf-8") as f:
+    reader = csv.DictReader(f, delimiter="\t")
+    for row in reader:
+        if row["language"] != "en":
+            continue
+        taxon_id = int(row["taxonID"])
+        vernacular_name = row["vernacularName"]
+        if taxon_id not in vernacular_names:
+            vernacular_names[taxon_id] = set()
+        vernacular_names[taxon_id].add(vernacular_name.lower())
+
+df = pd.read_csv(
+    input_file,
+    sep="\t",
+    quoting=csv.QUOTE_NONE,  # this fixes a parsing issue where \n and \t
+    # characters are enclosed in quotes in the original file.
+    engine="python",  # REQUIRED
+    escapechar="\\",  # optional but often needed
+)
+
+df = df[df["kingdom"] == "Animalia"]
+df = df.set_index("taxonID")
+df = df[df["taxonRank"].isin(["species", "subspecies", "variety", "form"])]
+tokeep = [
+    "acceptedNameUsageID",
+    "parentNameUsageID",  # keep so we can look up subspecies
+    "canonicalName",
+    "taxonRank",
+    "taxonomicStatus",
+    "kingdom",
+    "phylum",
+    "class",
+    "order",
+    "family",
+    "genus",
+]
+df = df[tokeep]
+
+
+def get_vernacular_name(taxon_id: int) -> str:
+    """
+    Gets csv of vernacular names for a taxon id
+
+    Returns
+    --------
+    str csv of vernacular names
+    """
+    taxon_id = int(taxon_id)
+    if taxon_id not in vernacular_names:
+        return ""
+    else:
+        return ",".join(sorted(vernacular_names[taxon_id]))
+
+
+print("getting vernacular names")
+df["vernacularName"] = df.index.map(get_vernacular_name)
+print("done getting vernacular names")
+df.to_csv(output_file, sep="\t")
+
+# df = pd.read_csv(output_file, sep='\t', index_col='taxonID')

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -425,8 +425,7 @@ def test_add_taxonomy_with_add_taxonomic_name(tmp_path: Path) -> None:
 
     # Check that taxonomic_name is in the added columns
     assert "taxonomic_name" in metadata["taxonomy_columns_added"]
-    assert backend[0]["taxonomic_name"] == "Animalia Chordata Aves "
-    "Passeriformes Corvidae Corvus corax"
+    assert backend[0]["taxonomic_name"] == "Animalia Chordata Aves Passeriformes Corvidae Corvus corax"
 
 
 def test_add_taxonomy_make_taxonomic_name(tmp_path: Path) -> None:

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -1,0 +1,538 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from esp_data.backends import PandasBackend
+from esp_data.discover import AddTaxonomy, AddTaxonomyConfig, GBIFConverter
+
+
+def _write_gbif_tsv(tmp_path: Path, rows: List[Dict[str, Any]]) -> str:
+    """
+    Write a minimal GBIF-like TSV for testing and return its filepath.
+
+    The GBIFConverter implementation expects at least these columns:
+    - taxonID
+    - canonicalName
+    - taxonomicStatus
+    - taxonRank
+    - parentNameUsageID
+    - acceptedNameUsageID
+    """
+    df = pd.DataFrame(rows)
+
+    # Ensure column presence and ordering (useful for debugging)
+    required_cols = [
+        "taxonID",
+        "canonicalName",
+        "taxonomicStatus",
+        "taxonRank",
+        "parentNameUsageID",
+        "acceptedNameUsageID",
+    ]
+    missing = [c for c in required_cols if c not in df.columns]
+    if missing:
+        raise AssertionError(f"Missing required columns for fixture TSV: {missing}")
+
+    fp = tmp_path / "gbif_animals_minimal.tsv"
+    df.to_csv(fp, sep="\t", index=False)
+    return str(fp)
+
+
+# GBIFConverter Unit Tests
+
+def test_get_accepted_species_info_no_match(tmp_path: Path) -> None:
+    fp = _write_gbif_tsv(
+        tmp_path,
+        rows=[
+            {
+                "taxonID": 1,
+                "canonicalName": "Corvus corax",
+                "taxonomicStatus": "accepted",
+                "taxonRank": "species",
+                "parentNameUsageID": np.nan,
+                "acceptedNameUsageID": np.nan,
+            }
+        ],
+    )
+    converter = GBIFConverter(gbif_animals_tsv_fp=fp)
+
+    out, ok = converter("Does not exist")
+    assert out == {}
+    assert ok is False
+
+
+def test_get_accepted_species_info_accepts_species(tmp_path: Path) -> None:
+    fp = _write_gbif_tsv(
+        tmp_path,
+        rows=[
+            {
+                "taxonID": 10,
+                "canonicalName": "Corvus corax",
+                "taxonomicStatus": "accepted",
+                "taxonRank": "species",
+                "parentNameUsageID": np.nan,
+                "acceptedNameUsageID": np.nan,
+            }
+        ],
+    )
+    converter = GBIFConverter(gbif_animals_tsv_fp=fp)
+
+    out, ok = converter("Corvus corax")
+    assert ok is True
+    assert out["taxonID"] == 10
+    assert out["taxonomicStatus"] == "accepted"
+    assert out["taxonRank"] == "species"
+    assert out["canonicalName"] == "Corvus corax"
+
+
+def test_get_accepted_species_info_resolves_synonym_to_accepted(tmp_path: Path) -> None:
+    fp = _write_gbif_tsv(
+        tmp_path,
+        rows=[
+            # accepted usage
+            {
+                "taxonID": 100,
+                "canonicalName": "Puma concolor",
+                "taxonomicStatus": "accepted",
+                "taxonRank": "species",
+                "parentNameUsageID": np.nan,
+                "acceptedNameUsageID": np.nan,
+            },
+            # synonym that points to accepted usage
+            {
+                "taxonID": 101,
+                "canonicalName": "Felis concolor",
+                "taxonomicStatus": "synonym",
+                "taxonRank": "species",
+                "parentNameUsageID": np.nan,
+                "acceptedNameUsageID": 100.0,
+            },
+        ],
+    )
+    converter = GBIFConverter(gbif_animals_tsv_fp=fp)
+
+    out, ok = converter("Felis concolor")
+    assert ok is True
+    assert out["taxonID"] == 100
+    assert out["canonicalName"] == "Puma concolor"
+    assert out["taxonomicStatus"] == "accepted"
+    assert out["taxonRank"] == "species"
+
+
+def test_get_accepted_species_info_walks_up_from_lower_rank(tmp_path: Path) -> None:
+    fp = _write_gbif_tsv(
+        tmp_path,
+        rows=[
+            # accepted species
+            {
+                "taxonID": 200,
+                "canonicalName": "Canis lupus",
+                "taxonomicStatus": "accepted",
+                "taxonRank": "species",
+                "parentNameUsageID": np.nan,
+                "acceptedNameUsageID": np.nan,
+            },
+            # subspecies that points to parent species
+            {
+                "taxonID": 201,
+                "canonicalName": "Canis lupus familiaris",
+                "taxonomicStatus": "accepted",
+                "taxonRank": "subspecies",
+                "parentNameUsageID": 200.0,
+                "acceptedNameUsageID": np.nan,
+            },
+        ],
+    )
+    converter = GBIFConverter(gbif_animals_tsv_fp=fp)
+
+    out, ok = converter("Canis lupus familiaris")
+    assert ok is True
+    assert out["taxonID"] == 200
+    assert out["canonicalName"] == "Canis lupus"
+    assert out["taxonRank"] == "species"
+    assert out["taxonomicStatus"] == "accepted"
+
+
+def test_get_accepted_species_info_duplicate_canonical_prefers_accepted(tmp_path: Path) -> None:
+    fp = _write_gbif_tsv(
+        tmp_path,
+        rows=[
+            # accepted row for same canonicalName
+            {
+                "taxonID": 300,
+                "canonicalName": "Dup name",
+                "taxonomicStatus": "accepted",
+                "taxonRank": "species",
+                "parentNameUsageID": np.nan,
+                "acceptedNameUsageID": np.nan,
+            },
+            # non-accepted duplicate
+            {
+                "taxonID": 301,
+                "canonicalName": "Dup name",
+                "taxonomicStatus": "synonym",
+                "taxonRank": "species",
+                "parentNameUsageID": np.nan,
+                "acceptedNameUsageID": 300.0,
+            },
+        ],
+    )
+    converter = GBIFConverter(gbif_animals_tsv_fp=fp)
+
+    out, ok = converter("Dup name")
+    assert ok is True
+    assert out["taxonID"] == 300
+    assert out["taxonomicStatus"] == "accepted"
+    assert out["taxonRank"] == "species"
+    assert out["canonicalName"] == "Dup name"
+
+
+def test_get_accepted_species_info_cycle_is_detected(tmp_path: Path) -> None:
+    fp = _write_gbif_tsv(
+        tmp_path,
+        rows=[
+            # non-species record whose parent points to itself (cycle)
+            {
+                "taxonID": 400,
+                "canonicalName": "Cycle name",
+                "taxonomicStatus": "accepted",
+                "taxonRank": "subspecies",
+                "parentNameUsageID": 400.0,
+                "acceptedNameUsageID": np.nan,
+            }
+        ],
+    )
+    converter = GBIFConverter(gbif_animals_tsv_fp=fp)
+
+    out, ok = converter("Cycle name")
+    assert out == {}
+    assert ok is False
+
+
+# AddTaxonomy Transform Unit Tests
+
+def _create_gbif_tsv_with_taxonomy(tmp_path: Path) -> str:
+    """Create a GBIF TSV with full taxonomy info for testing AddTaxonomy."""
+    rows = [
+        {
+            "taxonID": 1,
+            "canonicalName": "Corvus corax",
+            "taxonomicStatus": "accepted",
+            "taxonRank": "species",
+            "parentNameUsageID": np.nan,
+            "acceptedNameUsageID": np.nan,
+            "kingdom": "Animalia",
+            "phylum": "Chordata",
+            "class": "Aves",
+            "order": "Passeriformes",
+            "family": "Corvidae",
+            "genus": "Corvus",
+        },
+        {
+            "taxonID": 2,
+            "canonicalName": "Passer domesticus",
+            "taxonomicStatus": "accepted",
+            "taxonRank": "species",
+            "parentNameUsageID": np.nan,
+            "acceptedNameUsageID": np.nan,
+            "kingdom": "Animalia",
+            "phylum": "Chordata",
+            "class": "Aves",
+            "order": "Passeriformes",
+            "family": "Passeridae",
+            "genus": "Passer",
+        },
+        {
+            "taxonID": 3,
+            "canonicalName": "Canis lupus",
+            "taxonomicStatus": "accepted",
+            "taxonRank": "species",
+            "parentNameUsageID": np.nan,
+            "acceptedNameUsageID": np.nan,
+            "kingdom": "Animalia",
+            "phylum": "Chordata",
+            "class": "Mammalia",
+            "order": "Carnivora",
+            "family": "Canidae",
+            "genus": "Canis",
+        },
+        # add one synonym entry
+        {
+            "taxonID": 4,
+            "canonicalName": "Felis concolor",
+            "taxonomicStatus": "synonym",
+            "taxonRank": "species",
+            "parentNameUsageID": np.nan,
+            "acceptedNameUsageID": 5.0,
+            "kingdom": "Animalia",
+            "phylum": "Chordata",
+            "class": "Mammalia",
+            "order": "Carnivora",
+            "family": "Felidae",
+            "genus": "Felis",
+        },
+        {
+            "taxonID": 5,
+            "canonicalName": "Puma concolor",
+            "taxonomicStatus": "accepted",
+            "taxonRank": "species",
+            "parentNameUsageID": np.nan,
+            "acceptedNameUsageID": np.nan,
+            "kingdom": "Animalia",
+            "phylum": "Chordata",
+            "class": "Mammalia",
+            "order": "Carnivora",
+            "family": "Felidae",
+            "genus": "Puma",
+        },
+    ]
+    df = pd.DataFrame(rows)
+    fp = tmp_path / "gbif_with_taxonomy.tsv"
+    df.to_csv(fp, sep="\t", index=False)
+    return str(fp)
+
+
+def test_add_taxonomy_basic(tmp_path: Path) -> None:
+    """Test basic AddTaxonomy transform functionality."""
+    gbif_path = _create_gbif_tsv_with_taxonomy(tmp_path)
+
+    # Create test data
+    df = pd.DataFrame({"scientific_name": ["Corvus corax", "Passer domesticus"]})
+    backend = PandasBackend(df)
+
+    # Apply transform
+    transform = AddTaxonomy(feature="scientific_name", gbif_taxonomy_path=gbif_path)
+    result_backend, metadata = transform(backend)
+
+    # Check that taxonomy columns were added
+    result_df = result_backend.unwrap
+    assert "kingdom" in result_df.columns
+    assert "phylum" in result_df.columns
+    assert "class" in result_df.columns
+    assert "order" in result_df.columns
+    assert "family" in result_df.columns
+    assert "genus" in result_df.columns
+
+    # Check values
+    assert result_df.loc[0, "kingdom"] == "Animalia"
+    assert result_df.loc[0, "class"] == "Aves"
+    assert result_df.loc[0, "family"] == "Corvidae"
+    assert result_df.loc[1, "family"] == "Passeridae"
+
+
+def test_add_taxonomy_from_config(tmp_path: Path) -> None:
+    """Test AddTaxonomy.from_config class method."""
+    gbif_path = _create_gbif_tsv_with_taxonomy(tmp_path)
+
+    config = AddTaxonomyConfig(
+        type="add_taxonomy",
+        feature="species",
+        gbif_taxonomy_path=gbif_path,
+    )
+    transform = AddTaxonomy.from_config(config)
+
+    # Create test data
+    df = pd.DataFrame({"species": ["Canis lupus"]})
+    backend = PandasBackend(df)
+
+    result_backend, metadata = transform(backend)
+
+    result_df = result_backend.unwrap
+    assert result_df.loc[0, "class"] == "Mammalia"
+    assert result_df.loc[0, "order"] == "Carnivora"
+    assert result_df.loc[0, "family"] == "Canidae"
+
+
+def test_add_taxonomy_missing_feature_column(tmp_path: Path) -> None:
+    """Test that AddTaxonomy raises ValueError for missing feature column."""
+    gbif_path = _create_gbif_tsv_with_taxonomy(tmp_path)
+
+    df = pd.DataFrame({"wrong_column": ["Corvus corax"]})
+    backend = PandasBackend(df)
+
+    transform = AddTaxonomy(feature="scientific_name", gbif_taxonomy_path=gbif_path)
+
+    with pytest.raises(ValueError, match="Feature column 'scientific_name' not found in data"):
+        transform(backend)
+
+
+def test_add_taxonomy_metadata(tmp_path: Path) -> None:
+    """Test that AddTaxonomy returns correct metadata."""
+    gbif_path = _create_gbif_tsv_with_taxonomy(tmp_path)
+
+    # Create test data with some duplicates and one unresolvable name
+    df = pd.DataFrame(
+        {
+            "scientific_name": [
+                "Corvus corax",
+                "Corvus corax",  # duplicate
+                "Passer domesticus",
+                "Unknown species",  # won't resolve
+            ]
+        }
+    )
+    backend = PandasBackend(df)
+
+    transform = AddTaxonomy(feature="scientific_name", gbif_taxonomy_path=gbif_path)
+    _, metadata = transform(backend)
+
+    assert metadata["feature"] == "scientific_name"
+    assert metadata["unique_names"] == 3  # 3 unique names
+    assert metadata["resolved"] == 2  # 2 resolved
+    assert metadata["failed"] == 1  # 1 failed
+
+
+def test_add_taxonomy_unresolvable_names(tmp_path: Path) -> None:
+    """Test AddTaxonomy with names that cannot be resolved."""
+    gbif_path = _create_gbif_tsv_with_taxonomy(tmp_path)
+
+    df = pd.DataFrame({"scientific_name": ["Unknown species", "Another unknown"]})
+    backend = PandasBackend(df)
+
+    transform = AddTaxonomy(feature="scientific_name", gbif_taxonomy_path=gbif_path)
+    result_backend, metadata = transform(backend)
+
+    result_df = result_backend.unwrap
+
+    # Unresolved names should have NaN/None in taxonomy columns
+    assert pd.isna(result_df.loc[0, "kingdom"])
+    assert pd.isna(result_df.loc[0, "family"])
+
+    assert metadata["resolved"] == 0
+    assert metadata["failed"] == 2
+
+
+def test_add_taxonomy_with_add_taxonomic_name(tmp_path: Path) -> None:
+    """Test AddTaxonomy with add_taxonomic_name=True."""
+    gbif_path = _create_gbif_tsv_with_taxonomy(tmp_path)
+
+    config = AddTaxonomyConfig(
+        type="add_taxonomy",
+        feature="scientific_name",
+        gbif_taxonomy_path=gbif_path,
+        add_taxonomic_name=True,
+    )
+    transform = AddTaxonomy.from_config(config)
+
+    df = pd.DataFrame({"scientific_name": ["Corvus corax"]})
+    backend = PandasBackend(df)
+
+    _, metadata = transform(backend)
+
+    # Check that taxonomic_name is in the added columns
+    assert "taxonomic_name" in metadata["taxonomy_columns_added"]
+
+
+def test_add_taxonomy_make_taxonomic_name(tmp_path: Path) -> None:
+    """Test the _make_taxonomic_name method."""
+    gbif_path = _create_gbif_tsv_with_taxonomy(tmp_path)
+
+    transform = AddTaxonomy(feature="scientific_name", gbif_taxonomy_path=gbif_path)
+
+    info = {
+        "kingdom": "Animalia",
+        "phylum": "Chordata",
+        "class": "Aves",
+        "order": "Passeriformes",
+        "family": "Corvidae",
+        "genus": "Corvus",
+        "canonicalName": "Corvus corax",
+    }
+
+    result = transform._make_taxonomic_name(info)
+
+    # Should include kingdom, phylum, class, order, family (not genus) and canonicalName
+    assert "Animalia" in result
+    assert "Chordata" in result
+    assert "Aves" in result
+    assert "Passeriformes" in result
+    assert "Corvidae" in result
+    assert "Corvus corax" in result
+
+
+def test_add_taxonomy_make_taxonomic_name_empty(tmp_path: Path) -> None:
+    """Test _make_taxonomic_name with empty info."""
+    gbif_path = _create_gbif_tsv_with_taxonomy(tmp_path)
+
+    transform = AddTaxonomy(feature="scientific_name", gbif_taxonomy_path=gbif_path)
+
+    result = transform._make_taxonomic_name({})
+
+    assert result is None
+
+
+def test_add_taxonomy_config_validation(tmp_path: Path) -> None:
+    """Test that AddTaxonomyConfig validates file existence."""
+    with pytest.raises(ValueError, match="GBIF data file does not exist"):
+        AddTaxonomyConfig(
+            type="add_taxonomy",
+            feature="scientific_name",
+            gbif_taxonomy_path="/nonexistent/path/to/file.tsv",
+        )
+
+
+def test_add_taxonomy_empty_dataframe(tmp_path: Path) -> None:
+    """Test AddTaxonomy with an empty dataframe."""
+    gbif_path = _create_gbif_tsv_with_taxonomy(tmp_path)
+
+    df = pd.DataFrame({"scientific_name": []})
+    backend = PandasBackend(df)
+
+    transform = AddTaxonomy(feature="scientific_name", gbif_taxonomy_path=gbif_path)
+    result_backend, metadata = transform(backend)
+
+    assert len(result_backend) == 0
+    assert metadata["unique_names"] == 0
+    assert metadata["resolved"] == 0
+    assert metadata["failed"] == 0
+
+
+def test_add_taxonomy_integration_with_beanszero() -> None:
+    """Integration test: Apply AddTaxonomy to a subset of BEANSZero dataset.
+
+    This test uses the real GBIF taxonomy data from GCS and applies the
+    AddTaxonomy transform to a sample from the BEANSZero dataset.
+    """
+    from esp_data.datasets import BeansZero
+
+    # Load a small subset of iNaturalist (just enough for testing)
+    dataset = BeansZero(split="unseen-species-sci", backend="pandas")
+
+    # Get the first 100 rows for testing
+    sample_backend = dataset._data[:100]
+
+    # iNaturalist has 'canonical_name' column with scientific names
+    transform = AddTaxonomy(
+        feature="output",  # 'output' column has the canonical names in BeansZero
+        add_taxonomic_name=True,
+        # Uses default GCS path: gs://sound-event-detection/taxonomy/gbif_animals.tsv
+    )
+
+    result_backend, metadata = transform(sample_backend)
+
+    result_df = result_backend.unwrap
+
+    # Check that taxonomy columns were added
+    expected_columns = ["kingdom", "phylum", "class", "order", "family", "genus"]
+    for col in expected_columns:
+        assert col in result_df.columns, f"Expected column '{col}' not found in result"
+
+    # Check metadata
+    assert metadata["feature"] == "output"
+    assert metadata["unique_names"] > 0
+    assert metadata["resolved"] >= 0
+
+    # At least some names should have resolved successfully
+    non_null_kingdoms = result_df["kingdom"].notna().sum()
+    assert non_null_kingdoms > 0, "Expected at least some taxonomy resolutions"
+
+    # Check that resolved rows have consistent taxonomy
+    resolved_rows = result_df[result_df["kingdom"].notna()]
+    if len(resolved_rows) > 0:
+        # All resolved rows should have "Animalia" as kingdom (iNaturalist animal sounds)
+        assert (resolved_rows["kingdom"] == "Animalia").all()

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -59,7 +59,7 @@ def test_get_accepted_species_info_no_match(tmp_path: Path) -> None:
             }
         ],
     )
-    converter = GBIFConverter(gbif_animals_tsv_fp=fp)
+    converter = GBIFConverter(gbif_animals_tsv_fp=fp, cache_path=None)
 
     out, ok = converter("Does not exist")
     assert out == {}
@@ -80,7 +80,7 @@ def test_get_accepted_species_info_accepts_species(tmp_path: Path) -> None:
             }
         ],
     )
-    converter = GBIFConverter(gbif_animals_tsv_fp=fp)
+    converter = GBIFConverter(gbif_animals_tsv_fp=fp, cache_path=None)
 
     out, ok = converter("Corvus corax")
     assert ok is True
@@ -114,7 +114,7 @@ def test_get_accepted_species_info_resolves_synonym_to_accepted(tmp_path: Path) 
             },
         ],
     )
-    converter = GBIFConverter(gbif_animals_tsv_fp=fp)
+    converter = GBIFConverter(gbif_animals_tsv_fp=fp, cache_path=None)
 
     out, ok = converter("Felis concolor")
     assert ok is True
@@ -148,7 +148,7 @@ def test_get_accepted_species_info_walks_up_from_lower_rank(tmp_path: Path) -> N
             },
         ],
     )
-    converter = GBIFConverter(gbif_animals_tsv_fp=fp)
+    converter = GBIFConverter(gbif_animals_tsv_fp=fp, cache_path=None)
 
     out, ok = converter("Canis lupus familiaris")
     assert ok is True
@@ -182,7 +182,7 @@ def test_get_accepted_species_info_duplicate_canonical_prefers_accepted(tmp_path
             },
         ],
     )
-    converter = GBIFConverter(gbif_animals_tsv_fp=fp)
+    converter = GBIFConverter(gbif_animals_tsv_fp=fp, cache_path=None)
 
     out, ok = converter("Dup name")
     assert ok is True
@@ -207,7 +207,7 @@ def test_get_accepted_species_info_cycle_is_detected(tmp_path: Path) -> None:
             }
         ],
     )
-    converter = GBIFConverter(gbif_animals_tsv_fp=fp)
+    converter = GBIFConverter(gbif_animals_tsv_fp=fp, cache_path=None)
 
     out, ok = converter("Cycle name")
     assert out == {}
@@ -382,7 +382,6 @@ def test_add_taxonomy_metadata(tmp_path: Path) -> None:
     _, metadata = transform(backend)
 
     assert metadata["feature"] == "scientific_name"
-    assert metadata["unique_names"] == 3  # 3 unique names
     assert metadata["resolved"] == 2  # 2 resolved
     assert metadata["failed"] == 1  # 1 failed
 
@@ -422,10 +421,12 @@ def test_add_taxonomy_with_add_taxonomic_name(tmp_path: Path) -> None:
     df = pd.DataFrame({"scientific_name": ["Corvus corax"]})
     backend = PandasBackend(df)
 
-    _, metadata = transform(backend)
+    backend, metadata = transform(backend)
 
     # Check that taxonomic_name is in the added columns
     assert "taxonomic_name" in metadata["taxonomy_columns_added"]
+    assert backend[0]["taxonomic_name"] == "Animalia Chordata Aves "
+    "Passeriformes Corvidae Corvus corax"
 
 
 def test_add_taxonomy_make_taxonomic_name(tmp_path: Path) -> None:
@@ -487,7 +488,6 @@ def test_add_taxonomy_empty_dataframe(tmp_path: Path) -> None:
     result_backend, metadata = transform(backend)
 
     assert len(result_backend) == 0
-    assert metadata["unique_names"] == 0
     assert metadata["resolved"] == 0
     assert metadata["failed"] == 0
 
@@ -506,15 +506,13 @@ def test_add_taxonomy_integration_with_beanszero() -> None:
     # Get the first 100 rows for testing
     sample_backend = dataset._data[:100]
 
-    # iNaturalist has 'canonical_name' column with scientific names
     transform = AddTaxonomy(
         feature="output",  # 'output' column has the canonical names in BeansZero
         add_taxonomic_name=True,
-        # Uses default GCS path: gs://sound-event-detection/taxonomy/gbif_animals.tsv
+        # Uses cache if present
     )
 
     result_backend, metadata = transform(sample_backend)
-
     result_df = result_backend.unwrap
 
     # Check that taxonomy columns were added
@@ -524,7 +522,6 @@ def test_add_taxonomy_integration_with_beanszero() -> None:
 
     # Check metadata
     assert metadata["feature"] == "output"
-    assert metadata["unique_names"] > 0
     assert metadata["resolved"] >= 0
 
     # At least some names should have resolved successfully
@@ -536,3 +533,10 @@ def test_add_taxonomy_integration_with_beanszero() -> None:
     if len(resolved_rows) > 0:
         # All resolved rows should have "Animalia" as kingdom (iNaturalist animal sounds)
         assert (resolved_rows["kingdom"] == "Animalia").all()
+
+    # Taxonomic names should be present
+    assert "taxonomic_name" in result_df.columns
+    for idx, row in resolved_rows.iterrows():
+        taxonomic_name = row["taxonomic_name"]
+        assert taxonomic_name is not None
+        assert "Animalia" in taxonomic_name


### PR DESCRIPTION
- Port GBIFConverter from taxonomy repo to esp-data as part of the new data discovery module (calling it `discover` for now, the idea would be to have a cli tool first like `uv run discover .. some queries ..`. Having taxonomy in this module will help to build a more comprehensive DatasetInfo c.f. #189 and do taxonomy validation.
- Added a `AddTaxonomy` transform that can help users add GBIF taxonomy to their datasets.
- Tests