### PR TITLE
add long-tail and select columns

### DIFF
--- a/esp_data/transforms/__init__.py
+++ b/esp_data/transforms/__init__.py
@@ -5,10 +5,12 @@ from .balanced_sample import BalancedSample, BalancedSampleConfig
 from .deduplicate import Deduplicate, DeduplicateConfig
 from .filter import Filter, FilterConfig
 from .label_from_feature import LabelFromFeature, LabelFromFeatureConfig
+from .long_tail_upsample import LongTailUpsample, LongTailUpsampleConfig
 from .multilabel_from_features import (
     MultiLabelFromFeatures,
     MultiLabelFromFeaturesConfig,
 )
+from .select_columns import SelectColumns, SelectColumnsConfig
 from .subsample import Subsample, SubsampleConfig
 
 __all__ = [
@@ -20,8 +22,12 @@ __all__ = [
     "FilterConfig",
     "LabelFromFeature",
     "LabelFromFeatureConfig",
+    "LongTailUpsample",
+    "LongTailUpsampleConfig",
     "MultiLabelFromFeatures",
     "MultiLabelFromFeaturesConfig",
+    "SelectColumns",
+    "SelectColumnsConfig",
     "Subsample",
     "SubsampleConfig",
     "register_transform",

--- a/esp_data/transforms/long_tail_upsample.py
+++ b/esp_data/transforms/long_tail_upsample.py
@@ -1,0 +1,162 @@
+import logging
+from typing import Literal
+
+from pydantic import BaseModel, field_validator
+
+from esp_data.backends.protocol import DataBackend
+
+from . import register_transform
+
+logger = logging.Logger("esp_data")
+
+
+class LongTailUpsampleConfig(BaseModel):
+    type: Literal["long_tail_upsample"]
+    property: str
+    sufficient_threshold: int
+    max_repeats: int
+    seed: int = 42
+
+    @field_validator("sufficient_threshold")
+    @classmethod
+    def validate_sufficient_threshold(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("`sufficient_threshold` must be >= 1")
+        return v
+
+    @field_validator("max_repeats")
+    @classmethod
+    def validate_max_repeats(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("`max_repeats` must be >= 1")
+        return v
+
+
+class LongTailUpsample:
+    """Upsample under-represented categories without excessive repetition.
+
+    Designed for long-tail distributions (e.g. bioacoustic species counts) where
+    a few categories dominate and many categories have very few examples. This
+    transform lifts the tail towards a `sufficient_threshold` while capping how
+    many times any single example can be repeated via `max_repeats`.
+
+    For each category with count *c*:
+
+    - If ``c >= sufficient_threshold``: the category is left untouched.
+    - If ``c < sufficient_threshold``: the target becomes
+      ``min(sufficient_threshold, c * max_repeats)``.
+
+    This produces a gradual compression of the distribution: well-represented
+    categories keep all their data, moderately-represented categories are boosted
+    to the threshold, and very rare categories are boosted as much as possible
+    without repeating any single example more than `max_repeats` times.
+
+    Parameters
+    ----------
+    property : str
+        The name of the property (column) to balance on.
+    sufficient_threshold : int
+        Categories with at least this many examples are left as-is. Categories
+        below this count are upsampled towards it, subject to `max_repeats`.
+    max_repeats : int
+        Maximum number of times any individual example may appear in the output.
+        Prevents over-fitting on very rare categories.
+    seed : int
+        Random seed for reproducibility. Defaults to 42.
+
+    Examples
+    -------
+    >>> from esp_data.transforms import LongTailUpsample, LongTailUpsampleConfig
+    >>> from esp_data.backends import PandasBackend
+    >>> import pandas as pd
+    >>> config = LongTailUpsampleConfig(
+    ...     type="long_tail_upsample",
+    ...     property="species",
+    ...     sufficient_threshold=6,
+    ...     max_repeats=3,
+    ...     seed=42,
+    ... )
+    >>> transform = LongTailUpsample.from_config(config)
+    >>> df = pd.DataFrame({
+    ...     "species": (
+    ...         ["common"] * 10
+    ...         + ["moderate"] * 4
+    ...         + ["rare"] * 1
+    ...     ),
+    ... })
+    >>> backend = PandasBackend(df)
+    >>> result, _ = transform(backend)
+    >>> # common (10): untouched — already >= 6
+    >>> # moderate (4): upsampled to min(6, 4*3)=6
+    >>> # rare (1): upsampled to min(6, 1*3)=3
+    """
+
+    def __init__(
+        self,
+        property: str,
+        sufficient_threshold: int,
+        max_repeats: int,
+        seed: int = 42,
+    ) -> None:
+        self.property = property
+        self.sufficient_threshold = sufficient_threshold
+        self.max_repeats = max_repeats
+        self.seed = seed
+
+    @classmethod
+    def from_config(cls, cfg: LongTailUpsampleConfig) -> "LongTailUpsample":
+        return cls(**cfg.model_dump(exclude=("type")))
+
+    def __call__(self, backend: DataBackend) -> tuple[DataBackend, dict]:
+        """Apply the long-tail upsample transformation.
+
+        Categories below `sufficient_threshold` are upsampled towards it,
+        bounded by `max_repeats`. Categories at or above the threshold are
+        left unchanged.
+
+        Parameters
+        ----------
+        backend : DataBackend
+            The backend wrapping the dataframe to transform.
+
+        Returns
+        -------
+        tuple[DataBackend, dict]
+            A tuple containing the transformed backend (same type as input)
+            and an empty metadata dictionary.
+
+        Raises
+        ------
+        KeyError
+            If the specified property is not found in the DataFrame columns.
+        """
+        if self.property not in backend.columns:
+            raise KeyError(f"Property '{self.property}' not found in the DataFrame columns.")
+
+        category_counts = backend.histogram(self.property)
+
+        if not category_counts:
+            return backend, {}
+
+        target_counts: dict[str, int] = {}
+        for value, count in category_counts.items():
+            if count == 0:
+                target_counts[value] = 0
+            elif count >= self.sufficient_threshold:
+                target_counts[value] = count
+            else:
+                target_counts[value] = min(
+                    self.sufficient_threshold,
+                    count * self.max_repeats,
+                )
+
+        sampled_backend = backend.upsample_by_column(
+            column=self.property,
+            target_counts=target_counts,
+            seed=self.seed,
+        )
+
+        return sampled_backend, {}
+
+
+register_transform(LongTailUpsampleConfig, LongTailUpsample)

--- a/esp_data/transforms/long_tail_upsample.py
+++ b/esp_data/transforms/long_tail_upsample.py
@@ -123,7 +123,8 @@ class LongTailUpsample:
         -------
         tuple[DataBackend, dict]
             A tuple containing the transformed backend (same type as input)
-            and an empty metadata dictionary.
+            and a metadata dictionary with keys ``histogram_before`` and
+            ``histogram_after``, each mapping category values to their counts.
 
         Raises
         ------
@@ -136,7 +137,7 @@ class LongTailUpsample:
         category_counts = backend.histogram(self.property)
 
         if not category_counts:
-            return backend, {}
+            return backend, {"histogram_before": {}, "histogram_after": {}}
 
         target_counts: dict[str, int] = {}
         for value, count in category_counts.items():
@@ -156,7 +157,12 @@ class LongTailUpsample:
             seed=self.seed,
         )
 
-        return sampled_backend, {}
+        histogram_after = sampled_backend.histogram(self.property)
+
+        return sampled_backend, {
+            "histogram_before": category_counts,
+            "histogram_after": histogram_after,
+        }
 
 
 register_transform(LongTailUpsampleConfig, LongTailUpsample)

--- a/esp_data/transforms/select_columns.py
+++ b/esp_data/transforms/select_columns.py
@@ -1,0 +1,92 @@
+import logging
+from typing import Literal
+
+from pydantic import BaseModel, field_validator
+
+from esp_data.backends.protocol import DataBackend
+
+from . import register_transform
+
+logger = logging.Logger("esp_data")
+
+
+class SelectColumnsConfig(BaseModel):
+    type: Literal["select_columns"]
+    columns: list[str]
+
+    @field_validator("columns")
+    @classmethod
+    def validate_columns(cls, v: list[str]) -> list[str]:
+        if len(v) == 0:
+            raise ValueError("`columns` must contain at least one column name")
+        return v
+
+
+class SelectColumns:
+    """Select a subset of columns from the dataset.
+
+    This transform keeps only the specified columns and drops all others.
+
+    Works with any backend (pandas, polars) through the DataBackend protocol.
+
+    Parameters
+    ----------
+    columns : list[str]
+        List of column names to keep.
+
+    Examples
+    -------
+    >>> from esp_data.transforms import SelectColumns, SelectColumnsConfig
+    >>> from esp_data.backends import PandasBackend
+    >>> import pandas as pd
+    >>> config = SelectColumnsConfig(
+    ...     type="select_columns",
+    ...     columns=["species", "audio"],
+    ... )
+    >>> transform = SelectColumns.from_config(config)
+    >>> df = pd.DataFrame({
+    ...     "species": ["bee", "ant"],
+    ...     "audio": ["/a.wav", "/b.wav"],
+    ...     "extra": [1, 2],
+    ... })
+    >>> backend = PandasBackend(df)
+    >>> result, _ = transform(backend)
+    """
+
+    def __init__(self, columns: list[str]) -> None:
+        self.columns = columns
+
+    @classmethod
+    def from_config(cls, cfg: SelectColumnsConfig) -> "SelectColumns":
+        return cls(columns=cfg.columns)
+
+    def __call__(self, backend: DataBackend) -> tuple[DataBackend, dict]:
+        """Select the specified columns from the backend.
+
+        Parameters
+        ----------
+        backend : DataBackend
+            The backend wrapping the dataframe to transform.
+
+        Returns
+        -------
+        tuple[DataBackend, dict]
+            A tuple containing the transformed backend with only the selected
+            columns and an empty metadata dictionary.
+
+        Raises
+        ------
+        KeyError
+            If any of the specified columns are not found in the backend.
+        """
+        missing = [c for c in self.columns if c not in backend.columns]
+        if missing:
+            raise KeyError(
+                f"Columns {missing} not found in the DataFrame. "
+                f"Available columns: {backend.columns}"
+            )
+
+        return backend.select_columns(self.columns), {}
+
+
+register_transform(SelectColumnsConfig, SelectColumns)

--- a/tests/test_long_tail_upsample.py
+++ b/tests/test_long_tail_upsample.py
@@ -1,0 +1,268 @@
+import pandas as pd
+import polars as pl
+import pytest
+
+from esp_data.backends import PandasBackend, PolarsBackend
+from esp_data.transforms import LongTailUpsample, LongTailUpsampleConfig
+
+
+def _get_class_counts(
+    backend: PandasBackend | PolarsBackend,
+    backend_type: str,
+    column: str = "class",
+) -> dict[str, int]:
+    """Extract per-class counts from a backend regardless of type.
+
+    Parameters
+    ----------
+    backend : PandasBackend | PolarsBackend
+        The backend to extract counts from.
+    backend_type : str
+        Either "pandas" or "polars".
+    column : str
+        Column name to count by.
+
+    Returns
+    -------
+    dict[str, int]
+        Mapping of category values to their counts.
+    """
+    if backend_type == "pandas":
+        df = backend.unwrap
+        return df[column].value_counts().to_dict()
+    else:
+        df = backend.unwrap
+        if isinstance(df, pl.LazyFrame):
+            df = df.collect()
+        counts_df = df.group_by(column).len()
+        return dict(
+            zip(
+                counts_df[column].to_list(),
+                counts_df["len"].to_list(),
+                strict=True,
+            )
+        )
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_above_threshold_untouched(backend_type: str) -> None:
+    """Categories at or above sufficient_threshold keep their original count."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"class": ["common"] * 500, "value": range(500)})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"class": ["common"] * 500, "value": range(500)})
+        backend = PolarsBackend(df)
+
+    config = LongTailUpsampleConfig(
+        type="long_tail_upsample",
+        property="class",
+        sufficient_threshold=300,
+        max_repeats=5,
+        seed=42,
+    )
+    transform = LongTailUpsample.from_config(config)
+    result, _ = transform(backend)
+
+    counts = _get_class_counts(result, backend_type)
+    assert counts["common"] == 500
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_below_threshold_upsampled_to_threshold(backend_type: str) -> None:
+    """Categories below threshold are upsampled to it when max_repeats allows."""
+    # 100 examples * max_repeats=5 = 500 >= threshold=300, so target = 300
+    if backend_type == "pandas":
+        df = pd.DataFrame({"class": ["moderate"] * 100, "value": range(100)})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"class": ["moderate"] * 100, "value": range(100)})
+        backend = PolarsBackend(df)
+
+    config = LongTailUpsampleConfig(
+        type="long_tail_upsample",
+        property="class",
+        sufficient_threshold=300,
+        max_repeats=5,
+        seed=42,
+    )
+    transform = LongTailUpsample.from_config(config)
+    result, _ = transform(backend)
+
+    counts = _get_class_counts(result, backend_type)
+    assert counts["moderate"] == 300
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_rare_capped_by_max_repeats(backend_type: str) -> None:
+    """Very rare categories are capped by max_repeats, not reaching threshold."""
+    # 3 examples * max_repeats=5 = 15 < threshold=300, so target = 15
+    if backend_type == "pandas":
+        df = pd.DataFrame({"class": ["rare"] * 3, "value": range(3)})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"class": ["rare"] * 3, "value": range(3)})
+        backend = PolarsBackend(df)
+
+    config = LongTailUpsampleConfig(
+        type="long_tail_upsample",
+        property="class",
+        sufficient_threshold=300,
+        max_repeats=5,
+        seed=42,
+    )
+    transform = LongTailUpsample.from_config(config)
+    result, _ = transform(backend)
+
+    counts = _get_class_counts(result, backend_type)
+    assert counts["rare"] == 15
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_long_tail_distribution(backend_type: str) -> None:
+    """End-to-end test with a realistic long-tail distribution."""
+    # common=500, moderate=100, uncommon=40, rare=3
+    # threshold=300, max_repeats=5
+    # Expected: common=500, moderate=300, uncommon=200, rare=15
+    classes = ["common"] * 500 + ["moderate"] * 100 + ["uncommon"] * 40 + ["rare"] * 3
+    values = list(range(len(classes)))
+
+    if backend_type == "pandas":
+        df = pd.DataFrame({"class": classes, "value": values})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"class": classes, "value": values})
+        backend = PolarsBackend(df)
+
+    config = LongTailUpsampleConfig(
+        type="long_tail_upsample",
+        property="class",
+        sufficient_threshold=300,
+        max_repeats=5,
+        seed=42,
+    )
+    transform = LongTailUpsample.from_config(config)
+    result, _ = transform(backend)
+
+    counts = _get_class_counts(result, backend_type)
+    assert counts["common"] == 500  # untouched
+    assert counts["moderate"] == 300  # min(300, 100*5=500) = 300
+    assert counts["uncommon"] == 200  # min(300, 40*5=200) = 200
+    assert counts["rare"] == 15  # min(300, 3*5=15) = 15
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_max_repeats_one_leaves_data_unchanged(backend_type: str) -> None:
+    """With max_repeats=1, no upsampling occurs regardless of threshold."""
+    classes = ["common"] * 500 + ["rare"] * 3
+    values = list(range(len(classes)))
+
+    if backend_type == "pandas":
+        df = pd.DataFrame({"class": classes, "value": values})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"class": classes, "value": values})
+        backend = PolarsBackend(df)
+
+    config = LongTailUpsampleConfig(
+        type="long_tail_upsample",
+        property="class",
+        sufficient_threshold=300,
+        max_repeats=1,
+        seed=42,
+    )
+    transform = LongTailUpsample.from_config(config)
+    result, _ = transform(backend)
+
+    counts = _get_class_counts(result, backend_type)
+    assert counts["common"] == 500
+    assert counts["rare"] == 3
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_missing_property_raises_key_error(backend_type: str) -> None:
+    """KeyError is raised when the property column does not exist."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"species": ["a", "b"], "value": [1, 2]})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"species": ["a", "b"], "value": [1, 2]})
+        backend = PolarsBackend(df)
+
+    transform = LongTailUpsample(
+        property="class",
+        sufficient_threshold=10,
+        max_repeats=3,
+    )
+    with pytest.raises(KeyError, match="class"):
+        transform(backend)
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_manual_vs_config(backend_type: str) -> None:
+    """Manual instantiation and from_config produce the same result."""
+    classes = ["a"] * 50 + ["b"] * 10 + ["c"] * 2
+    values = list(range(len(classes)))
+
+    if backend_type == "pandas":
+        df = pd.DataFrame({"class": classes, "value": values})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"class": classes, "value": values})
+        backend = PolarsBackend(df)
+
+    manual = LongTailUpsample(
+        property="class",
+        sufficient_threshold=30,
+        max_repeats=4,
+        seed=42,
+    )
+    manual_result, _ = manual(backend)
+
+    config = LongTailUpsampleConfig(
+        type="long_tail_upsample",
+        property="class",
+        sufficient_threshold=30,
+        max_repeats=4,
+        seed=42,
+    )
+    config_result, _ = LongTailUpsample.from_config(config)(backend)
+
+    if backend_type == "pandas":
+        manual_sorted = manual_result.unwrap.sort_values(by=["class", "value"]).reset_index(
+            drop=True
+        )
+        config_sorted = config_result.unwrap.sort_values(by=["class", "value"]).reset_index(
+            drop=True
+        )
+        pd.testing.assert_frame_equal(manual_sorted, config_sorted)
+    else:
+        m = manual_result.unwrap
+        c = config_result.unwrap
+        if isinstance(m, pl.LazyFrame):
+            m = m.collect()
+        if isinstance(c, pl.LazyFrame):
+            c = c.collect()
+        assert m.sort(by=["class", "value"]).equals(c.sort(by=["class", "value"]))
+
+
+def test_config_validation_sufficient_threshold() -> None:
+    """sufficient_threshold must be >= 1."""
+    with pytest.raises(ValueError, match="sufficient_threshold"):
+        LongTailUpsampleConfig(
+            type="long_tail_upsample",
+            property="class",
+            sufficient_threshold=0,
+            max_repeats=3,
+        )
+
+
+def test_config_validation_max_repeats() -> None:
+    """max_repeats must be >= 1."""
+    with pytest.raises(ValueError, match="max_repeats"):
+        LongTailUpsampleConfig(
+            type="long_tail_upsample",
+            property="class",
+            sufficient_threshold=100,
+            max_repeats=0,
+        )

--- a/tests/test_long_tail_upsample.py
+++ b/tests/test_long_tail_upsample.py
@@ -6,44 +6,6 @@ from esp_data.backends import PandasBackend, PolarsBackend
 from esp_data.transforms import LongTailUpsample, LongTailUpsampleConfig
 
 
-def _get_class_counts(
-    backend: PandasBackend | PolarsBackend,
-    backend_type: str,
-    column: str = "class",
-) -> dict[str, int]:
-    """Extract per-class counts from a backend regardless of type.
-
-    Parameters
-    ----------
-    backend : PandasBackend | PolarsBackend
-        The backend to extract counts from.
-    backend_type : str
-        Either "pandas" or "polars".
-    column : str
-        Column name to count by.
-
-    Returns
-    -------
-    dict[str, int]
-        Mapping of category values to their counts.
-    """
-    if backend_type == "pandas":
-        df = backend.unwrap
-        return df[column].value_counts().to_dict()
-    else:
-        df = backend.unwrap
-        if isinstance(df, pl.LazyFrame):
-            df = df.collect()
-        counts_df = df.group_by(column).len()
-        return dict(
-            zip(
-                counts_df[column].to_list(),
-                counts_df["len"].to_list(),
-                strict=True,
-            )
-        )
-
-
 @pytest.mark.parametrize("backend_type", ["pandas", "polars"])
 def test_above_threshold_untouched(backend_type: str) -> None:
     """Categories at or above sufficient_threshold keep their original count."""
@@ -64,7 +26,7 @@ def test_above_threshold_untouched(backend_type: str) -> None:
     transform = LongTailUpsample.from_config(config)
     result, _ = transform(backend)
 
-    counts = _get_class_counts(result, backend_type)
+    counts = result.histogram("class")
     assert counts["common"] == 500
 
 
@@ -89,7 +51,7 @@ def test_below_threshold_upsampled_to_threshold(backend_type: str) -> None:
     transform = LongTailUpsample.from_config(config)
     result, _ = transform(backend)
 
-    counts = _get_class_counts(result, backend_type)
+    counts = result.histogram("class")
     assert counts["moderate"] == 300
 
 
@@ -114,7 +76,7 @@ def test_rare_capped_by_max_repeats(backend_type: str) -> None:
     transform = LongTailUpsample.from_config(config)
     result, _ = transform(backend)
 
-    counts = _get_class_counts(result, backend_type)
+    counts = result.histogram("class")
     assert counts["rare"] == 15
 
 
@@ -142,13 +104,16 @@ def test_long_tail_distribution(backend_type: str) -> None:
         seed=42,
     )
     transform = LongTailUpsample.from_config(config)
-    result, _ = transform(backend)
+    result, meta = transform(backend)
 
-    counts = _get_class_counts(result, backend_type)
+    counts = result.histogram("class")
     assert counts["common"] == 500  # untouched
     assert counts["moderate"] == 300  # min(300, 100*5=500) = 300
     assert counts["uncommon"] == 200  # min(300, 40*5=200) = 200
     assert counts["rare"] == 15  # min(300, 3*5=15) = 15
+
+    assert meta["histogram_before"] == {"common": 500, "moderate": 100, "uncommon": 40, "rare": 3}
+    assert meta["histogram_after"] == counts
 
 
 @pytest.mark.parametrize("backend_type", ["pandas", "polars"])
@@ -172,11 +137,12 @@ def test_max_repeats_one_leaves_data_unchanged(backend_type: str) -> None:
         seed=42,
     )
     transform = LongTailUpsample.from_config(config)
-    result, _ = transform(backend)
+    result, meta = transform(backend)
 
-    counts = _get_class_counts(result, backend_type)
+    counts = result.histogram("class")
     assert counts["common"] == 500
     assert counts["rare"] == 3
+    assert meta["histogram_before"] == meta["histogram_after"]
 
 
 @pytest.mark.parametrize("backend_type", ["pandas", "polars"])
@@ -217,7 +183,7 @@ def test_manual_vs_config(backend_type: str) -> None:
         max_repeats=4,
         seed=42,
     )
-    manual_result, _ = manual(backend)
+    manual_result, manual_meta = manual(backend)
 
     config = LongTailUpsampleConfig(
         type="long_tail_upsample",
@@ -226,12 +192,13 @@ def test_manual_vs_config(backend_type: str) -> None:
         max_repeats=4,
         seed=42,
     )
-    config_result, _ = LongTailUpsample.from_config(config)(backend)
+    config_result, config_meta = LongTailUpsample.from_config(config)(backend)
 
-    manual_counts = _get_class_counts(manual_result, backend_type)
-    config_counts = _get_class_counts(config_result, backend_type)
+    manual_counts = manual_result.histogram("class")
+    config_counts = config_result.histogram("class")
     assert manual_counts == config_counts
     assert len(manual_result) == len(config_result)
+    assert manual_meta == config_meta
 
 
 def test_config_validation_sufficient_threshold() -> None:

--- a/tests/test_long_tail_upsample.py
+++ b/tests/test_long_tail_upsample.py
@@ -200,7 +200,7 @@ def test_missing_property_raises_key_error(backend_type: str) -> None:
 
 @pytest.mark.parametrize("backend_type", ["pandas", "polars"])
 def test_manual_vs_config(backend_type: str) -> None:
-    """Manual instantiation and from_config produce the same result."""
+    """Manual instantiation and from_config produce the same per-class counts."""
     classes = ["a"] * 50 + ["b"] * 10 + ["c"] * 2
     values = list(range(len(classes)))
 
@@ -228,22 +228,10 @@ def test_manual_vs_config(backend_type: str) -> None:
     )
     config_result, _ = LongTailUpsample.from_config(config)(backend)
 
-    if backend_type == "pandas":
-        manual_sorted = manual_result.unwrap.sort_values(by=["class", "value"]).reset_index(
-            drop=True
-        )
-        config_sorted = config_result.unwrap.sort_values(by=["class", "value"]).reset_index(
-            drop=True
-        )
-        pd.testing.assert_frame_equal(manual_sorted, config_sorted)
-    else:
-        m = manual_result.unwrap
-        c = config_result.unwrap
-        if isinstance(m, pl.LazyFrame):
-            m = m.collect()
-        if isinstance(c, pl.LazyFrame):
-            c = c.collect()
-        assert m.sort(by=["class", "value"]).equals(c.sort(by=["class", "value"]))
+    manual_counts = _get_class_counts(manual_result, backend_type)
+    config_counts = _get_class_counts(config_result, backend_type)
+    assert manual_counts == config_counts
+    assert len(manual_result) == len(config_result)
 
 
 def test_config_validation_sufficient_threshold() -> None:

--- a/tests/test_select_columns.py
+++ b/tests/test_select_columns.py
@@ -1,0 +1,123 @@
+import pandas as pd
+import polars as pl
+import pytest
+
+from esp_data.backends import PandasBackend, PolarsBackend
+from esp_data.transforms import SelectColumns, SelectColumnsConfig
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_select_subset(backend_type: str) -> None:
+    """Selecting a subset of columns keeps only those columns."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+        backend = PolarsBackend(df)
+
+    transform = SelectColumns(columns=["a", "c"])
+    result, metadata = transform(backend)
+
+    assert list(result.columns) == ["a", "c"]
+    assert metadata == {}
+    assert len(result) == 2
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_select_single_column(backend_type: str) -> None:
+    """Selecting a single column works correctly."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"x": [10, 20, 30], "y": [40, 50, 60]})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"x": [10, 20, 30], "y": [40, 50, 60]})
+        backend = PolarsBackend(df)
+
+    transform = SelectColumns(columns=["x"])
+    result, _ = transform(backend)
+
+    assert list(result.columns) == ["x"]
+    assert len(result) == 3
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_select_all_columns(backend_type: str) -> None:
+    """Selecting all columns returns a backend with the same shape."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"a": [1], "b": [2], "c": [3]})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"a": [1], "b": [2], "c": [3]})
+        backend = PolarsBackend(df)
+
+    transform = SelectColumns(columns=["a", "b", "c"])
+    result, _ = transform(backend)
+
+    assert list(result.columns) == ["a", "b", "c"]
+    assert len(result) == 1
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_missing_column_raises_key_error(backend_type: str) -> None:
+    """KeyError is raised when a requested column does not exist."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"a": [1], "b": [2]})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"a": [1], "b": [2]})
+        backend = PolarsBackend(df)
+
+    transform = SelectColumns(columns=["a", "missing"])
+    with pytest.raises(KeyError, match="missing"):
+        transform(backend)
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_preserves_column_order(backend_type: str) -> None:
+    """Output columns follow the order specified in the config, not the source."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"a": [1], "b": [2], "c": [3]})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"a": [1], "b": [2], "c": [3]})
+        backend = PolarsBackend(df)
+
+    transform = SelectColumns(columns=["c", "a"])
+    result, _ = transform(backend)
+
+    assert list(result.columns) == ["c", "a"]
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_manual_vs_config(backend_type: str) -> None:
+    """Manual instantiation and from_config produce the same result."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+        backend = PolarsBackend(df)
+
+    manual = SelectColumns(columns=["a", "c"])
+    manual_result, _ = manual(backend)
+
+    config = SelectColumnsConfig(type="select_columns", columns=["a", "c"])
+    config_result, _ = SelectColumns.from_config(config)(backend)
+
+    if backend_type == "pandas":
+        pd.testing.assert_frame_equal(manual_result.unwrap, config_result.unwrap)
+    else:
+        m = manual_result.unwrap
+        c = config_result.unwrap
+        if isinstance(m, pl.LazyFrame):
+            m = m.collect()
+        if isinstance(c, pl.LazyFrame):
+            c = c.collect()
+        assert m.equals(c)
+
+
+def test_config_validation_empty_columns() -> None:
+    """Config rejects an empty columns list."""
+    with pytest.raises(ValueError, match="columns"):
+        SelectColumnsConfig(type="select_columns", columns=[])


### PR DESCRIPTION
Adds two transforms:
- LongTailUpsample: A balancing transform slightly more tailored to bioacoustics, being used in both NatureLM-audio and SED so seems general enough to add
- select columns: filters to a subset of columns, used in NatureLM and flagged for addition to esp-data