### PR TITLE
Small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ for sample in beans_streaming:
     break
 ```
 
+> ⚠️ **Warning:** When using a PyTorch `DataLoader` with `num_workers > 0`, you must set the multiprocessing start method to `"spawn"` (not the default `"fork"` on Linux). esp-data datasets hold cloud-backed I/O handles (fsspec / `gcsfs` / `s3fs`) that are not safe to inherit across a `fork`; using `"fork"` can deadlock workers or corrupt audio reads. Either call `torch.multiprocessing.set_start_method("spawn", force=True)` at the top of your program, or pass a `"spawn"` context to the DataLoader, e.g.:
+>
+> ```python
+> import torch.multiprocessing as mp
+> from torch.utils.data import DataLoader
+>
+> loader = DataLoader(
+>     dataset,
+>     num_workers=4,
+>     multiprocessing_context=mp.get_context("spawn"),
+> )
+> ```
+
 Datasets and transforms can also be loaded from a YAML config:
 
 ```yaml

--- a/docs/concatenate.md
+++ b/docs/concatenate.md
@@ -33,14 +33,14 @@ More technically, dataset concatenation:
 
 ### A note on dataset merging
 
-In v1 of this approach, we have are three [merge strategies](#merge-strategies). Currently, because we use `pandas` DataFrames under the hood, the merge strategies are:
+There are three [merge strategies](#merge-strategies). The merge logic is implemented through the backend abstraction (`pandas` or `polars`), so the strategies behave consistently regardless of which backend the source datasets use:
 
 1. **Soft Merge**: Keeps all columns from all datasets, filling missing values with NaN.
 2. **Overlap Merge**: Keeps only columns that exist in all datasets.
 3. **Hard Merge**: Requires all datasets to have identical columns, raising an error if they differ.
 
 !!! warning
-    When merging two datasets, be aware that if a column with the same name appears in multiple datasets being concatenated, and the data type **dtype** of the column is not the same across datasets, the resulting column in the concatenated dataset will be of type `object` in pandas, which may lead to unexpected behavior in downstream processing because this can be a mixed data type!
+    When merging two datasets, be aware that if a column with the same name appears in multiple datasets being concatenated, and the data type (dtype) of the column is not the same across datasets, the resulting column in the concatenated dataset may be upcast to `object` (pandas) or fail to concatenate (polars). This can lead to unexpected behavior in downstream processing.
 
 ## How can I concatenate datasets?
 
@@ -49,17 +49,15 @@ Datasets can be concatenated using the `ConcatenatedDataset` class with differen
 ### Basic Usage
 
 ```python
-from esp_data.datasets import AnimalSpeak, BarkleyCanyon
-from esp_data.concat import ConcatanatedDataset
+from esp_data.datasets import AnimalSpeak, InsectSet459
+from esp_data.concat import ConcatenatedDataset
 
 # Load individual datasets
 dataset1 = AnimalSpeak(split="validation")
-dataset2 = BarkleyCanyon(split="train")
+dataset2 = InsectSet459(split="validation")
 
 print(f"Dataset 1 length: {len(dataset1)}")
-# 2033
 print(f"Dataset 2 length: {len(dataset2)}")
-# 9770
 
 # Concatenate with default soft merge
 combined_dataset = ConcatenatedDataset(
@@ -69,12 +67,8 @@ combined_dataset = ConcatenatedDataset(
 
 # Access the combined data
 print(f"Combined dataset length: {len(combined_dataset)}")
-# 11803
 sample = combined_dataset[0]  # Get first sample (should be AnimalSpeak)
 print(f"First sample: {sample.keys()}")
-
-# get last sample (should be BarkleyCanyon)
-print(f"Last sample: {combined_dataset[-1].keys()}")
 ```
 
 #### Create a combined dataset from a yaml config
@@ -113,13 +107,13 @@ combined_dataset = dataset_from_config("path/to/concat_config.yaml")
 You can apply transformations to the individual datasets *before* concatenation as shown in [transforms.md](transforms.md). This allows you to treat the data as needed, but you can also apply transformations *after* concatenation if you want to operate on the combined dataset as a whole. Here is an example of applying a filter transformation *after* concatenation:
 
 ```python
-from esp_data.datasets import AnimalSpeak, BarkleyCanyon
+from esp_data.datasets import AnimalSpeak, InsectSet459
 from esp_data.transforms import FilterConfig
 from esp_data.concat import ConcatenatedDataset
 
 # Load individual datasets
 dataset1 = AnimalSpeak(split="validation")
-dataset2 = BarkleyCanyon(split="train")
+dataset2 = InsectSet459(split="validation")
 # Concatenate datasets
 combined_dataset = ConcatenatedDataset([dataset1, dataset2])
 # Define a filter transformation
@@ -139,7 +133,7 @@ transform_metadata = combined_dataset.apply_transformations([filter_config])
     `NaN` for those datasets.
 
 
-As mentioned, ycou can also apply transforms to individual datasets before concatenation:
+As mentioned, you can also apply transforms to individual datasets before concatenation:
 
 ```python
 # Create and transform individual datasets
@@ -348,9 +342,9 @@ check_compatibility([dataset1, dataset2])
 
 ### Current Limitations
 
-1. **No Configuration Loading**: `ConcatenatedDataset` cannot be created from `DatasetConfig`
-2. **Memory Usage**: All source datasets remain in memory
-3. **Single Split**: Concatenated datasets only support the "concatenated" split
+1. **Memory Usage**: All source datasets remain in memory (`streaming=True` is not supported for concatenation; use `ChainedDataset` for streaming).
+2. **Single Split**: Concatenated datasets only support the "concatenated" split.
+3. **Uniform Backend**: All source datasets must use the same backend type (e.g., all polars or all pandas).
 
 ### Performance Considerations
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,18 @@ for sample in beans_streaming:
     print(sample["audio"].shape)
     break
 ```
+
+!!! warning "PyTorch DataLoader with `num_workers > 0` requires `spawn`"
+    When wrapping an esp-data `Dataset` in a PyTorch `DataLoader` with
+    `num_workers > 0`, you must use the `"spawn"` multiprocessing start
+    method instead of the default `"fork"` on Linux. esp-data datasets hold
+    fsspec / `gcsfs` / `s3fs` handles that are not
+    safe to inherit across a `fork` — workers may deadlock or return
+    corrupted audio. Either call
+    `torch.multiprocessing.set_start_method("spawn", force=True)` once at
+    program start, or pass `multiprocessing_context=mp.get_context("spawn")`
+    to the `DataLoader`.
+
 Check out the datasets documentation for more details [here](./datasets.md).
 
 ## Installation

--- a/esp_data/chain.py
+++ b/esp_data/chain.py
@@ -62,11 +62,11 @@ class ChainedDataset(Dataset):
         if len(streaming_modes) > 1:
             raise ChainException(
                 "All datasets must have the same streaming mode "
-                "to be concatenated into a ConcatenatedDataset."
+                "to be combined into a ChainedDataset."
             )
         _streaming = streaming_modes.pop()
 
-        # _backend_class doesn'gt matter here since we override all data access methods
+        # _backend_class doesn't matter here since we override all data access methods
         super().__init__(streaming=_streaming)
 
         self._source_datasets = datasets
@@ -145,19 +145,19 @@ class ChainedDataset(Dataset):
     def from_config(
         cls, chain_config: ChainedDatasetConfig
     ) -> tuple["ChainedDataset", dict[str, Any]]:
-        """Create a ConcatenatedDataset from a ConcatConfig object.
+        """Create a `ChainedDataset` from a `ChainedDatasetConfig` object.
 
         Parameters
         ----------
         chain_config : ChainedDatasetConfig
-            Configuration object specifying the datasets to concatenate
-            and how to merge them.
+            Configuration object specifying the datasets to chain together.
 
         Returns
         -------
         tuple[ChainedDataset, dict]
-            A tuple containing the ConcatenatedDataset instance
-            and metadata about transformations applied.
+            A tuple containing the `ChainedDataset` instance and a metadata
+            dict aggregating transform metadata from each source dataset,
+            keyed by `f"{dataset_name}_metadata"`.
         """
         datasets = []
         metadata = {}

--- a/esp_data/dataset.py
+++ b/esp_data/dataset.py
@@ -38,7 +38,7 @@ class DatasetConfig(BaseModel):
     Examples
     --------
     >>> dataset_config = DatasetConfig(
-    ...    dataset_name="barkley_canyon",
+    ...    dataset_name="some_dataset",
     ...    transformations=[
     ...        {
     ...            "type": "label_from_feature",

--- a/esp_data/dataset.py
+++ b/esp_data/dataset.py
@@ -559,7 +559,12 @@ def list_registered_datasets() -> list[str]:
     list[str]
         List of dataset names
     """
-    return list(_dataset_registry.keys())
+    datasets = list(_dataset_registry.keys())
+    # Remove chained_dataset and concatenated_dataset
+    # from the list as they are not actual datasets
+    # but dataset collections
+    datasets = [d for d in datasets if d not in ("chained_dataset", "concatenated_dataset")]
+    return datasets
 
 
 def dataset_class_from_name(dataset_name: str) -> type[Dataset]:
@@ -589,6 +594,8 @@ def dataset_class_from_name(dataset_name: str) -> type[Dataset]:
 def print_registered_datasets() -> None:
     """Print all registered datasets."""
     for dataset_class in _dataset_registry.values():
+        if dataset_class.info.name in ("chained_dataset", "concatenated_dataset"):
+            continue
         print(dataset_class.info.model_dump_json(indent=2))
 
 

--- a/esp_data/dataset.py
+++ b/esp_data/dataset.py
@@ -36,7 +36,7 @@ class DatasetConfig(BaseModel):
         If None, the default is the parent directory of the split path.
 
     Examples
-    -------
+    --------
     >>> dataset_config = DatasetConfig(
     ...    dataset_name="barkley_canyon",
     ...    transformations=[
@@ -178,7 +178,7 @@ class DatasetInfo(BaseModel):
     """A Pydantic base model for the info (cfg) of a dataset.
 
     Attributes
-    ---------
+    ----------
     name : str
         Name of the dataset
     owner : str | list[str]
@@ -264,7 +264,7 @@ class DatasetInfo(BaseModel):
         using the semver package.
 
         Parameters
-        ---------
+        ----------
         v : str
             The version string to validate
 
@@ -289,6 +289,7 @@ class DatasetInfo(BaseModel):
 
 class Dataset(ABC):
     """Abstract base class defining the interface for ESP datasets.
+
     Any new dataset should inherit from this class to be added to the registry
     of available ESP datasets.
 
@@ -300,7 +301,7 @@ class Dataset(ABC):
 
     Methods
     -------
-    _load() -> pd.DataFrame
+    _load() -> Sequence[Any] | None
         Required method to load a specific split of the dataset.
     __len__() -> int
         Required method to return the number of samples in the dataset.
@@ -308,6 +309,18 @@ class Dataset(ABC):
         Required method to iterate over the samples in the dataset.
     __getitem__(idx: int) -> Dict[str, Any]
         Required method to get a specific sample from the dataset.
+
+    .. warning::
+        When using a PyTorch `DataLoader` with `num_workers > 0`, the
+        multiprocessing start method must be set to `"spawn"` rather than
+        the default `"fork"` on Linux. esp-data datasets hold fsspec,
+        `gcsfs`, and `s3fs` handles and resampling state that are not
+        safe to inherit across a `fork`, which can deadlock workers or
+        corrupt audio reads. Either call
+        `torch.multiprocessing.set_start_method("spawn", force=True)` at
+        program start, or pass
+        `multiprocessing_context=mp.get_context("spawn")` to the
+        `DataLoader`.
     """
 
     info: DatasetInfo
@@ -366,12 +379,14 @@ class Dataset(ABC):
 
     @abstractmethod
     def _load(self) -> Sequence[Any] | None:
-        """Load one split of the dataset.s
+        """Load one split of the dataset.
 
         Returns
         -------
-        Sequence[Any]
-            The requested split of the dataset.
+        Sequence[Any] | None
+            The requested split of the dataset, or `None` if the
+            implementation stores loaded data on the instance rather than
+            returning it.
         """
         pass
 
@@ -385,7 +400,7 @@ class Dataset(ABC):
 
         Parameters
         ----------
-        dataset_config : DatasetInfo
+        dataset_config : DatasetConfig
             The configuration for the dataset.
 
         Returns

--- a/esp_data/dataset.py
+++ b/esp_data/dataset.py
@@ -293,6 +293,18 @@ class Dataset(ABC):
     Any new dataset should inherit from this class to be added to the registry
     of available ESP datasets.
 
+    !!! warning "PyTorch DataLoader with `num_workers > 0` requires `spawn`"
+        When using a PyTorch `DataLoader` with `num_workers > 0`, the
+        multiprocessing start method must be set to `"spawn"` rather than
+        the default `"fork"` on Linux. esp-data datasets hold fsspec,
+        `gcsfs`, and `s3fs` handles and resampling state that are not
+        safe to inherit across a `fork`, which can deadlock workers or
+        corrupt audio reads. Either call
+        `torch.multiprocessing.set_start_method("spawn", force=True)` at
+        program start, or pass
+        `multiprocessing_context=mp.get_context("spawn")` to the
+        `DataLoader`.
+
     Attributes
     ----------
     info : DatasetInfo
@@ -309,18 +321,6 @@ class Dataset(ABC):
         Required method to iterate over the samples in the dataset.
     __getitem__(idx: int) -> Dict[str, Any]
         Required method to get a specific sample from the dataset.
-
-    .. warning::
-        When using a PyTorch `DataLoader` with `num_workers > 0`, the
-        multiprocessing start method must be set to `"spawn"` rather than
-        the default `"fork"` on Linux. esp-data datasets hold fsspec,
-        `gcsfs`, and `s3fs` handles and resampling state that are not
-        safe to inherit across a `fork`, which can deadlock workers or
-        corrupt audio reads. Either call
-        `torch.multiprocessing.set_start_method("spawn", force=True)` at
-        program start, or pass
-        `multiprocessing_context=mp.get_context("spawn")` to the
-        `DataLoader`.
     """
 
     info: DatasetInfo
@@ -566,6 +566,10 @@ def register_config(cls: type[DatasetConfig]) -> type[DatasetConfig]:
     return cls
 
 
+# Registered but excluded from listings — these are dataset collections, not datasets.
+_HIDDEN_DATASETS: frozenset[str] = frozenset({"chained_dataset", "concatenated_dataset"})
+
+
 def list_registered_datasets() -> list[str]:
     """List all registered datasets.
 
@@ -574,12 +578,7 @@ def list_registered_datasets() -> list[str]:
     list[str]
         List of dataset names
     """
-    datasets = list(_dataset_registry.keys())
-    # Remove chained_dataset and concatenated_dataset
-    # from the list as they are not actual datasets
-    # but dataset collections
-    datasets = [d for d in datasets if d not in ("chained_dataset", "concatenated_dataset")]
-    return datasets
+    return [d for d in _dataset_registry if d not in _HIDDEN_DATASETS]
 
 
 def dataset_class_from_name(dataset_name: str) -> type[Dataset]:
@@ -609,7 +608,7 @@ def dataset_class_from_name(dataset_name: str) -> type[Dataset]:
 def print_registered_datasets() -> None:
     """Print all registered datasets."""
     for dataset_class in _dataset_registry.values():
-        if dataset_class.info.name in ("chained_dataset", "concatenated_dataset"):
+        if dataset_class.info.name in _HIDDEN_DATASETS:
             continue
         print(dataset_class.info.model_dump_json(indent=2))
 

--- a/esp_data/datasets/esp_raincoast.py
+++ b/esp_data/datasets/esp_raincoast.py
@@ -18,7 +18,6 @@ from esp_data.io import (
     anypath,
     audio_stereo_to_mono,
     read_audio,
-    read_text,
 )
 
 
@@ -167,13 +166,10 @@ class ESPRaincoast(Dataset):
                 location, lines=True, streaming=self._streaming
             )
         else:
-            from io import StringIO
-
-            csv_text = read_text(location, encoding="utf-8")
             # TODO: Polars picked up some inconsistencies in the data!
             # Column "Call Quality" has a mix of f64 and string types
             self._data = self._backend_class.from_csv(
-                StringIO(csv_text), streaming=self._streaming, infer_schema_length=10000
+                location, streaming=self._streaming, infer_schema_length=10000
             )
 
     @classmethod

--- a/esp_data/datasets/voxaboxen.py
+++ b/esp_data/datasets/voxaboxen.py
@@ -14,7 +14,7 @@ from pydantic import Field
 from esp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
 from esp_data.backends import BackendType
 from esp_data.dataset import register_config
-from esp_data.io import DATA_HOME, AnyPathT, anypath, audio_stereo_to_mono, read_audio, read_text
+from esp_data.io import DATA_HOME, AnyPathT, anypath, audio_stereo_to_mono, read_audio
 
 _FILES_ROOT = f"{DATA_HOME}/voxaboxen/files"
 _OZF_SYN_ROOT = f"{_FILES_ROOT}/OZF_synthetic"
@@ -326,9 +326,7 @@ class Voxaboxen(Dataset):
             )
 
         location = self.info.split_paths[self.split]
-        # Read CSV content
-        csv_text = read_text(location, encoding="utf-8")
-        self._data = self._backend_class.from_csv(StringIO(csv_text), streaming=self._streaming)
+        self._data = self._backend_class.from_csv(location, streaming=self._streaming)
 
     @classmethod
     def from_config(cls, dataset_config: VoxaboxenConfig) -> tuple["Voxaboxen", dict[str, Any]]:
@@ -759,9 +757,7 @@ class VoxaboxenEvents(Dataset):
             )
 
         location = self.info.split_paths[self.split]
-        # Read CSV content
-        csv_text = read_text(location, encoding="utf-8")
-        self._data = self._backend_class.from_csv(StringIO(csv_text), streaming=self._streaming)
+        self._data = self._backend_class.from_csv(location, streaming=self._streaming)
 
     @classmethod
     def from_config(cls, dataset_config: DatasetConfig) -> tuple["VoxaboxenEvents", dict[str, Any]]:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -45,6 +45,10 @@ def test_list_registered_datasets():
     assert isinstance(datasets, list)
     assert len(datasets) > 0  # Assuming at least one dataset is registered
     assert "animalspeak" in datasets  # Assuming animalspeak is registered by default
+    # ChainedDataset is registered but should not appear in the list
+    assert "chained_dataset" not in datasets
+    # ConcatenatedDataset is registered but should not appear in the list
+    assert "concatenated_dataset" not in datasets
 
 
 def test_print_registered_datasets(capsys):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,25 +1,26 @@
 """Unit tests for the dataset module."""
 
-import pytest
 from pathlib import Path
-import yaml
-from typing import Any, Dict, Optional, Literal
+from typing import Any, Dict, Literal
+
 import pandas as pd
+import pytest
+import yaml
 from pydantic import BaseModel
 
-from esp_data.io import anypath, AnyPathT
 from esp_data import (
     Dataset,
     DatasetConfig,
     DatasetInfo,
     dataset_from_config,
-    register_dataset,
-    register_config,
     list_registered_datasets,
-    print_registered_datasets
+    print_registered_datasets,
+    register_config,
+    register_dataset,
 )
-from esp_data.transforms import register_transform, transform_from_config
 from esp_data.backends import PandasBackend
+from esp_data.io import AnyPathT
+from esp_data.transforms import register_transform, transform_from_config
 
 
 def test_register_dataset():
@@ -58,6 +59,9 @@ def test_print_registered_datasets(capsys):
     captured = capsys.readouterr()
     assert "animalspeak" in captured.out  # Assuming animalspeak is registered by default
     assert "birdset" in captured.out  # Assuming DummyDataset was registered in this test
+    # Dataset collections should not appear in the printed output
+    assert "chained_dataset" not in captured.out
+    assert "concatenated_dataset" not in captured.out
 
 
 def test_dataset_from_config():
@@ -75,7 +79,7 @@ class MyCustomConfig(DatasetConfig):
     dataset_name: str = "my_custom_dataset"
     split: str = "train"
     output_take_and_give: dict[str, str] | None = None
-    data_root: Optional[str | AnyPathT] = None
+    data_root: str | AnyPathT | None = None
 
 
 @register_dataset
@@ -109,8 +113,8 @@ class MyCustomDataset(Dataset):
     def __init__(
         self,
         split: str = "train",
-        output_take_and_give: Optional[dict[str, str]] = None,
-        data_root: Optional[str | AnyPathT] = None,
+        output_take_and_give: dict[str, str] | None = None,
+        data_root: str | AnyPathT | None = None,
     ) -> None:
         """Initialize the dataset."""
         super().__init__(output_take_and_give)
@@ -193,7 +197,6 @@ class MyCustomDataset(Dataset):
             return ds, transform_metadata
 
         return ds, {}
-
 
 
 class RenameConfig(BaseModel):


### PR DESCRIPTION
- Remove chained and concatenated datasets from `list_registered` and `print_registered_datasets`  #283 
- Adds Multiprocessing start method (spawn vs fork) warning to README, docs/index.md and Dataset class docstring so users are aware when using torch dataloader
- Fixed docs and docstrings (deleting/replacing mentions of BarkleyCanyon which has been removed)
- Fixing streaming bugs in esp-raincoast and voxaboxen datasets