### PR TITLE
WIP: DataRepo abstraction for dataset identity / physical location separation

### DIFF
--- a/esp_data/dataset.py
+++ b/esp_data/dataset.py
@@ -3,10 +3,11 @@ from collections.abc import Sequence
 from typing import Any, Dict, Iterator, Literal
 
 import semver
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, field_validator
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, field_validator, model_validator
 
 from esp_data.backends import BackendType, get_backend
 from esp_data.io import AnyPathT, read_yaml
+from esp_data.io.datarepo import resolve as _resolve_repo_url
 from esp_data.transforms import transform_from_config
 from esp_data.transforms.registry import RegisteredTransformConfigs
 
@@ -229,9 +230,38 @@ class DatasetInfo(BaseModel):
 
     owner: str = Field(min_length=1, description="ESP team owner(s) of the dataset")
 
-    split_paths: dict = Field(
+    split_paths: dict | None = Field(
+        default=None,
         description="""Paths to the dataset splits. The keys are the split names
-        and the values are the paths to the splits""",
+        and the values are the paths to the splits. May be provided directly
+        (legacy shape), or auto-derived from repos+folder+splits (modern shape).""",
+    )
+
+    # ------------------------------------------------------------------
+    # Modern-shape fields (optional). When set instead of `split_paths`,
+    # `split_paths` is auto-derived via the DataRepo resolver. See
+    # `esp_data/io/datarepo.py`.
+    # ------------------------------------------------------------------
+    repos: list[str] | None = Field(
+        default=None,
+        description="""IDs of DataRepos where this dataset is available.
+        If set (together with `folder` and `splits`), `split_paths` is
+        auto-derived at validation time by running the resolver against
+        the registered DataRepos.""",
+    )
+
+    folder: str | None = Field(
+        default=None,
+        description="""Path to this dataset's root folder relative to each
+        repo's base_url. Combined with repo.base_url + split relpath to
+        produce absolute URLs.""",
+    )
+
+    splits: dict | None = Field(
+        default=None,
+        description="""Map of split name to the split manifest's relative
+        path within `folder`. E.g. {"train": "train.csv"}. Used by the
+        resolver to populate `split_paths`.""",
     )
 
     version: str = Field(min_length=5, description="Version of the dataset")
@@ -256,6 +286,61 @@ class DatasetInfo(BaseModel):
     changelog: str = Field(
         default_factory=lambda: "", description="Changelog from previous version"
     )
+
+    @model_validator(mode="after")
+    def _resolve_or_require_split_paths(self) -> "DatasetInfo":
+        """Ensure split_paths is populated, either directly or via the DataRepo resolver.
+
+        Three valid cases:
+          1. `split_paths` provided directly (legacy): use as-is.
+          2. `repos` + `folder` + `splits` provided (modern): auto-derive
+             `split_paths` by running the resolver once per split.
+          3. Both provided: error — ambiguous intent.
+
+        Neither shape = error — a DatasetInfo without any split info isn't useful.
+
+        Returns
+        -------
+        DatasetInfo
+            The validated instance with `split_paths` guaranteed non-None.
+
+        Raises
+        ------
+        ValueError
+            If both legacy and modern shapes are provided simultaneously, or
+            if neither is provided, or if the modern shape is incomplete
+            (missing any of `repos`, `folder`, `splits`).
+        """
+        modern_set = self.repos is not None or self.folder is not None or self.splits is not None
+        if self.split_paths is not None and modern_set:
+            raise ValueError(
+                "DatasetInfo: provide either `split_paths` (legacy) OR "
+                "`repos`+`folder`+`splits` (modern), not both."
+            )
+
+        if self.split_paths is None:
+            # Modern shape — require all three new fields and derive split_paths
+            missing = [
+                name
+                for name, val in (
+                    ("repos", self.repos),
+                    ("folder", self.folder),
+                    ("splits", self.splits),
+                )
+                if val is None
+            ]
+            if missing:
+                raise ValueError(
+                    f"DatasetInfo: modern shape requires `repos`, `folder`, "
+                    f"and `splits` to all be set. Missing: {missing}."
+                )
+            derived = {
+                split_name: _resolve_repo_url(self.repos, self.folder, relpath)
+                for split_name, relpath in self.splits.items()
+            }
+            # Bypass validate_assignment to avoid re-running this validator
+            object.__setattr__(self, "split_paths", derived)
+        return self
 
     @field_validator("version")
     @classmethod

--- a/esp_data/io/__init__.py
+++ b/esp_data/io/__init__.py
@@ -1,3 +1,13 @@
+from esp_data.io.datarepo import (
+    DataRepo,
+    NoAccessibleRepoError,
+    get_repo,
+    list_repos,
+    register_repo,
+    resolve,
+    set_access_checker,
+    unregister_repo,
+)
 from esp_data.io.file_utils import exists, rm
 from esp_data.io.filesystem import filesystem, filesystem_from_path
 from esp_data.io.paths import AnyPathT, PureGSPath, PureHTTPSPath, PureR2Path, PureS3Path, anypath
@@ -13,18 +23,26 @@ from esp_data.io.read_utils import (
 __all__ = [
     "anypath",
     "AnyPathT",
+    "DataRepo",
+    "NoAccessibleRepoError",
     "PureGSPath",
     "PureHTTPSPath",
     "PureR2Path",
     "PureS3Path",
-    "read_audio",
-    "read_text",
     "audio_stereo_to_mono",
-    "get_audio_info",
+    "exists",
     "filesystem",
     "filesystem_from_path",
-    "exists",
-    "rm",
+    "get_audio_info",
+    "get_repo",
+    "list_repos",
+    "read_audio",
     "read_json",
+    "read_text",
     "read_yaml",
+    "register_repo",
+    "resolve",
+    "rm",
+    "set_access_checker",
+    "unregister_repo",
 ]

--- a/esp_data/io/datarepo.py
+++ b/esp_data/io/datarepo.py
@@ -1,0 +1,320 @@
+"""DataRepo abstraction — separates dataset identity from physical access location.
+
+The idea: a dataset's identity (its name, version, schema, and the relative
+paths of files within its folder) is independent of *where* it's physically
+hosted. A `DataRepo` declares one physical location (base URL + kind), and
+datasets can list multiple repos they are available in. At read time, the
+resolver picks the highest-priority accessible repo and joins its base URL
+with the dataset folder + relative path to produce a fetchable URL.
+
+This is the same pattern used by Python packaging (PyPI + mirrors), HuggingFace
+Hub (repo ID + CDN), Docker (image digest + registries), Maven/Go/npm, etc.
+
+Backward compat: `DatasetInfo.split_paths` remains the public interface that
+Dataset subclasses read. When a DatasetInfo is constructed with `repos` +
+`folder` + `splits` instead of `split_paths`, a Pydantic `model_validator`
+auto-derives `split_paths` by running the resolver. Nothing in the 37 existing
+Dataset subclasses needs to change.
+
+See `docs/esp-data-datarepos-plan.md` in the parent monorepo for the full
+design rationale.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+RepoKind = Literal["gs", "s3", "https", "local"]
+PathEncoding = Literal["strict", "legacy_raw", "legacy_percent"]
+
+# Strict relative-path grammar: POSIX-style, URL-safe ASCII subset
+# (RFC 3986 unreserved chars + forward slash). No leading slash,
+# no ".." traversal, no trailing slash.
+_STRICT_RELPATH_RE = re.compile(r"^(?!/)(?!.*(?:^|/)\.\.(?:/|$))[A-Za-z0-9._~\-/]+(?<!/)$")
+
+
+class InvalidRelativePathError(ValueError):
+    """Raised when a relative path fails the strict-subset grammar for a
+    `path_encoding='strict'` repo."""
+
+
+def validate_strict_relpath(relpath: str) -> None:
+    """Assert that `relpath` conforms to the strict subset.
+
+    Constraints:
+      - allowed chars: [A-Za-z0-9._~\\-/]
+      - no leading or trailing slash
+      - no ".." segments (directory traversal)
+
+    Raises
+    ------
+    InvalidRelativePathError
+        If `relpath` violates any rule. Message identifies which.
+    """
+    if not isinstance(relpath, str) or not relpath:
+        raise InvalidRelativePathError(f"Relative path must be a non-empty string; got {relpath!r}")
+    if relpath.startswith("/"):
+        raise InvalidRelativePathError(f"Relative path must not start with '/': {relpath!r}")
+    if relpath.endswith("/"):
+        raise InvalidRelativePathError(
+            f"Relative path must not end with '/' (files only): {relpath!r}"
+        )
+    # Check for ".." as a path segment (simple string check is enough since
+    # the char class below forbids quoted dots)
+    segments = relpath.split("/")
+    if ".." in segments:
+        raise InvalidRelativePathError(
+            f"Relative path must not contain '..' (directory traversal): {relpath!r}"
+        )
+    if not _STRICT_RELPATH_RE.match(relpath):
+        # Identify which char is the problem for a better error message.
+        # Must use ASCII-only checks — `str.isalnum()` is Unicode-aware and
+        # would accept chars like `ñ`, which the strict regex rejects.
+        _ASCII_ALNUM = frozenset("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+        _OTHER_ALLOWED = frozenset("._~-/")
+        allowed = _ASCII_ALNUM | _OTHER_ALLOWED
+        for ch in relpath:
+            if ch not in allowed:
+                raise InvalidRelativePathError(
+                    f"Relative path contains disallowed char {ch!r} (U+{ord(ch):04X}) "
+                    f"in {relpath!r}. Strict subset is [A-Za-z0-9._~-/]."
+                )
+        # Fallback — shouldn't reach here but be safe
+        raise InvalidRelativePathError(f"Relative path {relpath!r} doesn't match strict subset.")
+
+
+@dataclass(frozen=True)
+class DataRepo:
+    """A location where one or more datasets are available.
+
+    Parameters
+    ----------
+    id : str
+        Unique identifier for this repo (e.g., ``"esp-internal-gcs"``,
+        ``"esp-public-r2"``).
+    kind : RepoKind
+        Protocol used to access this repo. Determines how `base_url` is
+        joined with relative paths.
+    base_url : str
+        Root URL prefix (e.g., ``"gs://esp-ml-datasets/"``,
+        ``"https://pub-abc.r2.dev/"``). Trailing slash is optional; the
+        resolver normalizes.
+    path_encoding : PathEncoding, default "strict"
+        How relative paths within datasets stored in this repo are
+        encoded. ``"strict"`` means URL-safe ASCII subset only.
+        ``"legacy_raw"`` and ``"legacy_percent"`` exist for datasets
+        like xeno-canto that have filename bytes outside the strict subset.
+    priority : int, default 100
+        Lower numbers are preferred when multiple repos for a dataset
+        are accessible. ESP-internal typically gets priority ~10; public
+        mirrors get ~50.
+    """
+
+    id: str
+    kind: RepoKind
+    base_url: str
+    path_encoding: PathEncoding = "strict"
+    priority: int = 100
+
+
+# In-memory repo registry. Populated at import time with ESP defaults; users
+# can override via `register_repo` / `unregister_repo`.
+_REPO_REGISTRY: dict[str, DataRepo] = {}
+
+# Optional per-repo access checker. Default: accept all registered repos.
+# Real deployment might check for valid credentials, network reachability,
+# etc. before returning True.
+_access_checker: Callable[[DataRepo], bool] | None = None
+
+
+def register_repo(repo: DataRepo) -> None:
+    """Register a DataRepo in the global registry."""
+    _REPO_REGISTRY[repo.id] = repo
+
+
+def unregister_repo(repo_id: str) -> None:
+    """Remove a DataRepo from the registry by id. No-op if not present."""
+    _REPO_REGISTRY.pop(repo_id, None)
+
+
+def get_repo(repo_id: str) -> DataRepo | None:
+    """Return the DataRepo with the given id, or None if not registered.
+
+    Returns
+    -------
+    DataRepo | None
+        The registered repo with that id, or None if not registered.
+    """
+    return _REPO_REGISTRY.get(repo_id)
+
+
+def list_repos() -> list[DataRepo]:
+    """Return all currently-registered DataRepos.
+
+    Returns
+    -------
+    list[DataRepo]
+        All registered repos, in no particular order.
+    """
+    return list(_REPO_REGISTRY.values())
+
+
+def set_access_checker(checker: Callable[[DataRepo], bool] | None) -> None:
+    """Install a function that decides whether a repo is accessible.
+
+    When `resolve()` picks among candidate repos, only those for which the
+    checker returns True are considered. Use this to gate private repos
+    behind credential checks, or to restrict to offline-available repos, etc.
+    """
+    global _access_checker
+    _access_checker = checker
+
+
+def _join_relpath_parts(*parts: str) -> str:
+    """Normalize + join path segments with a single forward slash.
+
+    Strips leading/trailing slashes from each part, drops empty parts.
+    Intended for relative-path joining only; caller handles base URLs.
+
+    Returns
+    -------
+    str
+        The joined relative path, or an empty string if all inputs were empty.
+    """
+    cleaned = [p.strip("/") for p in parts if p]
+    return "/".join(p for p in cleaned if p)
+
+
+def join_url(repo: DataRepo, *relpath_parts: str) -> str:
+    """Join a repo's base URL with relative path parts, dispatching on kind.
+
+    Parameters
+    ----------
+    repo : DataRepo
+        The repo whose `base_url` will be the prefix.
+    *relpath_parts : str
+        Relative path segments (e.g. dataset folder, split file name).
+        Each is normalized independently — leading/trailing slashes
+        stripped, empty segments dropped.
+
+    Returns
+    -------
+    str
+        A URL (or filesystem path, for `kind="local"`) suitable for
+        passing to `anypath()` or directly to a filesystem backend.
+
+    Raises
+    ------
+    ValueError
+        If `repo.kind` is not one of the supported kinds.
+    """
+    base = repo.base_url.rstrip("/")
+    relpath = _join_relpath_parts(*relpath_parts)
+    if repo.kind in ("gs", "s3", "https"):
+        # All three are URL-shaped; simple string concat with single slash.
+        # (urllib.parse.urljoin would fight with gs:// and s3:// schemes.)
+        return f"{base}/{relpath}" if relpath else base
+    elif repo.kind == "local":
+        return str(Path(base) / relpath) if relpath else base
+    else:
+        raise ValueError(f"Unknown repo kind: {repo.kind}")
+
+
+class NoAccessibleRepoError(RuntimeError):
+    """Raised when resolve() can't find any registered + accessible repo for a dataset."""
+
+
+def resolve(
+    repos_ids: list[str],
+    folder: str,
+    relpath: str,
+    registry: dict[str, DataRepo] | None = None,
+) -> str:
+    """Resolve (dataset repo list, dataset folder, relative path) to a fetchable URL.
+
+    Picks the highest-priority accessible repo from `repos_ids` that is
+    currently registered. Joins its base URL with the dataset's folder
+    and the relative path.
+
+    Parameters
+    ----------
+    repos_ids : list[str]
+        Ordered list of repo IDs the dataset declares itself available in.
+        The order is advisory; the actual choice is driven by priority
+        among the accessible ones.
+    folder : str
+        Path within each repo to the dataset's root folder. Relative.
+    relpath : str
+        Path within the dataset folder to the target file. Relative.
+    registry : dict[str, DataRepo] | None
+        Optional explicit registry to use instead of the global one.
+        For testing, mostly.
+
+    Returns
+    -------
+    str
+        The resolved URL.
+
+    Raises
+    ------
+    NoAccessibleRepoError
+        If none of the named repos are registered and accessible.
+    """
+    reg = registry if registry is not None else _REPO_REGISTRY
+    candidates: list[DataRepo] = []
+    for rid in repos_ids:
+        repo = reg.get(rid)
+        if repo is None:
+            continue
+        if _access_checker is not None and not _access_checker(repo):
+            continue
+        candidates.append(repo)
+
+    if not candidates:
+        raise NoAccessibleRepoError(
+            f"No accessible repos for dataset. Declared: {repos_ids}. "
+            f"Registered: {sorted(reg.keys())}."
+        )
+
+    candidates.sort(key=lambda r: r.priority)
+    chosen = candidates[0]
+
+    # Validate path encoding at resolution time — failure here is a
+    # data-configuration error, not a runtime issue, and should surface clearly.
+    if chosen.path_encoding == "strict":
+        validate_strict_relpath(folder)
+        validate_strict_relpath(relpath)
+    # "legacy_raw" and "legacy_percent" modes: no constraint enforced yet.
+    # See `docs/esp-data-datarepos-plan.md` for the planned conversion logic.
+
+    return join_url(chosen, folder, relpath)
+
+
+def _register_default_repos() -> None:
+    """Register the ESP default repo(s). Called at module import."""
+    register_repo(
+        DataRepo(
+            id="esp-internal-gcs",
+            kind="gs",
+            base_url="gs://esp-ml-datasets/",
+            path_encoding="strict",
+            priority=10,
+        )
+    )
+    # TODO: register the public R2 mirror once we know its base_url.
+    # register_repo(
+    #     DataRepo(
+    #         id="esp-public-r2",
+    #         kind="https",
+    #         base_url="https://pub-<id>.r2.dev/",
+    #         path_encoding="strict",
+    #         priority=50,
+    #     )
+    # )
+
+
+_register_default_repos()

--- a/tests/io/test_datarepo.py
+++ b/tests/io/test_datarepo.py
@@ -1,0 +1,403 @@
+"""Tests for the DataRepo abstraction and DatasetInfo backward compat."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from esp_data.dataset import DatasetInfo
+from esp_data.io.datarepo import (
+    DataRepo,
+    InvalidRelativePathError,
+    NoAccessibleRepoError,
+    get_repo,
+    join_url,
+    list_repos,
+    register_repo,
+    resolve,
+    set_access_checker,
+    unregister_repo,
+    validate_strict_relpath,
+)
+
+
+# ---------- DataRepo basics --------------------------------------------------
+
+
+class TestDataRepo:
+    def test_construction_and_immutability(self):
+        r = DataRepo(id="test", kind="gs", base_url="gs://bucket/")
+        assert r.id == "test"
+        assert r.kind == "gs"
+        assert r.base_url == "gs://bucket/"
+        # Frozen dataclass — mutation should fail
+        with pytest.raises(Exception):
+            r.id = "changed"  # noqa (deliberate failure)
+
+    def test_default_priority_and_encoding(self):
+        r = DataRepo(id="x", kind="https", base_url="https://a.b/")
+        assert r.priority == 100
+        assert r.path_encoding == "strict"
+
+
+# ---------- join_url: URL-kind dispatch --------------------------------------
+
+
+class TestJoinURL:
+    def test_gs_join(self):
+        r = DataRepo(id="x", kind="gs", base_url="gs://bucket/")
+        assert join_url(r, "folder", "file.csv") == "gs://bucket/folder/file.csv"
+
+    def test_gs_no_trailing_slash(self):
+        r = DataRepo(id="x", kind="gs", base_url="gs://bucket")  # no trailing /
+        assert join_url(r, "folder", "file.csv") == "gs://bucket/folder/file.csv"
+
+    def test_s3_join(self):
+        r = DataRepo(id="x", kind="s3", base_url="s3://bkt/")
+        assert join_url(r, "a", "b.wav") == "s3://bkt/a/b.wav"
+
+    def test_https_join(self):
+        r = DataRepo(id="x", kind="https", base_url="https://example.com/data/")
+        assert join_url(r, "ds", "train.csv") == "https://example.com/data/ds/train.csv"
+
+    def test_local_join(self):
+        r = DataRepo(id="x", kind="local", base_url="/tmp/data")
+        assert join_url(r, "ds", "train.csv") == "/tmp/data/ds/train.csv"
+
+    def test_join_handles_extra_slashes(self):
+        r = DataRepo(id="x", kind="gs", base_url="gs://bucket//")
+        # Each part has leading/trailing slashes stripped
+        assert join_url(r, "/folder/", "/file.csv/") == "gs://bucket/folder/file.csv"
+
+    def test_join_no_parts_returns_base(self):
+        r = DataRepo(id="x", kind="gs", base_url="gs://bucket/")
+        assert join_url(r) == "gs://bucket"
+
+    def test_join_empty_parts_dropped(self):
+        r = DataRepo(id="x", kind="gs", base_url="gs://bucket/")
+        assert join_url(r, "", "folder", "", "file.csv") == "gs://bucket/folder/file.csv"
+
+
+# ---------- Registry + resolve with explicit registry dicts ------------------
+
+
+class TestResolve:
+    def _make_registry(self, *repos):
+        return {r.id: r for r in repos}
+
+    def test_single_repo(self):
+        reg = self._make_registry(
+            DataRepo(id="gcs", kind="gs", base_url="gs://bkt/"),
+        )
+        url = resolve(["gcs"], "dataset/v1", "train.csv", registry=reg)
+        assert url == "gs://bkt/dataset/v1/train.csv"
+
+    def test_picks_highest_priority(self):
+        reg = self._make_registry(
+            DataRepo(id="slow", kind="gs", base_url="gs://a/", priority=50),
+            DataRepo(id="fast", kind="gs", base_url="gs://b/", priority=10),
+        )
+        url = resolve(["slow", "fast"], "ds", "train.csv", registry=reg)
+        assert url.startswith("gs://b/")
+
+    def test_skips_unregistered(self):
+        reg = self._make_registry(
+            DataRepo(id="only", kind="https", base_url="https://a/"),
+        )
+        url = resolve(["missing", "only"], "ds", "train.csv", registry=reg)
+        assert url == "https://a/ds/train.csv"
+
+    def test_raises_when_no_accessible(self):
+        reg = self._make_registry(
+            DataRepo(id="a", kind="gs", base_url="gs://a/"),
+        )
+        with pytest.raises(NoAccessibleRepoError):
+            resolve(["missing"], "ds", "train.csv", registry=reg)
+
+
+# ---------- Global registry (exercises the default-repo wiring) --------------
+
+
+class TestGlobalRegistry:
+    def test_default_repo_registered(self):
+        repos = {r.id: r for r in list_repos()}
+        assert "esp-internal-gcs" in repos
+        assert repos["esp-internal-gcs"].kind == "gs"
+
+    def test_register_and_retrieve(self):
+        register_repo(DataRepo(id="_test_custom", kind="https", base_url="https://x/"))
+        try:
+            assert get_repo("_test_custom") is not None
+            assert get_repo("_test_custom").kind == "https"
+        finally:
+            unregister_repo("_test_custom")
+
+    def test_unregister(self):
+        register_repo(DataRepo(id="_test_delete_me", kind="local", base_url="/tmp"))
+        assert get_repo("_test_delete_me") is not None
+        unregister_repo("_test_delete_me")
+        assert get_repo("_test_delete_me") is None
+
+
+# ---------- Access-checker gate ----------------------------------------------
+
+
+class TestAccessChecker:
+    def test_blocked_repos_excluded(self):
+        reg = {
+            "blocked": DataRepo(id="blocked", kind="gs", base_url="gs://a/", priority=5),
+            "allowed": DataRepo(id="allowed", kind="https", base_url="https://b/", priority=10),
+        }
+        set_access_checker(lambda r: r.id != "blocked")
+        try:
+            url = resolve(["blocked", "allowed"], "ds", "x.csv", registry=reg)
+            assert url.startswith("https://b/")
+        finally:
+            set_access_checker(None)
+
+    def test_all_blocked_raises(self):
+        reg = {"a": DataRepo(id="a", kind="gs", base_url="gs://a/")}
+        set_access_checker(lambda r: False)
+        try:
+            with pytest.raises(NoAccessibleRepoError):
+                resolve(["a"], "ds", "x.csv", registry=reg)
+        finally:
+            set_access_checker(None)
+
+
+# ---------- Strict relative-path validator -----------------------------------
+
+
+class TestStrictRelpath:
+    """Validate that strict-mode repos reject paths outside the URL-safe subset.
+
+    This is the gate that keeps xeno-canto-style mixed-encoding paths from
+    sneaking into new datasets.
+    """
+
+    # -- positive cases (should NOT raise) --
+
+    def test_simple_filename(self):
+        validate_strict_relpath("file.csv")
+
+    def test_nested_path(self):
+        validate_strict_relpath("audio/cbi/wav/XC135454.wav")
+
+    def test_allowed_punctuation(self):
+        validate_strict_relpath("a/b_c/d-e.f~g.wav")
+
+    def test_hashed_filename(self):
+        # The canonical content-addressed shape we expect long-term
+        validate_strict_relpath("audio/a7/a7f3b2c1d9e8f0123456789abcdef0.wav")
+
+    # -- negative cases (should raise) --
+
+    def test_empty_rejected(self):
+        with pytest.raises(InvalidRelativePathError, match="non-empty"):
+            validate_strict_relpath("")
+
+    def test_leading_slash_rejected(self):
+        with pytest.raises(InvalidRelativePathError, match="start with"):
+            validate_strict_relpath("/absolute/path.csv")
+
+    def test_trailing_slash_rejected(self):
+        with pytest.raises(InvalidRelativePathError, match="end with"):
+            validate_strict_relpath("folder/")
+
+    def test_double_dot_traversal_rejected(self):
+        with pytest.raises(InvalidRelativePathError, match=r"\.\."):
+            validate_strict_relpath("folder/../secret.csv")
+
+    def test_space_rejected(self):
+        with pytest.raises(InvalidRelativePathError, match="disallowed"):
+            validate_strict_relpath("Yellow-legged Gull/file.wav")
+
+    def test_unicode_rejected(self):
+        with pytest.raises(InvalidRelativePathError, match="disallowed"):
+            validate_strict_relpath("Espiñeiro.mp3")
+
+    def test_percent_rejected(self):
+        # Percent-encoded URLs are "legacy_percent", not strict
+        with pytest.raises(InvalidRelativePathError, match="disallowed"):
+            validate_strict_relpath("my%20file.csv")
+
+    def test_query_string_rejected(self):
+        with pytest.raises(InvalidRelativePathError, match="disallowed"):
+            validate_strict_relpath("file.csv?v=1.2")
+
+    def test_strict_repo_rejects_at_resolve_time(self):
+        """resolve() should raise when the chosen repo is strict and the path
+        contains forbidden chars."""
+        reg = {"strict-gs": DataRepo(id="strict-gs", kind="gs", base_url="gs://b/", path_encoding="strict")}
+        with pytest.raises(InvalidRelativePathError):
+            resolve(["strict-gs"], "dataset/v1", "file with space.csv", registry=reg)
+
+    def test_legacy_repo_does_not_enforce_yet(self):
+        """Legacy-encoded repos don't enforce the strict grammar (placeholder
+        until conversion logic lands)."""
+        reg = {
+            "legacy": DataRepo(
+                id="legacy", kind="gs", base_url="gs://b/", path_encoding="legacy_raw",
+            )
+        }
+        # This would reject under strict; should pass under legacy_raw for now.
+        url = resolve(["legacy"], "Yellow-legged Gull", "file.wav", registry=reg)
+        assert "Yellow-legged Gull" in url
+
+
+# ---------- DatasetInfo backward compatibility -------------------------------
+
+
+class TestDatasetInfoBackwardCompat:
+    """The most important tests: the 37 existing Dataset subclasses must
+    continue to work without modification.
+    """
+
+    def test_legacy_split_paths_only(self):
+        """Legacy shape: split_paths is set explicitly, new fields unset."""
+        info = DatasetInfo(
+            name="legacy",
+            owner="test",
+            split_paths={"train": "gs://esp-ml-datasets/legacy/train.csv"},
+            version="0.1.0",
+            description="test",
+            sources=["synthetic"],
+        )
+        assert info.split_paths == {"train": "gs://esp-ml-datasets/legacy/train.csv"}
+        assert info.repos is None
+        assert info.folder is None
+        assert info.splits is None
+
+    def test_modern_shape_derives_split_paths(self):
+        """Modern shape: repos+folder+splits set; split_paths is auto-derived."""
+        info = DatasetInfo(
+            name="modern",
+            owner="test",
+            repos=["esp-internal-gcs"],
+            folder="modern-ds/v0.1.0/raw",
+            splits={"train": "train.csv", "val": "val.csv"},
+            version="0.1.0",
+            description="test",
+            sources=["synthetic"],
+        )
+        assert info.split_paths == {
+            "train": "gs://esp-ml-datasets/modern-ds/v0.1.0/raw/train.csv",
+            "val": "gs://esp-ml-datasets/modern-ds/v0.1.0/raw/val.csv",
+        }
+        # Modern fields are preserved on the instance
+        assert info.repos == ["esp-internal-gcs"]
+        assert info.folder == "modern-ds/v0.1.0/raw"
+
+    def test_both_shapes_rejected(self):
+        with pytest.raises(ValidationError, match="either.*legacy.*modern"):
+            DatasetInfo(
+                name="both",
+                owner="test",
+                split_paths={"train": "gs://..."},
+                repos=["esp-internal-gcs"],
+                folder="x",
+                splits={"train": "train.csv"},
+                version="0.1.0",
+                description="test",
+                sources=["synthetic"],
+            )
+
+    def test_neither_shape_rejected(self):
+        with pytest.raises(ValidationError, match="modern shape requires"):
+            DatasetInfo(
+                name="neither",
+                owner="test",
+                version="0.1.0",
+                description="test",
+                sources=["synthetic"],
+            )
+
+    def test_modern_partial_fields_rejected(self):
+        """Missing folder or splits when repos is set should error with clarity."""
+        with pytest.raises(ValidationError, match="modern shape requires"):
+            DatasetInfo(
+                name="partial",
+                owner="test",
+                repos=["esp-internal-gcs"],
+                # folder + splits missing
+                version="0.1.0",
+                description="test",
+                sources=["synthetic"],
+            )
+
+    def test_modern_subclass_reads_split_paths_as_before(self):
+        """The load path uses `info.split_paths[split]` directly — confirm that
+        still works for modern-shape DatasetInfo."""
+        info = DatasetInfo(
+            name="subclass-compat",
+            owner="test",
+            repos=["esp-internal-gcs"],
+            folder="compat/v0.1.0",
+            splits={"train": "train.csv"},
+            version="0.1.0",
+            description="test",
+            sources=["synthetic"],
+        )
+        # This is exactly what Dataset subclasses do:
+        location = info.split_paths["train"]
+        assert location == "gs://esp-ml-datasets/compat/v0.1.0/train.csv"
+        available = list(info.split_paths.keys())
+        assert available == ["train"]
+
+
+# ---------- DatasetInfo resolver integration ---------------------------------
+
+
+class TestDatasetInfoResolverBehavior:
+    def test_runtime_repo_override(self):
+        """Changing the registered repo's base_url changes the resolved URL
+        for new DatasetInfo instances."""
+        original = get_repo("esp-internal-gcs")
+        register_repo(DataRepo(
+            id="esp-internal-gcs",
+            kind="gs",
+            base_url="gs://staging-bucket/",
+            priority=10,
+        ))
+        try:
+            info = DatasetInfo(
+                name="override",
+                owner="test",
+                repos=["esp-internal-gcs"],
+                folder="ds/v0.1.0",
+                splits={"train": "train.csv"},
+                version="0.1.0",
+                description="test",
+                sources=["synthetic"],
+            )
+            assert info.split_paths["train"] == "gs://staging-bucket/ds/v0.1.0/train.csv"
+        finally:
+            register_repo(original)
+
+    def test_priority_fallback_to_public_mirror(self):
+        """When multiple repos are listed and the highest-priority one is
+        unavailable (unregistered in this test), resolver picks the next."""
+        # Save + temporarily remove ESP-internal
+        original = get_repo("esp-internal-gcs")
+        unregister_repo("esp-internal-gcs")
+        register_repo(DataRepo(
+            id="_test_public",
+            kind="https",
+            base_url="https://pub-test.r2.dev/esp/",
+            priority=50,
+        ))
+        try:
+            info = DatasetInfo(
+                name="public-fallback",
+                owner="test",
+                repos=["esp-internal-gcs", "_test_public"],
+                folder="ds/v0.1.0",
+                splits={"train": "train.csv"},
+                version="0.1.0",
+                description="test",
+                sources=["synthetic"],
+            )
+            assert info.split_paths["train"] == "https://pub-test.r2.dev/esp/ds/v0.1.0/train.csv"
+        finally:
+            unregister_repo("_test_public")
+            register_repo(original)


### PR DESCRIPTION
**Status:** Draft — looking for design feedback before formalizing.

Targets `gagan/fsspec-read-public-r2-bucket` (#267) so the diff stays clean. Our resolver generates HTTPS URLs that depend on #267's `PureHTTPSPath` / fsspec HTTP integration. When #267 merges, GitHub should auto-retarget this to `main`.

## What this adds

An optional new shape for `DatasetInfo` that separates **what a dataset is** (identity: name, version, schema, relative paths of files) from **where it's physically hosted** (base URL of one or more repos it's mirrored to). Same pattern as Python packaging (PyPI + mirrors), HuggingFace Hub, Docker/OCI, Maven/Go/npm — a dataset has an identity + a list of repositories it's available in; a resolver picks the highest-priority accessible repo at read time.

Concretely:

- New module `esp_data/io/datarepo.py` — `DataRepo` dataclass, in-memory registry (`register_repo` / `unregister_repo` / `get_repo` / `list_repos`), `join_url` helper, `resolve(repos_ids, folder, relpath)` function, strict-subset path validator, pluggable `access_checker` hook.
- `DatasetInfo` gains three optional fields: `repos: list[str]`, `folder: str`, `splits: dict`. `split_paths` is now also optional. A `@model_validator(mode=\"after\")` enforces exactly one of the two shapes (legacy `split_paths`, or modern `repos+folder+splits`) and auto-derives `split_paths` from the modern fields when used.
- `esp_data/io/__init__.py` re-exports the new public API.
- 41 new tests in `tests/io/test_datarepo.py`.

## Why I think this is worth the weight

Today `DatasetInfo.split_paths` hardcodes one physical URL per split. OSS users without GCP credentials can't access ESP's datasets even when they're publicly mirrored. Adding a new mirror requires touching 37 Dataset subclasses. #267 lets a user manually swap in an HTTPS URL, but doesn't address the coupling between dataset identity and physical location.

With a Repo abstraction, the same catalog serves ESP-internal (via `gs://`), OSS users (via the R2 public mirror's `https://`), and future mirrors (AWS Open Data, Zenodo) with a single config change per dataset — no code edit per subclass. The resolver picks based on priority + accessibility.

**Backward compat is real, not theoretical:** the 37 existing Dataset subclasses read `info.split_paths[split]` and `info.split_paths.keys()` — both continue to work unchanged whether the info was constructed legacy or modern. I verified this end-to-end by instantiating `BarkleyCanyon` (zero code changes to the subclass) backed by a modern-shape `DatasetInfo` pointing at a local-kind `DataRepo`, and loading 9,770 real rows successfully.

Existing tests (`test_dataset.py`, `test_concat.py`, `test_chained.py`) — 33 pass, 2 skipped, 0 failed, same as on the base branch.

## Open questions I'd love your take on

1. **Is \"dataset identity vs. physical location\" a separation you've considered before?** The unmerged `tar-exporter` branch and the `schema-*` branches are adjacent in shape, and I don't want to reinvent something you've already thought through. The `schema-descriptions` work in particular composes nicely with this — schemas describe what's in a dataset, DataRepos describe where to get it.

2. **Does the auto-derive `split_paths` from modern fields feel right?** The `@model_validator` + `object.__setattr__` pattern means zero subclass changes, but it means at-init resolution — if the repo registry changes after a DatasetInfo is built, stale. A future version could use `@computed_field` for lazy resolution; I kept it simple for the prototype.

3. **Is `path_encoding` worth implementing fully now, or defer until xeno-canto needs it?** The field is declared on `DataRepo` but not yet used in `join_url`. For strict-only deployments (all our data today except xeno-canto) it's a no-op. My lean: defer.

4. **Would you want this stacked as-is on your branch, or should I wait for #267 to land and rebase off main?** I can see arguments either way. Stacking keeps the diff focused; rebasing gives you a cleaner independent review.

## Design notes (things you might want to know)

- **Strict subset `[A-Za-z0-9._~\\-/]`** chosen because most existing ESP paths already fit it. I empirically surveyed 1,873 path values across 28 dataset modules — `fn`, `filename`, `filepath`, `audio_fp`, `local_path`, `originals_path` are all within this subset today. Only xeno-canto has spaces / non-ASCII in filenames, and that dataset has pre-existing mixed-encoding inconsistencies that \"legacy_raw\"/\"legacy_percent\" modes are placeholders for.
- **Built-in default repo:** `esp-internal-gcs` with `base_url=\"gs://esp-ml-datasets/\"`, priority 10. Registered at module import. Users override with `register_repo(...)`.
- **Relative-path validation runs at `resolve()` time**, not at `DataRepo` construction time. This is a deliberate choice: the constraint depends on the target repo's `path_encoding`, and the same dataset can be served from repos with different encodings.

## What this explicitly doesn't touch

- The 37 existing Dataset subclasses. They keep using `split_paths` via the legacy branch.
- `PureHTTPSPath` from #267. Coexists; not used by this code directly.
- `DatasetConfig` / `ChainedDatasetConfig` — I didn't see any parallel changes needed but haven't exhaustively read those paths. Worth flagging if you spot something I missed.

## Future follow-ups (not in this PR)

- `legacy_raw` / `legacy_percent` path encoding conversion in `join_url`. Needed before xeno-canto can use the system.
- Lazy `@computed_field` resolution if repo-registry changes need to affect in-flight Datasets.
- Credential/auth system beyond the `access_checker` boolean.
- Porting existing Dataset subclasses to modern shape — additive migration, can happen per-dataset when someone has bandwidth.
- Registering the public R2 repo (waiting on the mirror URL).

---

I haven't pitched any of this to Milad or anyone else yet — wanted to get your read first since this is downstream of your #267 work and adjacent to your schema branches.