### PR TITLE
fix polars backend for __iter__

### DIFF
--- a/esp_data/backends/polars_backend.py
+++ b/esp_data/backends/polars_backend.py
@@ -186,7 +186,10 @@ class PolarsBackend(DataBackend):
             Backend instance wrapping the loaded DataFrame or LazyFrame
         """
         # Filter out kwargs for any non-polars argument
-        valid_params = set(inspect.signature(pl.scan_csv).parameters.keys())
+        if streaming:
+            valid_params = set(inspect.signature(pl.scan_parquet).parameters.keys())
+        else:
+            valid_params = set(inspect.signature(pl.read_parquet).parameters.keys())
         filtered_kwargs = {k: v for k, v in kwargs.items() if k in valid_params}
         if streaming:
             # Use scan_parquet for lazy/streaming mode
@@ -309,7 +312,9 @@ class PolarsBackend(DataBackend):
     def __iter__(self) -> Iterator[dict[str, Any]]:
         """Iterate over DataFrame rows as dictionaries.
 
-        In streaming mode (LazyFrame), collects and yields rows.
+        In streaming mode (LazyFrame), uses `LazyFrame.collect_batches()` to
+        materialize the query one chunk at a time, so the full result never
+        needs to live in memory at once.
         In eager mode (DataFrame), yields rows directly.
 
         Yields
@@ -317,9 +322,13 @@ class PolarsBackend(DataBackend):
         dict[str, Any]
             Dictionary for each row mapping column names to values
         """
-        df = self._ensure_collected()
-        for row in df.iter_rows(named=True):
-            yield row
+        if isinstance(self._df, pl.LazyFrame):
+            for batch in self._df.collect_batches():
+                for row in batch.iter_rows(named=True):
+                    yield row
+        else:
+            for row in self._df.iter_rows(named=True):
+                yield row
 
     def iter_batches(self, batch_size: int = 1000) -> Iterator["PolarsBackend"]:
         """Iterate over DataFrame in batches.
@@ -332,17 +341,25 @@ class PolarsBackend(DataBackend):
         Yields
         ------
         PolarsBackend
-            Backend instances wrapping batches of up to batch_size rows
+            Backend instances wrapping batches of up to batch_size rows.
+            Yielded backends are always in eager mode.
 
-        Note
-        ----
-        In streaming mode, polars LazyFrame will be collected in one go.
-        For truly streaming batch processing, iterate and manually batch.
+        Notes
+        -----
+        In streaming mode, uses `LazyFrame.collect_batches(chunk_size=batch_size)`
+        to produce batches incrementally, so the full result never needs to
+        live in memory at once. Note that polars may return chunks that are
+        smaller than `batch_size`; it treats it as a hint rather than a strict
+        cap.
         """
-        df = self._ensure_collected()
-        for start_idx in range(0, len(df), batch_size):
-            end_idx = min(start_idx + batch_size, len(df))
-            yield PolarsBackend(df[start_idx:end_idx], streaming=False)
+        if isinstance(self._df, pl.LazyFrame):
+            for batch in self._df.collect_batches(chunk_size=batch_size):
+                yield PolarsBackend(batch, streaming=False)
+        else:
+            df = self._df
+            for start_idx in range(0, len(df), batch_size):
+                end_idx = min(start_idx + batch_size, len(df))
+                yield PolarsBackend(df[start_idx:end_idx], streaming=False)
 
     def filter_isin(
         self,
@@ -456,7 +473,21 @@ class PolarsBackend(DataBackend):
         -------
         list[Any]
             Sorted list of unique values (nulls excluded)
+
+        Notes
+        -----
+        In streaming mode (LazyFrame), materializes the full column to
+        compute uniques. A UserWarning is emitted because this forces
+        collection of the underlying query.
         """
+        if self._streaming:
+            warnings.warn(
+                "get_unique() requires collection of LazyFrame to compute uniques. "
+                "The backend itself is not modified, but the underlying query will "
+                "be executed in full.",
+                UserWarning,
+                stacklevel=2,
+            )
         df = self._ensure_collected()
         # Drop nulls and get unique values
         unique_values = df[column].drop_nulls().unique().to_list()
@@ -474,7 +505,21 @@ class PolarsBackend(DataBackend):
         -------
         dict[Any, int]
             Dictionary mapping unique values to their counts (nulls excluded)
+
+        Notes
+        -----
+        In streaming mode (LazyFrame), materializes the full column to
+        compute counts. A UserWarning is emitted because this forces
+        collection of the underlying query.
         """
+        if self._streaming:
+            warnings.warn(
+                "histogram() requires collection of LazyFrame to compute counts. "
+                "The backend itself is not modified, but the underlying query will "
+                "be executed in full.",
+                UserWarning,
+                stacklevel=2,
+            )
         df = self._ensure_collected()
         # Drop nulls and group by column to get counts
         counts_df = df.drop_nulls(subset=[column]).group_by(column).len()
@@ -656,7 +701,7 @@ class PolarsBackend(DataBackend):
         bool
             True if column exists, False otherwise
         """
-        return column in self._df.columns
+        return column in self._df.collect_schema().names()
 
     @property
     def unwrap(self) -> pl.DataFrame | pl.LazyFrame:

--- a/esp_data/backends/polars_backend.py
+++ b/esp_data/backends/polars_backend.py
@@ -323,6 +323,8 @@ class PolarsBackend(DataBackend):
             Dictionary for each row mapping column names to values
         """
         if isinstance(self._df, pl.LazyFrame):
+            # TODO: polars LazyFrame.collect_batches is marked unstable!
+            # see: https://docs.pola.rs/api/python/dev/reference/lazyframe/api/polars.LazyFrame.collect_batches.html
             for batch in self._df.collect_batches():
                 for row in batch.iter_rows(named=True):
                     yield row
@@ -352,7 +354,8 @@ class PolarsBackend(DataBackend):
         smaller than `batch_size`; it treats it as a hint rather than a strict
         cap.
         """
-        if isinstance(self._df, pl.LazyFrame):
+        if self._streaming:
+            # TODO: collect_batches is unstable
             for batch in self._df.collect_batches(chunk_size=batch_size):
                 yield PolarsBackend(batch, streaming=False)
         else:
@@ -686,7 +689,10 @@ class PolarsBackend(DataBackend):
         list[str]
             List of column names
         """
-        return self._df.collect_schema().names()
+        if self._streaming:
+            return self._df.collect_schema().names()
+        else:
+            return self._df.columns
 
     def column_exists(self, column: str) -> bool:
         """Check if a column exists in the DataFrame.
@@ -701,7 +707,10 @@ class PolarsBackend(DataBackend):
         bool
             True if column exists, False otherwise
         """
-        return column in self._df.collect_schema().names()
+        if self._streaming:
+            return column in self._df.collect_schema().names()
+        else:
+            return column in self._df.columns
 
     @property
     def unwrap(self) -> pl.DataFrame | pl.LazyFrame:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -4,6 +4,7 @@ import tempfile
 from pathlib import Path
 
 import pandas as pd
+import polars as pl
 import pytest
 
 from esp_data.backends import PandasBackend, PolarsBackend
@@ -124,11 +125,6 @@ class TestPolarsStreaming:
 
     def test_streaming_property(self):
         """Test is_streaming property."""
-        try:
-            import polars as pl
-        except ImportError:
-            pytest.skip("polars not installed")
-
         # Eager mode
         df = pl.DataFrame({"a": [1, 2, 3]})
         backend = PolarsBackend(df, streaming=False)
@@ -143,11 +139,6 @@ class TestPolarsStreaming:
 
     def test_streaming_getitem_raises(self):
         """Test that __getitem__ raises error in streaming mode."""
-        try:
-            import polars as pl
-        except ImportError:
-            pytest.skip("polars not installed")
-
         df = pl.DataFrame({"a": [1, 2, 3]})
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             df.write_csv(f.name)
@@ -160,11 +151,6 @@ class TestPolarsStreaming:
 
     def test_streaming_len_raises(self):
         """Test that __len__ raises error in streaming mode."""
-        try:
-            import polars as pl
-        except ImportError:
-            pytest.skip("polars not installed")
-
         df = pl.DataFrame({"a": [1, 2, 3]})
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             df.write_csv(f.name)
@@ -177,11 +163,6 @@ class TestPolarsStreaming:
 
     def test_streaming_iteration(self):
         """Test that iteration works in streaming mode."""
-        try:
-            import polars as pl
-        except ImportError:
-            pytest.skip("polars not installed")
-
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             df.write_csv(f.name)
@@ -200,11 +181,6 @@ class TestPolarsStreaming:
 
     def test_streaming_operations_work(self):
         """Test that LazyFrame operations work in streaming mode."""
-        try:
-            import polars as pl
-        except ImportError:
-            pytest.skip("polars not installed")
-
         df = pl.DataFrame({"a": [1, 2, 2, 3]})
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             df.write_csv(f.name)
@@ -227,19 +203,15 @@ class TestPolarsStreaming:
             cleaned_collected = cleaned.collect()
             assert sorted(cleaned_collected.unwrap["a"].to_list()) == [1, 2, 2, 3]
 
-            # get_unique requires collection
-            unique_vals = backend.get_unique("a")
+            # get_unique requires collection — expect a warning to that effect
+            with pytest.warns(UserWarning, match="get_unique.*requires collection"):
+                unique_vals = backend.get_unique("a")
             assert sorted(unique_vals) == [1, 2, 3]
 
             Path(f.name).unlink()
 
     def test_streaming_json_lines(self):
         """Test streaming with JSON lines."""
-        try:
-            import polars as pl
-        except ImportError:
-            pytest.skip("polars not installed")
-
         df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
         with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
             df.write_ndjson(f.name)
@@ -257,11 +229,6 @@ class TestPolarsStreaming:
 
     def test_eager_mode_still_works(self):
         """Test that eager mode still works correctly after adding streaming."""
-        try:
-            import polars as pl
-        except ImportError:
-            pytest.skip("polars not installed")
-
         df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
         backend = PolarsBackend(df, streaming=False)
 
@@ -274,11 +241,6 @@ class TestPolarsStreaming:
 
     def test_collect_method(self):
         """Test that collect() materializes LazyFrame and switches to eager mode."""
-        try:
-            import polars as pl
-        except ImportError:
-            pytest.skip("polars not installed")
-
         df = pl.DataFrame({"a": [1, 2, 3]})
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             df.write_csv(f.name)
@@ -298,11 +260,6 @@ class TestPolarsStreaming:
 
     def test_subsample_warning(self):
         """Test that subsample_by_column warns when in streaming mode."""
-        try:
-            import polars as pl
-        except ImportError:
-            pytest.skip("polars not installed")
-
         df = pl.DataFrame({"a": [1, 1, 2, 2, 3, 3], "b": ["x", "y", "z", "w", "v", "u"]})
         with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
             df.write_csv(f.name)
@@ -316,5 +273,137 @@ class TestPolarsStreaming:
 
             # Result should be in eager mode
             assert not result.is_streaming
+
+            Path(f.name).unlink()
+
+    def test_streaming_iter_does_not_fully_collect(self):
+        """Iteration over a LazyFrame should not require collecting everything
+        first — the backend should wrap `LazyFrame.collect_batches()`.
+        """
+        df = pl.DataFrame({"a": list(range(10)), "b": ["x"] * 10})
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            df.write_csv(f.name)
+            backend = PolarsBackend.from_csv(f.name, streaming=True)
+
+            # Underlying must still be a LazyFrame after constructing the iterator
+            # (calling iter itself should not coerce the backend to eager).
+            it = iter(backend)
+            assert isinstance(backend.unwrap, pl.LazyFrame)
+
+            first = next(it)
+            assert first == {"a": 0, "b": "x"}
+
+            rest = list(it)
+            assert len(rest) == 9
+            assert rest[-1] == {"a": 9, "b": "x"}
+
+            Path(f.name).unlink()
+
+    def test_streaming_iter_batches(self):
+        """iter_batches should stream chunks from a LazyFrame, never
+        materializing the whole thing at once.
+        """
+        df = pl.DataFrame({"a": list(range(50))})
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            df.write_csv(f.name)
+            backend = PolarsBackend.from_csv(f.name, streaming=True)
+
+            batches = list(backend.iter_batches(batch_size=10))
+
+            # Every yielded batch should be eager (DataFrame), not a LazyFrame.
+            for b in batches:
+                assert not b.is_streaming
+                assert isinstance(b.unwrap, pl.DataFrame)
+
+            # All rows accounted for.
+            total_rows = sum(len(b) for b in batches)
+            assert total_rows == 50
+
+            # Values recover the original series (order not guaranteed across
+            # batches in streaming engines, so we sort).
+            collected = sorted(v for b in batches for v in b.unwrap["a"].to_list())
+            assert collected == list(range(50))
+
+            Path(f.name).unlink()
+
+    def test_eager_iter_batches(self):
+        """iter_batches on an eager DataFrame still works and yields fixed-size
+        slices.
+        """
+        df = pl.DataFrame({"a": list(range(25))})
+        backend = PolarsBackend(df, streaming=False)
+
+        batches = list(backend.iter_batches(batch_size=10))
+        sizes = [len(b) for b in batches]
+        assert sizes == [10, 10, 5]
+
+    def test_column_exists_on_lazyframe(self):
+        """column_exists must work on a streaming backend without raising
+        or triggering full collection.
+        """
+        df = pl.DataFrame({"foo": [1, 2, 3], "bar": ["a", "b", "c"]})
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            df.write_csv(f.name)
+            backend = PolarsBackend.from_csv(f.name, streaming=True)
+
+            assert backend.column_exists("foo")
+            assert backend.column_exists("bar")
+            assert not backend.column_exists("baz")
+
+            # Still lazy afterwards.
+            assert isinstance(backend.unwrap, pl.LazyFrame)
+
+            Path(f.name).unlink()
+
+    def test_get_unique_streaming_warns(self):
+        """get_unique forces collection on a LazyFrame — warn the caller."""
+        df = pl.DataFrame({"a": [1, 1, 2, 2, 3]})
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            df.write_csv(f.name)
+            backend = PolarsBackend.from_csv(f.name, streaming=True)
+
+            with pytest.warns(UserWarning, match="get_unique.*requires collection"):
+                uniques = backend.get_unique("a")
+
+            assert uniques == [1, 2, 3]
+            Path(f.name).unlink()
+
+    def test_histogram_streaming_warns(self):
+        """histogram forces collection on a LazyFrame — warn the caller."""
+        df = pl.DataFrame({"a": [1, 1, 2, 2, 2, 3]})
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
+            df.write_csv(f.name)
+            backend = PolarsBackend.from_csv(f.name, streaming=True)
+
+            with pytest.warns(UserWarning, match="histogram.*requires collection"):
+                hist = backend.histogram("a")
+
+            assert hist == {1: 2, 2: 3, 3: 1}
+            Path(f.name).unlink()
+
+    def test_from_parquet_kwargs_filtered_against_parquet_signature(self):
+        """from_parquet must filter kwargs against `scan_parquet` /
+        `read_parquet` signatures, not `scan_csv`.
+
+        Regression: a copy-paste bug previously filtered kwargs against the
+        `scan_csv` signature, silently stripping legitimate parquet-only
+        arguments such as `row_index_name`.
+        """
+        df = pl.DataFrame({"a": [1, 2, 3]})
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".parquet", delete=False) as f:
+            df.write_parquet(f.name)
+
+            # row_index_name is valid for scan_parquet / read_parquet but NOT
+            # for scan_csv. With the bug it would be silently dropped; with the
+            # fix it actually gets applied.
+            backend_stream = PolarsBackend.from_parquet(
+                f.name, streaming=True, row_index_name="idx"
+            )
+            assert "idx" in backend_stream.columns
+
+            backend_eager = PolarsBackend.from_parquet(
+                f.name, streaming=False, row_index_name="idx"
+            )
+            assert "idx" in backend_eager.columns
 
             Path(f.name).unlink()

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -276,55 +276,50 @@ class TestPolarsStreaming:
 
             Path(f.name).unlink()
 
-    def test_streaming_iter_does_not_fully_collect(self):
+    def test_streaming_iter_does_not_fully_collect(self, tmp_path):
         """Iteration over a LazyFrame should not require collecting everything
         first — the backend should wrap `LazyFrame.collect_batches()`.
         """
         df = pl.DataFrame({"a": list(range(10)), "b": ["x"] * 10})
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-            df.write_csv(f.name)
-            backend = PolarsBackend.from_csv(f.name, streaming=True)
+        df.write_csv(tmp_path / "test.csv")
+        backend = PolarsBackend.from_csv(tmp_path / "test.csv", streaming=True)
 
-            # Underlying must still be a LazyFrame after constructing the iterator
-            # (calling iter itself should not coerce the backend to eager).
-            it = iter(backend)
-            assert isinstance(backend.unwrap, pl.LazyFrame)
+        # Underlying must still be a LazyFrame after constructing the iterator
+        # (calling iter itself should not coerce the backend to eager).
+        it = iter(backend)
+        assert isinstance(backend.unwrap, pl.LazyFrame)
 
-            first = next(it)
-            assert first == {"a": 0, "b": "x"}
+        first = next(it)
+        assert first == {"a": 0, "b": "x"}
 
-            rest = list(it)
-            assert len(rest) == 9
-            assert rest[-1] == {"a": 9, "b": "x"}
+        rest = list(it)
+        assert len(rest) == 9
+        assert rest[-1] == {"a": 9, "b": "x"}
 
-            Path(f.name).unlink()
-
-    def test_streaming_iter_batches(self):
+    def test_streaming_iter_batches(self, tmp_path):
         """iter_batches should stream chunks from a LazyFrame, never
         materializing the whole thing at once.
         """
         df = pl.DataFrame({"a": list(range(50))})
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-            df.write_csv(f.name)
-            backend = PolarsBackend.from_csv(f.name, streaming=True)
+        fname = tmp_path / "test.csv"
+        df.write_csv(fname)
+        backend = PolarsBackend.from_csv(fname, streaming=True)
 
-            batches = list(backend.iter_batches(batch_size=10))
+        batches = list(backend.iter_batches(batch_size=10))
 
-            # Every yielded batch should be eager (DataFrame), not a LazyFrame.
-            for b in batches:
-                assert not b.is_streaming
-                assert isinstance(b.unwrap, pl.DataFrame)
+        # Every yielded batch should be eager (DataFrame), not a LazyFrame.
+        for b in batches:
+            assert not b.is_streaming
+            assert isinstance(b.unwrap, pl.DataFrame)
 
-            # All rows accounted for.
-            total_rows = sum(len(b) for b in batches)
-            assert total_rows == 50
+        # All rows accounted for.
+        total_rows = sum(len(b) for b in batches)
+        assert total_rows == 50
 
-            # Values recover the original series (order not guaranteed across
-            # batches in streaming engines, so we sort).
-            collected = sorted(v for b in batches for v in b.unwrap["a"].to_list())
-            assert collected == list(range(50))
-
-            Path(f.name).unlink()
+        # Values recover the original series (order not guaranteed across
+        # batches in streaming engines, so we sort).
+        collected = sorted(v for b in batches for v in b.unwrap["a"].to_list())
+        assert collected == list(range(50))
 
     def test_eager_iter_batches(self):
         """iter_batches on an eager DataFrame still works and yields fixed-size
@@ -341,47 +336,37 @@ class TestPolarsStreaming:
         """column_exists must work on a streaming backend without raising
         or triggering full collection.
         """
-        df = pl.DataFrame({"foo": [1, 2, 3], "bar": ["a", "b", "c"]})
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-            df.write_csv(f.name)
-            backend = PolarsBackend.from_csv(f.name, streaming=True)
+        df = pl.LazyFrame({"foo": [1, 2, 3], "bar": ["a", "b", "c"]})
+        backend = PolarsBackend(df, streaming=True)
 
-            assert backend.column_exists("foo")
-            assert backend.column_exists("bar")
-            assert not backend.column_exists("baz")
+        assert backend.column_exists("foo")
+        assert backend.column_exists("bar")
+        assert not backend.column_exists("baz")
 
-            # Still lazy afterwards.
-            assert isinstance(backend.unwrap, pl.LazyFrame)
-
-            Path(f.name).unlink()
+        # Still lazy afterwards.
+        assert isinstance(backend.unwrap, pl.LazyFrame)
 
     def test_get_unique_streaming_warns(self):
         """get_unique forces collection on a LazyFrame — warn the caller."""
-        df = pl.DataFrame({"a": [1, 1, 2, 2, 3]})
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-            df.write_csv(f.name)
-            backend = PolarsBackend.from_csv(f.name, streaming=True)
+        df = pl.LazyFrame({"a": [1, 1, 2, 2, 3]})
+        backend = PolarsBackend(df, streaming=True)
 
-            with pytest.warns(UserWarning, match="get_unique.*requires collection"):
-                uniques = backend.get_unique("a")
+        with pytest.warns(UserWarning, match="get_unique.*requires collection"):
+            uniques = backend.get_unique("a")
 
-            assert uniques == [1, 2, 3]
-            Path(f.name).unlink()
+        assert uniques == [1, 2, 3]
 
     def test_histogram_streaming_warns(self):
         """histogram forces collection on a LazyFrame — warn the caller."""
-        df = pl.DataFrame({"a": [1, 1, 2, 2, 2, 3]})
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-            df.write_csv(f.name)
-            backend = PolarsBackend.from_csv(f.name, streaming=True)
+        df = pl.LazyFrame({"a": [1, 1, 2, 2, 2, 3]})
+        backend = PolarsBackend(df, streaming=True)
 
-            with pytest.warns(UserWarning, match="histogram.*requires collection"):
-                hist = backend.histogram("a")
+        with pytest.warns(UserWarning, match="histogram.*requires collection"):
+            hist = backend.histogram("a")
 
-            assert hist == {1: 2, 2: 3, 3: 1}
-            Path(f.name).unlink()
+        assert hist == {1: 2, 2: 3, 3: 1}
 
-    def test_from_parquet_kwargs_filtered_against_parquet_signature(self):
+    def test_from_parquet_kwargs_filtered_against_parquet_signature(self, tmp_path):
         """from_parquet must filter kwargs against `scan_parquet` /
         `read_parquet` signatures, not `scan_csv`.
 
@@ -390,20 +375,18 @@ class TestPolarsStreaming:
         arguments such as `row_index_name`.
         """
         df = pl.DataFrame({"a": [1, 2, 3]})
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".parquet", delete=False) as f:
-            df.write_parquet(f.name)
+        fname = tmp_path / "test.parquet"
+        df.write_parquet(fname)
 
-            # row_index_name is valid for scan_parquet / read_parquet but NOT
-            # for scan_csv. With the bug it would be silently dropped; with the
-            # fix it actually gets applied.
-            backend_stream = PolarsBackend.from_parquet(
-                f.name, streaming=True, row_index_name="idx"
-            )
-            assert "idx" in backend_stream.columns
+        # row_index_name is valid for scan_parquet / read_parquet but NOT
+        # for scan_csv. With the bug it would be silently dropped; with the
+        # fix it actually gets applied.
+        backend_stream = PolarsBackend.from_parquet(
+            fname, streaming=True, row_index_name="idx"
+        )
+        assert "idx" in backend_stream.columns
 
-            backend_eager = PolarsBackend.from_parquet(
-                f.name, streaming=False, row_index_name="idx"
-            )
-            assert "idx" in backend_eager.columns
-
-            Path(f.name).unlink()
+        backend_eager = PolarsBackend.from_parquet(
+            fname, streaming=False, row_index_name="idx"
+        )
+        assert "idx" in backend_eager.columns


### PR DESCRIPTION
TLDR: polars streaming was actually not streaming 😑 

Diff to polars_backend.py
                                                                                             
  - `__iter__` collected the full LazyFrame before yielding rows, so                                                                     
    `streaming=True` materialized the *whole* dataset. Routing                                                                        through LazyFrame.collect_batches() so iteration is truly lazy.                                                                    
  - iter_batches had the same flaw; use collect_batches(chunk_size=                                                                    
    batch_size) to produce batches incrementally.                                                                                      
  - 🐞 `from_parquet` filtered kwargs against pl.scan_csv's signature                                                                       
    (copy-paste bug), silently dropping parquet-only kwargs like                                                                       
    row_index_name. Filter against scan_parquet/read_parquet instead.                                                                  
  - column_exists uses collect_schema().names() for LazyFrame compat,
    matching the columns property.                                                                                                     
  - `get_unique` and `histogram` emit a UserWarning when they force
    collection of a LazyFrame, mirroring subsample/upsample.