### PR TITLE
Index a couple of new transforms in docs, and version bump

### DIFF
--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -166,10 +166,10 @@ The `SelectColumns` transform allows you to select a subset of columns from your
         show_source: true
 
 
-### LongtailUpsample Transform
-The `LongtailUpsample` transform performs upsampling of underrepresented classes in a long-tailed distribution. Example use case: Increasing the number of samples for rare species in a biodiversity dataset.
+### LongTailUpsample Transform
+The `LongTailUpsample` transform performs upsampling of underrepresented classes in a long-tailed distribution. Example use case: Increasing the number of samples for rare species in a biodiversity dataset.
 
-::: esp_data.transforms.LongtailUpsample
+::: esp_data.transforms.LongTailUpsample
     handler: python
     options:
         show_root_heading: true

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -154,3 +154,33 @@ The `Deduplicate` transform removes duplicate rows from your dataset based on sp
     options:
         show_root_heading: true
         show_source: true
+
+
+### SelectColumns Transform
+The `SelectColumns` transform allows you to select a subset of columns from your dataset. Example use case: Keeping only the 'audio' and 'label' columns for a machine learning task.
+
+::: esp_data.transforms.SelectColumns
+    handler: python
+    options:
+        show_root_heading: true
+        show_source: true
+
+
+### LongtailUpsample Transform
+The `LongtailUpsample` transform performs upsampling of underrepresented classes in a long-tailed distribution. Example use case: Increasing the number of samples for rare species in a biodiversity dataset.
+
+::: esp_data.transforms.LongtailUpsample
+    handler: python
+    options:
+        show_root_heading: true
+        show_source: true
+
+
+### AddTaxonomy Transform
+The `AddTaxonomy` transform adds precomputed GBIF taxonomic information to your dataset based on existing features. Example use case: Adding family and order information to a dataset with a 'species' column using GBIF taxonomy.
+
+::: esp_data.discover.AddTaxonomy
+    handler: python
+    options:
+        show_root_heading: true
+        show_source: true

--- a/esp_data/discover/gbif_taxonomy.py
+++ b/esp_data/discover/gbif_taxonomy.py
@@ -161,8 +161,11 @@ class AddTaxonomy:
     ----------
     feature : str
         Column name containing scientific names to look up.
-    precomputed_fp : str | AnyPathT
-        Path to precomputed GBIF taxonomy json file.
+    gbif_precomputed_taxonomy_path : str | AnyPathT
+        Path to GBIF taxonomy json file, preprocessed via
+        scripts/cache_gbif_taxonomy_conversion.py
+    add_taxonomic_name : bool
+        Whether to add a 'taxonomic_name' column with the full taxonomic name.
     """
 
     def __init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "esp-data"
-version = "1.7.0"
+version = "1.8.0"
 description = "Data tools for ESP projects"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -882,7 +882,7 @@ wheels = [
 
 [[package]]
 name = "esp-data"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "gcsfs" },


### PR DESCRIPTION
This release:

+ New datasets: Dclde2026, refreshed birdset, wabad, a few datasets with 16 and 32 Khz resampled versions
+ LongtailUpsample and SelectColumns transforms
+ Self-hosted CI runner 
+ Small doc update