### PR TITLE
Add downsample and upsample transforms

### DIFF
--- a/esp_data/transforms/__init__.py
+++ b/esp_data/transforms/__init__.py
@@ -3,6 +3,7 @@ from .registry import register_transform, transform_from_config  # isort:skip
 
 from .balanced_sample import BalancedSample, BalancedSampleConfig
 from .deduplicate import Deduplicate, DeduplicateConfig
+from .downsample import Downsample, DownsampleConfig
 from .filter import Filter, FilterConfig
 from .label_from_feature import LabelFromFeature, LabelFromFeatureConfig
 from .long_tail_upsample import LongTailUpsample, LongTailUpsampleConfig
@@ -12,12 +13,15 @@ from .multilabel_from_features import (
 )
 from .select_columns import SelectColumns, SelectColumnsConfig
 from .subsample import Subsample, SubsampleConfig
+from .upsample import Upsample, UpsampleConfig
 
 __all__ = [
     "BalancedSample",
     "BalancedSampleConfig",
     "Deduplicate",
     "DeduplicateConfig",
+    "Downsample",
+    "DownsampleConfig",
     "Filter",
     "FilterConfig",
     "LabelFromFeature",
@@ -30,6 +34,8 @@ __all__ = [
     "SelectColumnsConfig",
     "Subsample",
     "SubsampleConfig",
+    "Upsample",
+    "UpsampleConfig",
     "register_transform",
     "transform_from_config",
 ]

--- a/esp_data/transforms/downsample.py
+++ b/esp_data/transforms/downsample.py
@@ -1,0 +1,71 @@
+"""Transform to randomly keep a fraction of rows."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from esp_data.backends.protocol import DataBackend
+
+from . import register_transform
+
+
+class DownsampleConfig(BaseModel):
+    type: Literal["downsample"]
+    fraction: float = Field(gt=0.0, le=1.0)
+    seed: int = 42
+
+
+class Downsample:
+    """Randomly sample a fraction of rows from the dataset.
+
+    This transform keeps a random subset of rows, specified as a fraction of
+    the total.  Useful for quickly reducing dataset size for development or
+    ablation experiments.
+
+    Works with any backend (pandas, polars) through the DataBackend protocol.
+
+    Parameters
+    ----------
+    fraction : float
+        Fraction of rows to retain, in (0, 1].
+    seed : int
+        Random seed for reproducibility.
+
+    Examples
+    -------
+    >>> from esp_data.transforms import Downsample, DownsampleConfig
+    >>> from esp_data.backends import PandasBackend
+    >>> import pandas as pd
+    >>> config = DownsampleConfig(type="downsample", fraction=0.5, seed=42)
+    >>> downsample_transform = Downsample.from_config(config)
+    >>> df = pd.DataFrame({"species": ["bee"] * 100, "count": range(100)})
+    >>> backend = PandasBackend(df)
+    >>> downsampled_backend, _ = downsample_transform(backend)
+    """
+
+    def __init__(self, fraction: float, seed: int = 42) -> None:
+        self.fraction = fraction
+        self.seed = seed
+
+    @classmethod
+    def from_config(cls, cfg: DownsampleConfig) -> "Downsample":
+        return cls(**cfg.model_dump(exclude=("type",)))
+
+    def __call__(self, backend: DataBackend) -> tuple[DataBackend, dict]:
+        """Randomly keep ``fraction`` of the rows.
+
+        Parameters
+        ----------
+        backend : DataBackend
+            The backend wrapping the data to downsample.
+
+        Returns
+        -------
+        tuple[DataBackend, dict]
+            The downsampled backend and empty metadata dict.
+        """
+        n = max(1, round(len(backend) * self.fraction))
+        return backend.sample_rows(n=n, seed=self.seed), {}
+
+
+register_transform(DownsampleConfig, Downsample)

--- a/esp_data/transforms/upsample.py
+++ b/esp_data/transforms/upsample.py
@@ -1,0 +1,68 @@
+"""Transform to duplicate all rows N times."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from esp_data.backends.protocol import DataBackend
+
+from . import register_transform
+
+
+class UpsampleConfig(BaseModel):
+    type: Literal["upsample"]
+    factor: int = Field(ge=2)
+
+
+class Upsample:
+    """Repeat every row in a dataset a fixed number of times.
+
+    This transform concatenates the dataset with itself ``factor`` times,
+    effectively duplicating every row.  Useful when a small dataset needs to
+    be epoch-matched with larger ones during training.
+
+    Works with any backend (pandas, polars) through the DataBackend protocol.
+
+    Parameters
+    ----------
+    factor : int
+        Number of copies of the full dataset to concatenate.  Must be >= 2.
+
+    Examples
+    -------
+    >>> from esp_data.transforms import Upsample, UpsampleConfig
+    >>> from esp_data.backends import PandasBackend
+    >>> import pandas as pd
+    >>> config = UpsampleConfig(type="upsample", factor=3)
+    >>> upsample_transform = Upsample.from_config(config)
+    >>> df = pd.DataFrame({"species": ["bee", "ant"], "count": [3, 1]})
+    >>> backend = PandasBackend(df)
+    >>> upsampled_backend, _ = upsample_transform(backend)
+    >>> len(upsampled_backend)
+    6
+    """
+
+    def __init__(self, factor: int) -> None:
+        self.factor = factor
+
+    @classmethod
+    def from_config(cls, cfg: UpsampleConfig) -> "Upsample":
+        return cls(**cfg.model_dump(exclude=("type",)))
+
+    def __call__(self, backend: DataBackend) -> tuple[DataBackend, dict]:
+        """Repeat every row ``factor`` times.
+
+        Parameters
+        ----------
+        backend : DataBackend
+            The backend wrapping the data to upsample.
+
+        Returns
+        -------
+        tuple[DataBackend, dict]
+            The upsampled backend and empty metadata dict.
+        """
+        return type(backend).concat([backend] * self.factor), {}
+
+
+register_transform(UpsampleConfig, Upsample)

--- a/tests/test_downsample.py
+++ b/tests/test_downsample.py
@@ -1,0 +1,88 @@
+import pandas as pd
+import polars as pl
+import pytest
+
+from esp_data.backends import PandasBackend, PolarsBackend
+from esp_data.transforms import Downsample, DownsampleConfig
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_downsample(backend_type: str) -> None:
+    """Test that downsample keeps approximately the right fraction of rows."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"species": ["bee"] * 200, "value": range(200)})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"species": ["bee"] * 200, "value": range(200)})
+        backend = PolarsBackend(df)
+
+    config = DownsampleConfig(type="downsample", fraction=0.5, seed=42)
+    transform = Downsample.from_config(config)
+    result, meta = transform(backend)
+
+    assert meta == {}
+    assert abs(len(result) - 100) <= 1
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_downsample_full_fraction(backend_type: str) -> None:
+    """Test that fraction=1.0 keeps all rows."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"species": ["bee", "ant", "fly"], "value": [1, 2, 3]})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"species": ["bee", "ant", "fly"], "value": [1, 2, 3]})
+        backend = PolarsBackend(df)
+
+    transform = Downsample(fraction=1.0, seed=42)
+    result, _ = transform(backend)
+
+    assert len(result) == 3
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_downsample_small_fraction(backend_type: str) -> None:
+    """Test that a very small fraction still keeps at least 1 row."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"species": ["bee"] * 10, "value": range(10)})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"species": ["bee"] * 10, "value": range(10)})
+        backend = PolarsBackend(df)
+
+    transform = Downsample(fraction=0.01, seed=42)
+    result, _ = transform(backend)
+
+    assert len(result) >= 1
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_downsample_manual_vs_config(backend_type: str) -> None:
+    """Test that manual instantiation and from_config produce the same result."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"species": ["bee"] * 100, "value": range(100)})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"species": ["bee"] * 100, "value": range(100)})
+        backend = PolarsBackend(df)
+
+    manual_transform = Downsample(fraction=0.5, seed=42)
+    manual_result, _ = manual_transform(backend)
+
+    config = DownsampleConfig(type="downsample", fraction=0.5, seed=42)
+    config_transform = Downsample.from_config(config)
+    config_result, _ = config_transform(backend)
+
+    assert len(manual_result) == len(config_result)
+
+
+def test_downsample_config_validation() -> None:
+    """Test that invalid fraction values are rejected."""
+    with pytest.raises(Exception):
+        DownsampleConfig(type="downsample", fraction=0.0)
+
+    with pytest.raises(Exception):
+        DownsampleConfig(type="downsample", fraction=1.5)
+
+    with pytest.raises(Exception):
+        DownsampleConfig(type="downsample", fraction=-0.1)

--- a/tests/test_upsample.py
+++ b/tests/test_upsample.py
@@ -1,0 +1,81 @@
+import pandas as pd
+import polars as pl
+import pytest
+
+from esp_data.backends import PandasBackend, PolarsBackend
+from esp_data.transforms import Upsample, UpsampleConfig
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_upsample(backend_type: str) -> None:
+    """Test that upsample produces factor * original rows."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"species": ["bee", "ant", "fly"], "value": [1, 2, 3]})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"species": ["bee", "ant", "fly"], "value": [1, 2, 3]})
+        backend = PolarsBackend(df)
+
+    config = UpsampleConfig(type="upsample", factor=3)
+    transform = Upsample.from_config(config)
+    result, meta = transform(backend)
+
+    assert meta == {}
+    assert len(result) == 9
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_upsample_preserves_rows(backend_type: str) -> None:
+    """Test that all original rows appear in the upsampled result."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"species": ["bee", "ant"], "value": [10, 20]})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"species": ["bee", "ant"], "value": [10, 20]})
+        backend = PolarsBackend(df)
+
+    transform = Upsample(factor=2)
+    result, _ = transform(backend)
+
+    if backend_type == "pandas":
+        result_df = result.unwrap
+        assert set(result_df["species"].tolist()) == {"bee", "ant"}
+        assert sorted(result_df["value"].tolist()) == [10, 10, 20, 20]
+    else:
+        result_df = result.unwrap
+        if isinstance(result_df, pl.LazyFrame):
+            result_df = result_df.collect()
+        assert set(result_df["species"].to_list()) == {"bee", "ant"}
+        assert sorted(result_df["value"].to_list()) == [10, 10, 20, 20]
+
+
+@pytest.mark.parametrize("backend_type", ["pandas", "polars"])
+def test_upsample_manual_vs_config(backend_type: str) -> None:
+    """Test that manual instantiation and from_config produce the same result."""
+    if backend_type == "pandas":
+        df = pd.DataFrame({"species": ["bee", "ant"], "value": [1, 2]})
+        backend = PandasBackend(df)
+    else:
+        df = pl.DataFrame({"species": ["bee", "ant"], "value": [1, 2]})
+        backend = PolarsBackend(df)
+
+    manual_transform = Upsample(factor=4)
+    manual_result, _ = manual_transform(backend)
+
+    config = UpsampleConfig(type="upsample", factor=4)
+    config_transform = Upsample.from_config(config)
+    config_result, _ = config_transform(backend)
+
+    assert len(manual_result) == len(config_result) == 8
+
+
+def test_upsample_config_validation() -> None:
+    """Test that invalid factor values are rejected."""
+    with pytest.raises(Exception):
+        UpsampleConfig(type="upsample", factor=1)
+
+    with pytest.raises(Exception):
+        UpsampleConfig(type="upsample", factor=0)
+
+    with pytest.raises(Exception):
+        UpsampleConfig(type="upsample", factor=-1)


### PR DESCRIPTION
Downsample and upsample randomly to a given ratio. Could be either here or NatureLM-specific


## Summary

- **Downsample**: New transform that randomly keeps a fraction of rows. Configured via `fraction` (0, 1] and `seed`. Useful for quick dev iterations or ablation experiments.
- **Upsample**: New transform that repeats every row N times via concatenation. Configured via `factor` (>= 2). Useful for epoch-matching small datasets with larger ones during training.

Both transforms follow the existing esp-data conventions (Pydantic config with `Literal` type discriminator, `from_config` classmethod, `DataBackend` protocol, `register_transform` registration).

## Test plan

- [x] `test_downsample.py`: fraction accuracy, full fraction (1.0), small fraction floor (>= 1 row), manual vs config parity, config validation — all parametrized over pandas and polars backends
- [x] `test_upsample.py`: length correctness, row preservation, manual vs config parity, config validation — all parametrized over pandas and polars backends
- [x] All 16 tests pass locally
- [x] Pre-commit hooks pass (ruff, codespell, trailing whitespace, etc.)

Made with [Cursor](https://cursor.com)