### PR TITLE
Add spanish carrion crows vox

### DIFF
--- a/esp_data/datasets/__init__.py
+++ b/esp_data/datasets/__init__.py
@@ -28,6 +28,7 @@ from .nocturnal_bird_migration import NocturnalBirdMigration
 from .pipit_id import PipitId
 from .powdermill import Powdermill
 from .spanish_carrion_crows import SpanishCarrionCrows
+from .spanish_carrion_crows_vox import SpanishCarrionCrowsVox
 from .subsegmentation import Subsegmentation
 from .superb_starling import SuperbStarling
 from .voxaboxen import Voxaboxen, VoxaboxenEvents
@@ -78,4 +79,5 @@ __all__ = [
     "DCLDE2026",
     "Watkins",
     "SpanishCarrionCrows",
+    "SpanishCarrionCrowsVox",
 ]

--- a/esp_data/datasets/__init__.py
+++ b/esp_data/datasets/__init__.py
@@ -27,6 +27,7 @@ from .macaques_coo_calls import MacaquesCooCalls
 from .nocturnal_bird_migration import NocturnalBirdMigration
 from .pipit_id import PipitId
 from .powdermill import Powdermill
+from .spanish_carrion_crows import SpanishCarrionCrows
 from .subsegmentation import Subsegmentation
 from .superb_starling import SuperbStarling
 from .voxaboxen import Voxaboxen, VoxaboxenEvents
@@ -76,4 +77,5 @@ __all__ = [
     "CorvidWascher",
     "DCLDE2026",
     "Watkins",
+    "SpanishCarrionCrows",
 ]

--- a/esp_data/datasets/spanish_carrion_crows.py
+++ b/esp_data/datasets/spanish_carrion_crows.py
@@ -6,6 +6,7 @@ from io import StringIO
 from typing import Any, Iterator
 
 import librosa
+import numpy as np
 import pandas as pd
 
 from esp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
@@ -38,7 +39,7 @@ class SpanishCarrionCrows(Dataset):
         - Synchronized UTC timestamps across biologgers.
         - Annotations of file quality
           e.g., some biologgers prematurely detached from the bird and recorded
-          background sounds only
+          background sounds only. Therefore some selection tables are empty.
         - Call types
     If any additional data are needed, please contact Maddie.
 
@@ -46,65 +47,21 @@ class SpanishCarrionCrows(Dataset):
 
     TODO: Add preprint link.
 
+    Should talk to collaborators (Daniela Canestrari and Vittorio Baglione)
+    about usage in work to be published.
+
     """
 
     info = DatasetInfo(
         name="spanish-carrion-crows",
         owner="maddie",
         split_paths={
-            "all": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/all__spanish-carrion-crows_info.csv",
-            "2018_AW_Roja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_AW_Roja__spanish-carrion-crows_info.csv",
-            "2018_AW_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_AW_Azul__spanish-carrion-crows_info.csv",
-            "2018_AY_Amarilla": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_AY_Amarilla__spanish-carrion-crows_info.csv",
-            "2018_AY_Verde": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_AY_Verde__spanish-carrion-crows_info.csv",
-            "2018_BC_Amarilla": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_BC_Amarilla__spanish-carrion-crows_info.csv",
-            "2018_BC_Naranja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_BC_Naranja__spanish-carrion-crows_info.csv",
-            "2018_BC_Verde": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_BC_Verde__spanish-carrion-crows_info.csv",
-            "2018_CT_Rosa": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_CT_Rosa__spanish-carrion-crows_info.csv",
-            "2018_N1_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_N1_Azul__spanish-carrion-crows_info.csv",
-            "2018_O_Roja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_O_Roja__spanish-carrion-crows_info.csv",
-            "2018_O_Verde": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_O_Verde__spanish-carrion-crows_info.csv",
-            "2018_VAE_Amarilla": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_VAE_Amarilla__spanish-carrion-crows_info.csv",
-            "2018_VAE_Roja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_VAE_Roja__spanish-carrion-crows_info.csv",
-            "2019_AL_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_AL_Azul__spanish-carrion-crows_info.csv",
-            "2019_AL_Naranja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_AL_Naranja__spanish-carrion-crows_info.csv",
-            "2019_AL_Rosa": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_AL_Rosa__spanish-carrion-crows_info.csv",
-            "2019_BA_Amarilla": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BA_Amarilla__spanish-carrion-crows_info.csv",
-            "2019_BA_Roja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BA_Roja__spanish-carrion-crows_info.csv",
-            "2019_BD_Naranja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BD_Naranja__spanish-carrion-crows_info.csv",
-            "2019_BD_Rosa": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BD_Rosa__spanish-carrion-crows_info.csv",
-            "2019_BPBO_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BPBO_Azul__spanish-carrion-crows_info.csv",
-            "2019_BUCK_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BUCK_Azul__spanish-carrion-crows_info.csv",
-            "2019_BUCK_Morado": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BUCK_Morado__spanish-carrion-crows_info.csv",
-            "2019_BUCK_Rosa": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BUCK_Rosa__spanish-carrion-crows_info.csv",
-            "2019_BV_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BV_Azul__spanish-carrion-crows_info.csv",
-            "2019_BV_Morado": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BV_Morado__spanish-carrion-crows_info.csv",
-            "2019_CA_Rosa": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_CA_Rosa__spanish-carrion-crows_info.csv",
-            "2019_CV_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_CV_Azul__spanish-carrion-crows_info.csv",
-            "2019_CV_Roja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_CV_Roja__spanish-carrion-crows_info.csv",
-            "2019_CW_Amarillo": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_CW_Amarillo__spanish-carrion-crows_info.csv",
-            "2019_EB_Rojo": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_EB_Rojo__spanish-carrion-crows_info.csv",
-            "2019_EB_Verde": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_EB_Verde__spanish-carrion-crows_info.csv",
-            "2019_N7_Amarillo": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_N7_Amarillo__spanish-carrion-crows_info.csv",
-            "2019_N7_Morado": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_N7_Morado__spanish-carrion-crows_info.csv",
-            "2021_BPBO_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_BPBO_Azul__spanish-carrion-crows_info.csv",
-            "2021_BPBO_Verde": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_BPBO_Verde__spanish-carrion-crows_info.csv",
-            "2021_BQ_Naranja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_BQ_Naranja__spanish-carrion-crows_info.csv",
-            "2021_EB_Amarillo": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_EB_Amarillo__spanish-carrion-crows_info.csv",
-            "2021_FA_Amarillo": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_FA_Amarillo__spanish-carrion-crows_info.csv",
-            "2021_FA_Rojo": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_FA_Rojo__spanish-carrion-crows_info.csv",
-            "2021_LL_Amarillo": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_LL_Amarillo__spanish-carrion-crows_info.csv",
-            "2021_LL_Verde": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_LL_Verde__spanish-carrion-crows_info.csv",
-            "2021_N4_Naranja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_N4_Naranja__spanish-carrion-crows_info.csv",
-            "2021_N4_Verde": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_N4_Verde__spanish-carrion-crows_info.csv",
+            "all": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/all__spanish-carrion-crows_info.csv"
         },
         version="0.1.0",
         description="Crow biologger audio with Voxaboxen detections",
         sources="University of Leon",
-        license=(
-            "For ESP internal, non-commerical use only. "
-            "Should talk to collaborators about usage in work to be published."
-        ),
+        license="private",
     )
 
     _sample_rate_paths: dict[int, str] = {}
@@ -116,7 +73,7 @@ class SpanishCarrionCrows(Dataset):
         output_take_and_give: dict[str, str] | None = None,
         sample_rate: int | None = 16000,
         data_root: str | AnyPathT | None = None,
-        backend: BackendType = "pandas",
+        backend: BackendType = "polars",
         streaming: bool = False,
     ) -> None:
         """
@@ -227,8 +184,7 @@ class SpanishCarrionCrows(Dataset):
             audio_path = anypath(self.data_root) / row[self._originals_path_column]
 
         audio, sr = read_audio(audio_path)
-        # Should all be mono
-        # audio = audio_stereo_to_mono(audio, mono_method="average").astype(np.float32)
+        audio = audio.astype(np.float32)
 
         if not use_presampled and self.sample_rate is not None and sr != self.sample_rate:
             audio = librosa.resample(

--- a/esp_data/datasets/spanish_carrion_crows.py
+++ b/esp_data/datasets/spanish_carrion_crows.py
@@ -1,0 +1,343 @@
+"""SpanishCarrionCrows dataset"""
+
+from __future__ import annotations
+
+from io import StringIO
+from typing import Any, Iterator
+
+import librosa
+import pandas as pd
+
+from esp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
+from esp_data.backends import BackendType
+from esp_data.io import AnyPathT, anypath, read_audio
+
+
+@register_dataset
+class SpanishCarrionCrows(Dataset):
+    """SpanishCarrionCrows Dataset
+
+    Description
+    -----------
+    This class makes the Spanish carrion crow biologger dataset available
+    (2018, 2019, 2021). Each entry is an audio recording, sampling rate,
+    year, territory, focal individual (individual wearing the biologger),
+    plus a selection table derived from Voxaboxen inference. Each row of
+    the selection table has `Annotation` = an annotation of the caller
+    (focal adult non-focal adult, crow chick, or cuckoo chick), `Detection
+    Prob` = detection probability, `Class Prob` = classification probability,
+    start and stop time (in seconds within the file). In the paper, we
+    filtered detections with `Detection Prob` >= 0.5, and assigned a known
+    caller for `Class Prob` >= 0.5.
+
+    This dataset does not contain several aspects of the full crow dataset,
+    for example:
+        - (Non-synchronized) UTC timestamps for each detection
+          Note that audio files can skip, such that timestamps are not linearly
+          related to sec in the file. Mostly should not be an issue.
+        - Synchronized UTC timestamps across biologgers.
+        - Annotations of file quality
+          e.g., some biologgers prematurely detached from the bird and recorded
+          background sounds only
+        - Call types
+    If any additional data are needed, please contact Maddie.
+
+    There are currently no pre-computed sample rates.
+
+    TODO: Add preprint link.
+
+    """
+
+    info = DatasetInfo(
+        name="spanish-carrion-crows",
+        owner="maddie",
+        split_paths={
+            "all": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/all__spanish-carrion-crows_info.csv",
+            "2018_AW_Roja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_AW_Roja__spanish-carrion-crows_info.csv",
+            "2018_AW_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_AW_Azul__spanish-carrion-crows_info.csv",
+            "2018_AY_Amarilla": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_AY_Amarilla__spanish-carrion-crows_info.csv",
+            "2018_AY_Verde": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_AY_Verde__spanish-carrion-crows_info.csv",
+            "2018_BC_Amarilla": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_BC_Amarilla__spanish-carrion-crows_info.csv",
+            "2018_BC_Naranja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_BC_Naranja__spanish-carrion-crows_info.csv",
+            "2018_BC_Verde": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_BC_Verde__spanish-carrion-crows_info.csv",
+            "2018_CT_Rosa": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_CT_Rosa__spanish-carrion-crows_info.csv",
+            "2018_N1_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_N1_Azul__spanish-carrion-crows_info.csv",
+            "2018_O_Roja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_O_Roja__spanish-carrion-crows_info.csv",
+            "2018_O_Verde": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_O_Verde__spanish-carrion-crows_info.csv",
+            "2018_VAE_Amarilla": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_VAE_Amarilla__spanish-carrion-crows_info.csv",
+            "2018_VAE_Roja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2018_VAE_Roja__spanish-carrion-crows_info.csv",
+            "2019_AL_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_AL_Azul__spanish-carrion-crows_info.csv",
+            "2019_AL_Naranja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_AL_Naranja__spanish-carrion-crows_info.csv",
+            "2019_AL_Rosa": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_AL_Rosa__spanish-carrion-crows_info.csv",
+            "2019_BA_Amarilla": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BA_Amarilla__spanish-carrion-crows_info.csv",
+            "2019_BA_Roja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BA_Roja__spanish-carrion-crows_info.csv",
+            "2019_BD_Naranja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BD_Naranja__spanish-carrion-crows_info.csv",
+            "2019_BD_Rosa": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BD_Rosa__spanish-carrion-crows_info.csv",
+            "2019_BPBO_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BPBO_Azul__spanish-carrion-crows_info.csv",
+            "2019_BUCK_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BUCK_Azul__spanish-carrion-crows_info.csv",
+            "2019_BUCK_Morado": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BUCK_Morado__spanish-carrion-crows_info.csv",
+            "2019_BUCK_Rosa": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BUCK_Rosa__spanish-carrion-crows_info.csv",
+            "2019_BV_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BV_Azul__spanish-carrion-crows_info.csv",
+            "2019_BV_Morado": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_BV_Morado__spanish-carrion-crows_info.csv",
+            "2019_CA_Rosa": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_CA_Rosa__spanish-carrion-crows_info.csv",
+            "2019_CV_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_CV_Azul__spanish-carrion-crows_info.csv",
+            "2019_CV_Roja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_CV_Roja__spanish-carrion-crows_info.csv",
+            "2019_CW_Amarillo": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_CW_Amarillo__spanish-carrion-crows_info.csv",
+            "2019_EB_Rojo": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_EB_Rojo__spanish-carrion-crows_info.csv",
+            "2019_EB_Verde": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_EB_Verde__spanish-carrion-crows_info.csv",
+            "2019_N7_Amarillo": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_N7_Amarillo__spanish-carrion-crows_info.csv",
+            "2019_N7_Morado": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2019_N7_Morado__spanish-carrion-crows_info.csv",
+            "2021_BPBO_Azul": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_BPBO_Azul__spanish-carrion-crows_info.csv",
+            "2021_BPBO_Verde": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_BPBO_Verde__spanish-carrion-crows_info.csv",
+            "2021_BQ_Naranja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_BQ_Naranja__spanish-carrion-crows_info.csv",
+            "2021_EB_Amarillo": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_EB_Amarillo__spanish-carrion-crows_info.csv",
+            "2021_FA_Amarillo": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_FA_Amarillo__spanish-carrion-crows_info.csv",
+            "2021_FA_Rojo": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_FA_Rojo__spanish-carrion-crows_info.csv",
+            "2021_LL_Amarillo": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_LL_Amarillo__spanish-carrion-crows_info.csv",
+            "2021_LL_Verde": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_LL_Verde__spanish-carrion-crows_info.csv",
+            "2021_N4_Naranja": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_N4_Naranja__spanish-carrion-crows_info.csv",
+            "2021_N4_Verde": "gs://esp-ml-datasets/spanish-carrion-crows/v0.1.0/detections/2021_N4_Verde__spanish-carrion-crows_info.csv",
+        },
+        version="0.1.0",
+        description="Crow biologger audio with Voxaboxen detections",
+        sources="University of Leon",
+        license=(
+            "For ESP internal, non-commerical use only. "
+            "Should talk to collaborators about usage in work to be published."
+        ),
+    )
+
+    _sample_rate_paths: dict[int, str] = {}
+    _originals_path_column = "audio_fp"
+
+    def __init__(
+        self,
+        split: str = "all",
+        output_take_and_give: dict[str, str] | None = None,
+        sample_rate: int | None = 16000,
+        data_root: str | AnyPathT | None = None,
+        backend: BackendType = "pandas",
+        streaming: bool = False,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        split : str
+            Split to load (key in info.split_paths).
+        output_take_and_give : dict[str, str] | None
+            Optional mapping of original → new output keys (filters columns as well).
+        sample_rate : int | None
+            If set, audio is resampled to this rate.
+        data_root : str | AnyPathT | None
+            Optional root directory to prepend to each row['audio_fp'].
+        backend : BackendType, optional
+            The backend to use ("pandas" or "polars"), by default "polars"
+        streaming : bool, optional
+            Whether to use streaming mode, by default False
+        """
+        super().__init__(output_take_and_give, backend=backend, streaming=streaming)
+        self.split = split
+        self._data = None
+        self.annotation_columns = ["Annotation", "Detection Prob", "Class Prob", "RMS Amplitude"]
+        self.unknown_label = "Unknown"
+        self.sample_rate = sample_rate
+
+        self.full_dataset_available_labels = [
+            "focal",
+            "not focal",
+            "crowchicks",
+            "cuckoo",
+        ]  # for Annotation column
+
+        self._load()
+
+        if data_root is None:
+            self.data_root = anypath("gs://")
+        else:
+            self.data_root = anypath(data_root)
+
+    @property
+    def columns(self) -> list[str]:
+        return list(self._data.columns) if self._data is not None else []
+
+    @property
+    def available_splits(self) -> list[str]:
+        return list(self.info.split_paths.keys())
+
+    @property
+    def available_sample_rates(self) -> list[int]:
+        """Return pre-resampled sample rates whose path columns exist in the data."""
+        return [sr for sr, col in self._sample_rate_paths.items() if col in self._data.columns]
+
+    def _load(self) -> None:
+        if self.split not in self.info.split_paths:
+            raise LookupError(
+                f"Invalid split: {self.split}. Expected one of {list(self.info.split_paths.keys())}"
+            )
+        location = self.info.split_paths[self.split]
+        self._data = self._backend_class.from_csv(
+            location,
+            streaming=self._streaming,
+            keep_default_na=False,
+            na_values=[""],
+        )
+
+    def __len__(self) -> int:
+        """Return the number of samples in the dataset.
+
+        Returns
+        -------
+        int
+            Number of samples in the current split.
+
+        Raises
+        ------
+        RuntimeError
+            If no split has been loaded yet.
+        """
+        if self._data is None:
+            raise RuntimeError("No split has been loaded yet. Call _load() first.")
+        if self._streaming:
+            raise NotImplementedError(
+                "Length is not available in streaming mode. Iterate over the dataset instead."
+            )
+        return len(self._data)
+
+    def _process(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Process a single row of the dataset.
+
+        Parameters
+        ----------
+        row : dict[str, Any]
+            A dictionary representing a single row of the dataset.
+
+        Returns
+        -------
+        dict[str, Any]
+            The processed row.
+        """
+        use_presampled = False
+        if self.sample_rate is not None and self.sample_rate in self._sample_rate_paths:
+            path_column = self._sample_rate_paths[self.sample_rate]
+            if path_column in row and row[path_column] is not None and row[path_column] != "":
+                audio_path = anypath(self.data_root) / row[path_column]
+                use_presampled = True
+
+        if not use_presampled:
+            audio_path = anypath(self.data_root) / row[self._originals_path_column]
+
+        audio, sr = read_audio(audio_path)
+        # Should all be mono
+        # audio = audio_stereo_to_mono(audio, mono_method="average").astype(np.float32)
+
+        if not use_presampled and self.sample_rate is not None and sr != self.sample_rate:
+            audio = librosa.resample(
+                y=audio,
+                orig_sr=sr,
+                target_sr=self.sample_rate,
+                scale=True,
+                res_type="kaiser_best",
+            )
+            sr = self.sample_rate
+
+        st = pd.read_csv(StringIO(row["selection_table"]), sep="\t")
+        audio_dur = len(audio) / float(sr)
+        st = st[st["Begin Time (s)"] < audio_dur].copy()
+
+        row["audio"] = audio
+        row["sample_rate"] = sr
+        row["selection_table"] = st
+
+        if self.output_take_and_give:
+            item = {}
+            for old_key, new_key in self.output_take_and_give.items():
+                item[new_key] = row[old_key]
+            return item
+
+        return row
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        """Get a specific sample from the dataset.
+        Parameters
+        ----------
+        idx : int
+            Index of the sample to get.
+
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary containing the audio data, text label, label, and path.
+        """
+        row = self._data[idx]
+        return self._process(row)
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        """Iterate over samples in the dataset.
+
+        Yields
+        -------
+        dict[str, Any]
+            Each sample in the dataset.
+        """
+        for row in self._data:
+            yield self._process(row)
+
+    @classmethod
+    def from_config(
+        cls, dataset_config: DatasetConfig
+    ) -> tuple["SpanishCarrionCrows", dict[str, Any]]:
+        """Create a Dataset instance from a configuration dictionary.
+
+        Parameters
+        ----------
+        dataset_config : DatasetConfig
+            Configuration dictionary containing dataset parameters.
+
+        Returns
+        -------
+        tuple[Dataset, dict[str, Any]]
+            A tuple containing the dataset instance and metadata.
+            If the dataset_config contains transformations, they will be applied
+            and the metadata will be returned as dict, otherwise an empty dict.
+        """
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
+        ds = cls(
+            split=cfg["split"],
+            output_take_and_give=cfg["output_take_and_give"],
+            data_root=cfg["data_root"],
+            sample_rate=cfg["sample_rate"],
+            backend=cfg["backend"],
+            streaming=cfg["streaming"],
+        )
+
+        if dataset_config.transformations:
+            meta = ds.apply_transformations(dataset_config.transformations)
+            return ds, meta
+
+        return ds, {}
+
+    def get_available_labels(self, anno_column: str | None = "Annotation") -> list[str]:
+        """
+        Return all possible caller_id labels
+
+        Returns
+        ---------
+        A list of all the available labels for anno_column
+        """
+        if self.split == "all" and anno_column == "Annotation":
+            return self.full_dataset_available_labels
+        else:
+            available_labels = set()
+            for row in self._data:
+                st = pd.read_csv(StringIO(row["selection_table"]), sep="\t")
+                available_labels.update(st[anno_column].astype(str).tolist())
+            return sorted(available_labels)
+
+    def __str__(self) -> str:
+        base = f"{self.info.name} (v{self.info.version})"
+        return (
+            f"{base}\n"
+            f"Sources: {self.info.sources}\n"
+            f"License: {self.info.license}\n"
+            f"Available splits: {', '.join(self.info.split_paths.keys())}"
+        )

--- a/esp_data/datasets/spanish_carrion_crows_vox.py
+++ b/esp_data/datasets/spanish_carrion_crows_vox.py
@@ -1,0 +1,329 @@
+"""Spanish Carrion Crows adult focal vocalizations dataset"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator
+
+import librosa
+import numpy as np
+
+from esp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
+from esp_data.backends import BackendType
+from esp_data.io import AnyPathT, anypath, audio_stereo_to_mono, read_audio
+
+
+@register_dataset
+class SpanishCarrionCrowsVox(Dataset):
+    """Spanish Carrion Crows individual vocalizations dataset.
+
+    Description
+    -----------
+    Each entry is a single vocalization from a focal Spanish carrion crow,
+    clipped from a longer biologger recording. Audio can be returned as-is
+    (noisy) or denoised via MixIT source separation. Each entry is accompanied
+    by call type, focal individual ID, and synchronized timestamps.
+
+    Vocalization splits are contiguous segments with more than one focal
+    individual, from the same year and territory, making vocalizations.
+
+    See decode-library/runs/Carrion_Crow/matching_biologgers.ipynb for the
+    original of conversational_preprocessed.csv. Thanks to Emmanuel Fernandez.
+
+    Each item contains:
+    - audio: float32 numpy array, clipped to the vocalization window
+    - sample_rate: int
+    - call_type: derived.superpile_nickname
+    - focal_individual: individual wearing the biologger
+    - timestamp_start: UTC timestamp of vocalization start
+    - timestamp_end: UTC timestamp of vocalization end
+    - overlap_window_id: split index
+
+    When denoised=True, also contains:
+    - denoised_success: whether MixIT denoising succeeded for this row
+      Rows where denoising failed will raise ValueError at access time;
+      filter by derived.denoised_focal.success == True before iterating.
+
+    References
+    ----------
+    https://doi.org/10.64898/2026.04.02.715916
+
+    Should talk to collaborators (Daniela Canestrari and Vittorio Baglione)
+    about usage in work to be published.
+
+    """
+
+    info = DatasetInfo(
+        name="spanish_carrion_crows_vox",
+        owner="maddie",
+        split_paths={
+            # TODO: update path once finalized in GCS
+            "all": "gs://esp-ml-datasets/spanish-carrion-crows-vox/conversational_preprocessed.csv",
+        },
+        version="0.1.0",
+        description="Spanish carrion crow adult focal vocalizations with call type and timestamps",
+        sources="University of Leon",
+        license="private",
+    )
+
+    def __init__(
+        self,
+        split: str | int = "all",
+        output_take_and_give: Dict[str, str] | None = None,
+        sample_rate: int | None = 16000,
+        data_root: str | AnyPathT | None = None,
+        backend: BackendType = "polars",
+        streaming: bool = False,
+        denoised: bool = False,
+        fallback_to_noisy: bool = False,
+        padding_sec: float = 0.0,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        split : str | int
+            "all" to load every vocalization, or an overlap_window_id integer to
+            load only vocalizations that co-occur in that context window.
+        output_take_and_give : dict[str, str] | None
+            Optional mapping of original → new output keys (filters columns as well).
+        sample_rate : int | None
+            If set, audio is resampled to this rate. Defaults to 16000.
+        data_root : str | AnyPathT | None
+            Root directory prepended to each audio path in the CSV. Defaults to
+            "gs://" (audio paths in the CSV start with the bucket name).
+        backend : BackendType
+            Backend to use ("pandas" or "polars"). Defaults to "polars".
+        streaming : bool
+            Whether to use streaming mode. Defaults to False.
+        denoised : bool
+            If True, load the denoised (MixIT) audio instead of the noisy focal
+            recording. Defaults to False.
+        fallback_to_noisy : bool
+            Only used when denoised=True. If True, fall back to the noisy audio
+            when denoising failed rather than raising ValueError; the returned
+            item will have denoised_success=False. Defaults to False.
+        padding_sec : float
+            Seconds of context to include before the vocalization start and after
+            its end. Clamped to file boundaries. Defaults to 0.0.
+        """
+        super().__init__(output_take_and_give, backend=backend, streaming=streaming)
+        self.split = split
+        self._data = None
+        self.sample_rate = sample_rate
+        self.denoised = denoised
+        self.fallback_to_noisy = fallback_to_noisy
+        self.padding_sec = padding_sec
+
+        self.data_root = anypath(data_root) if data_root is not None else anypath("gs://")
+
+        self._load()
+
+    @property
+    def columns(self) -> list[str]:
+        return list(self._data.columns)
+
+    @property
+    def available_splits(self) -> list[str]:
+        return [
+            "all",
+            1,
+            2,
+            4,
+            6,
+            10,
+            12,
+            13,
+            14,
+            15,
+            17,
+            19,
+            21,
+            22,
+            24,
+            25,
+            26,
+            27,
+            28,
+            29,
+            30,
+            32,
+            33,
+            34,
+            35,
+            36,
+            37,
+            38,
+            40,
+            41,
+            42,
+            43,
+            44,
+            45,
+            47,
+            48,
+            49,
+            50,
+            51,
+            52,
+            53,
+            54,
+            55,
+            56,
+            57,
+            58,
+            59,
+            60,
+            61,
+            62,
+            63,
+            64,
+            65,
+            66,
+            67,
+            68,
+            69,
+            70,
+            71,
+            72,
+            73,
+            74,
+            75,
+            77,
+            78,
+            83,
+            85,
+            87,
+            88,
+            89,
+            90,
+            91,
+            93,
+            95,
+            96,
+            97,
+            98,
+            99,
+            100,
+            102,
+            103,
+            150,
+            154,
+            155,
+            275,
+            286,
+            287,
+            288,
+        ]
+
+    def _load(self) -> None:
+        location = self.info.split_paths["all"]
+        self._data = self._backend_class.from_csv(
+            location,
+            streaming=self._streaming,
+            keep_default_na=False,
+            na_values=[""],
+        )
+        if self.split != "all":
+            self._data = self._data.filter_isin("overlap_window_id", [float(self.split)])
+            if not self._streaming and len(self._data) == 0:
+                raise LookupError(
+                    f"No rows found for overlap_window_id={self.split}. "
+                    "Pass split='all' or a valid overlap_window_id value."
+                )
+
+    def __len__(self) -> int:
+        if self._data is None:
+            raise RuntimeError("No split has been loaded yet. Call _load() first.")
+        if self._streaming:
+            raise NotImplementedError(
+                "Length is not available in streaming mode. Iterate over the dataset instead."
+            )
+        return len(self._data)
+
+    def _process(self, row: dict[str, Any]) -> dict[str, Any]:
+        start_sec = max(0.0, float(row["derived.centered_focal.long.start_sec"]) - self.padding_sec)
+        end_sec = float(row["derived.centered_focal.long.end_sec"]) + self.padding_sec
+
+        if self.denoised:
+            denoised_success = row["derived.denoised_focal.success"]
+            if isinstance(denoised_success, str):
+                denoised_success = denoised_success == "True"
+            fp = row.get("derived.denoised_focal.fp") or ""
+            if denoised_success and fp:
+                audio_path = self.data_root / fp
+            elif self.fallback_to_noisy:
+                audio_path = self.data_root / row["derived.centered_focal.long.fp"]
+            else:
+                raise ValueError(
+                    "Denoised audio not available for this row "
+                    f"(derived.denoised_focal.success={row['derived.denoised_focal.success']}). "
+                    "Set fallback_to_noisy=True to use noisy audio when denoising failed, "
+                    "or filter rows by derived.denoised_focal.success == True before iterating."
+                )
+        else:
+            audio_path = self.data_root / row["derived.centered_focal.long.fp"]
+
+        audio, sample_rate = read_audio(audio_path, start_time=start_sec, end_time=end_sec)
+        audio = audio_stereo_to_mono(audio, mono_method="keep_first").astype(np.float32)
+
+        if self.sample_rate is not None and sample_rate != self.sample_rate:
+            audio = librosa.resample(
+                y=audio,
+                orig_sr=sample_rate,
+                target_sr=self.sample_rate,
+                scale=True,
+                res_type="kaiser_best",
+            )
+            sample_rate = self.sample_rate
+
+        out: dict[str, Any] = {
+            "audio": audio,
+            "sample_rate": sample_rate,
+            "call_type": row["derived.superpile_nickname"],
+            "focal_individual": row["focal_individual"],
+            "timestamp_start": row["start_timestamp_flex"],
+            "timestamp_end": row["end_timestamp_flex"],
+            "overlap_window_id": int(row["overlap_window_id"]),
+        }
+
+        if self.denoised:
+            out["denoised_success"] = denoised_success
+
+        if self.output_take_and_give:
+            return {new_key: out[old_key] for old_key, new_key in self.output_take_and_give.items()}
+
+        return out
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        row = self._data[idx]
+        return self._process(row)
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        for row in self._data:
+            yield self._process(row)
+
+    @classmethod
+    def from_config(
+        cls, dataset_config: DatasetConfig
+    ) -> tuple["SpanishCarrionCrowsVox", dict[str, Any]]:
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
+        ds = cls(
+            split=cfg["split"],
+            output_take_and_give=cfg["output_take_and_give"],
+            data_root=cfg["data_root"],
+            sample_rate=cfg["sample_rate"],
+            backend=cfg["backend"],
+            streaming=cfg["streaming"],
+        )
+        if dataset_config.transformations:
+            meta = ds.apply_transformations(dataset_config.transformations)
+            return ds, meta
+        return ds, {}
+
+    def __str__(self) -> str:
+        base = f"{self.info.name} (v{self.info.version})"
+        return (
+            f"{base}\n"
+            f"Sources: {self.info.sources}\n"
+            f"License: {self.info.license}\n"
+            f"Available splits: {', '.join(self.info.split_paths.keys())}"
+        )

--- a/esp_data/datasets/spanish_carrion_crows_vox.py
+++ b/esp_data/datasets/spanish_carrion_crows_vox.py
@@ -2,14 +2,63 @@
 
 from __future__ import annotations
 
+import ast
+import json
 from typing import Any, Dict, Iterator
 
 import librosa
 import numpy as np
 
-from esp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
+from esp_data import Dataset, DatasetConfig, DatasetInfo, register_config, register_dataset
 from esp_data.backends import BackendType
 from esp_data.io import AnyPathT, anypath, audio_stereo_to_mono, read_audio
+
+
+@register_config
+class SpanishCarrionCrowsVoxConfig(DatasetConfig):
+    """Configuration for the SpanishCarrionCrowsVox dataset.
+
+    Parameters
+    ----------
+    dataset_name : str
+        The name of the dataset. Must be "spanish-carrion-crows-vox".
+    split : str | int
+        The split to load: "all" or one of SpanishCarrionCrowsVox.available_splits.
+    output_take_and_give : dict[str, str] | None
+        A dictionary mapping the original column names to the new column names.
+        It acts as a filter as well.
+    sample_rate : int | None
+        The sample rate to which audio files should be resampled.
+    data_root : str | AnyPathT | None
+        The root directory for the dataset. This is optionally appended to the
+        path item of a sample in the dataset.
+    backend : BackendType
+        The backend to use ("pandas" or "polars"), by default "polars"
+    streaming : bool
+        Whether to use streaming mode, by default False
+    denoised : bool
+        If True, load the denoised (MixIT) audio instead of the noisy focal
+        recording. Defaults to False.
+    fallback_to_noisy : bool
+        Only used when denoised=True. If True, fall back to the noisy audio
+        when denoising failed rather than raising ValueError; the returned
+        item will have denoised_success=False. Defaults to False.
+    padding_sec : float
+        Seconds of context to include before the vocalization start and after
+        its end. Clamped to file boundaries. Defaults to 0.0.
+    """
+
+    dataset_name: str = "spanish-carrion-crows-vox"
+    split: str | int = "all"
+    version: str | None = None
+    output_take_and_give: dict[str, str] | None = None
+    sample_rate: int | None = 16000
+    data_root: str | AnyPathT | None = None
+    backend: BackendType = "polars"
+    streaming: bool = False
+    denoised: bool = False
+    fallback_to_noisy: bool = False
+    padding_sec: float = 0.0
 
 
 @register_dataset
@@ -36,7 +85,63 @@ class SpanishCarrionCrowsVox(Dataset):
     - focal_individual: individual wearing the biologger
     - timestamp_start: UTC timestamp of vocalization start
     - timestamp_end: UTC timestamp of vocalization end
+    - concurrent_behavior_category: dict[str, str]
+      - each key is an individual, value gives behavior of that individual at timestamp_start
+      - possible values:
+        - visit_{unknown, repeated, alternated}:
+          - Video: whether the bird is at the nest or not
+          - Audio/Accelerometer: not incorporated
+          - repeated: visit before this one was the same individual
+          - alternated: visit before this one was a different individual
+          - unknown: we do not know who made the previous visit
+        - flying_arriving_{short: < 10 s, long: > 10 s}
+        - flying_leaving_{short, long}
+        - flying_other_{short,long}
+          - Video: whether the activity after/before this flight was a nest visit
+          - Audio: bird is flying
+          - Accelerometer: not incorporated
+          - arriving/leaving: bird is flying to/from the nest, respectively
+          - other: bird is flying, but not to or from the nest
+        - flying_unknown
+          - Video: unavailable, so we do not know if flight is to/from the nest
+          - Audio: bird is flying
+          - Accelerometer: not incorporated
+          - bird is flying, but we do not know where
+        - high_activity / low_activity:
+          - Video: bird is not at the nest
+          - Audio: bird is not flying
+          - Accelerometer: high ODBA / low ODBA
+          - interpretation: individual is in high / low activity state,
+                            away from nest and not flying
+        - not_flying:
+          - Video: unavailable, so we do not know whether bird is at nest or not
+          - Audio: bird is not flying
+          - Accelerometer: not incorporated
+          - interpretation: bird is not flying, but we do not know where they
+                            are nor whether they are in high/low activity state
+        - unknown: nothing is known about this bird's behavior
+    - concurrent_is_visit: dict[str, bool | None]
+      - each key is an individual
+      - value gives whether the individual is at the nest or not, at the time of the vocalization
+      - if None, the value is unknown (e.g., we didn't have annotated
+        nest camera video, at that timepoint)
+    - concurrent_is_flying: dict[str, bool | None]
+      - each key is an individual
+      - value gives whether the individual is flying or not, at the time of the vocalization
+      - if None, the value is unknown (e.g., we didn't have biologger
+        for that individual, at that timepoint)
+    - has_matching_vox_on_logger: dict[str, bool]
+      - each key is an individual
+      - True if this vocalization was detected on individual's biologger
+      - always True if key == focal_individual
+      - may be True or False, if key != focal_individual. if True, means this vocalization
+        was non-focal on individual's biologger
+    - sec_until_next_E4: dict[str, (float, float) | None]
+      - each key is an individual
+      - first value gives time to next focal vocalization labeled E4, where caller = individual
+      - second value gives number of unobserved seconds between current vocalization and next E4
     - overlap_window_id: split index
+    - overlap_individuals: individuals which have biologgers defined in this split index
 
     When denoised=True, also contains:
     - denoised_success: whether MixIT denoising succeeded for this row
@@ -57,7 +162,7 @@ class SpanishCarrionCrowsVox(Dataset):
         owner="maddie",
         split_paths={
             # TODO: update path once finalized in GCS
-            "all": "gs://esp-ml-datasets/spanish-carrion-crows-vox/conversational_preprocessed.csv",
+            "all": "gs://esp-ml-datasets/spanish-carrion-crows-vox/conversational_preprocessed_with_behavior.csv",
         },
         version="0.1.0",
         description="Spanish carrion crow adult focal vocalizations with call type and timestamps",
@@ -119,7 +224,7 @@ class SpanishCarrionCrowsVox(Dataset):
 
     @property
     def columns(self) -> list[str]:
-        return list(self._data.columns)
+        return self._data.columns
 
     @property
     def available_splits(self) -> list[str]:
@@ -219,6 +324,9 @@ class SpanishCarrionCrowsVox(Dataset):
         self._data = self._backend_class.from_csv(
             location,
             streaming=self._streaming,
+            sep="\t",
+            separator="\t",
+            # TODO I don't know if we want this?
             keep_default_na=False,
             na_values=[""],
         )
@@ -245,8 +353,9 @@ class SpanishCarrionCrowsVox(Dataset):
 
         if self.denoised:
             denoised_success = row["derived.denoised_focal.success"]
-            if isinstance(denoised_success, str):
-                denoised_success = denoised_success == "True"
+            # if isinstance(denoised_success, str):
+            #     # TODO check underlying dataframe
+            #     denoised_success = denoised_success == "True"
             fp = row.get("derived.denoised_focal.fp") or ""
             if denoised_success and fp:
                 audio_path = self.data_root / fp
@@ -282,7 +391,13 @@ class SpanishCarrionCrowsVox(Dataset):
             "focal_individual": row["focal_individual"],
             "timestamp_start": row["start_timestamp_flex"],
             "timestamp_end": row["end_timestamp_flex"],
+            "concurrent_behavior_category": json.loads(row["concurrent_behavior_summary"]),
+            "concurrent_is_visit": json.loads(row["concurrent_is_visit"]),
+            "concurrent_is_flying": json.loads(row["concurrent_is_flying"]),
+            "has_matching_vox_on_logger": json.loads(row["matching_loggers"]),
+            "sec_until_next_E4": json.loads(row["time_until_next_E4"]),
             "overlap_window_id": int(row["overlap_window_id"]),
+            "overlap_individuals": ast.literal_eval(row["overlap_window_individuals"]),
         }
 
         if self.denoised:

--- a/esp_data/datasets/spanish_carrion_crows_vox.py
+++ b/esp_data/datasets/spanish_carrion_crows_vox.py
@@ -163,6 +163,8 @@ class SpanishCarrionCrowsVox(Dataset):
         split_paths={
             # TODO: update path once finalized in GCS
             "all": "gs://esp-ml-datasets/spanish-carrion-crows-vox/conversational_preprocessed_with_behavior.csv",
+            # ** Change for single biologger -->
+            # "all": "gs://esp-ml-datasets/spanish-carrion-crows-vox/single_preprocessed_with_behavior.csv"
         },
         version="0.1.0",
         description="Spanish carrion crow adult focal vocalizations with call type and timestamps",
@@ -228,6 +230,8 @@ class SpanishCarrionCrowsVox(Dataset):
 
     @property
     def available_splits(self) -> list[str]:
+        # ** Change for single biologger (should match overlap_window_id values in new csv) -->
+        # return ["all"] + list(range(1, 433))
         return [
             "all",
             1,
@@ -396,6 +400,10 @@ class SpanishCarrionCrowsVox(Dataset):
             "concurrent_is_flying": json.loads(row["concurrent_is_flying"]),
             "has_matching_vox_on_logger": json.loads(row["matching_loggers"]),
             "sec_until_next_E4": json.loads(row["time_until_next_E4"]),
+            # TODO have not added to tests
+            "feat.dominant_frequency": float(row["derived.dominant_frequency"]),
+            "feat.spectral_entropy": float(row["derived.spectral_entropy"]),
+            "feat.duration": float(row["derived.duration"]),
             "overlap_window_id": int(row["overlap_window_id"]),
             "overlap_individuals": ast.literal_eval(row["overlap_window_individuals"]),
         }

--- a/tests/test_spanish_carrion_crows.py
+++ b/tests/test_spanish_carrion_crows.py
@@ -1,0 +1,197 @@
+"""
+Unit tests for SpanishCarrionCrows dataset.
+
+Run with:
+    pytest -q test_spanish_carrion_crows.py
+"""
+
+from __future__ import annotations
+
+import random
+from typing import List
+
+import numpy as np
+import pandas as pd
+import pytest
+import hashlib
+
+from esp_data.datasets import SpanishCarrionCrows
+
+
+# # --- Dataset snapshot ---
+
+# # Code to generate snapshot:
+# from esp_data.datasets import SpanishCarrionCrows
+# ds = SpanishCarrionCrows(split="all", sample_rate=16000, backend="pandas")
+
+# print("len(ds) =", len(ds))
+
+# audio0 = ds[0]["audio"]
+# print("dtype:", audio0.dtype, "shape:", audio0.shape)
+
+# h = hashlib.sha256(audio0.tobytes()).hexdigest()
+# print("sha256:", h)
+
+# csv_bytes = (
+#         ds._data.unwrap.sort_index(axis=0)
+#         .sort_index(axis=1)
+#         .to_csv(index=True)
+#         .encode("utf-8")
+#     )
+# h = hashlib.sha256(csv_bytes).hexdigest()
+
+# print("annotations sha256:", h)
+
+# quit()
+# # # # #
+
+EXPECTED_LEN_ALL = 954  #
+EXPECTED_FIRST_ITEM_AUDIO_SHA256 = (
+    "1313ead69001c6f7bcd52672e90d51f3f138c73180afca19a7013d562b1877f9"
+)
+ANNOTATIONS_SHA256 = "ec39cccd782f6478dc22cc353fabcefc2a7efbb99e9734d5814b0e0c1ed3ccb2"
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def ds() -> SpanishCarrionCrows:
+    """Load SpanishCarrionCrows dataset for testing."""
+    return SpanishCarrionCrows(split="all", sample_rate=16000, backend="pandas")
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ds_polars() -> SpanishCarrionCrows:
+    """Load SpanishCarrionCrows dataset for testing."""
+    return SpanishCarrionCrows(split="all", sample_rate=16000, backend="polars")
+
+
+@pytest.fixture(scope="module")
+def sample_indices(ds_polars: SpanishCarrionCrows) -> List[int]:
+    """Deterministically choose up to 5 random indices for quick spot checks."""
+    n = len(ds_polars)
+    rng = random.Random(23)
+    return [rng.randrange(n) for _ in range(min(5, n))]
+
+
+def test_ds_not_empty(ds: SpanishCarrionCrows):
+    """Dataset should have at least one example."""
+    assert len(ds) > 0, "Dataset appears empty"
+
+def test_get_available_labels(ds: SpanishCarrionCrows):
+    """Test get_available_labels for caller ID column."""
+    labels = ds.get_available_labels(anno_column="Annotation")
+    assert isinstance(labels, list), "get_available_labels should return a list"
+    assert len(labels) > 0, "Should have at least one caller ID"
+    # Check that all labels can be converted to strings
+    for label in labels:
+        assert isinstance(label, str), f"Caller label for {label} should be string"
+
+def test_check_audio(ds_polars: SpanishCarrionCrows, sample_indices: List[int]):
+    """Basic audio integrity checks on a few random items."""
+    for idx in sample_indices:
+        item = ds_polars[idx]
+        assert "audio" in item, f"[{idx}] missing 'audio' key"
+        audio = item["audio"]
+
+        assert isinstance(audio, np.ndarray), f"[{idx}] audio is not a numpy array"
+        assert (
+            audio.dtype == np.float64
+        ), f"[{idx}] audio dtype is {audio.dtype}, expected float64"
+        assert audio.size >= 10, f"[{idx}] audio too short (size={audio.size})"
+        assert not np.any(np.isnan(audio)), f"[{idx}] audio contains NaN values"
+        assert not np.all(audio == 0), f"[{idx}] audio is all zeros"
+
+
+def test_available_splits(ds: SpanishCarrionCrows) -> None:
+    """Test if available_splits returns correct split names."""
+    # Available splits should contain these
+    expected_splits = ["all"]
+    assert all(split in ds.available_splits for split in expected_splits)
+
+
+def test_reference_item_stability(ds: SpanishCarrionCrows):
+    """
+    Check that a canonical item (index 0) is bitwise-stable.
+
+    We hash the raw float64 audio buffer. This catches:
+    - sample rate changes (resampling -> different samples)
+    - channel handling changes (stereo->mono logic changed)
+    - dtype changes
+    - ordering changes in the split (if a different recording moved to idx 0)
+
+    If this fails for a legitimate/intentional reason, recompute the hash below
+    and update EXPECTED_FIRST_ITEM_AUDIO_SHA256.
+
+    We do the same for the annotations csv.
+    """
+    # choose deterministic index
+    idx = 0
+    item = ds[idx]
+
+    # audio presence/type checks (defensive, so the hash failure message is clearer)
+    assert "audio" in item, "[0] missing 'audio' key"
+    audio = item["audio"]
+    assert isinstance(audio, np.ndarray), "[0] audio is not a numpy array"
+    assert (
+        audio.dtype == np.float64
+    ), f"[0] audio dtype is {audio.dtype}, expected float64"
+
+    # compute sha256 over raw bytes of the float64 array
+    h = hashlib.sha256(audio.tobytes()).hexdigest()
+
+    assert h == EXPECTED_FIRST_ITEM_AUDIO_SHA256, (
+        "First item's audio hash changed.\n"
+        f"Got    {h}\n"
+        f"Expect {EXPECTED_FIRST_ITEM_AUDIO_SHA256}\n\n"
+        "If this is an intentional dataset/content update, "
+        "replace EXPECTED_FIRST_ITEM_AUDIO_SHA256 with the new hash."
+    )
+
+    # compute sha256 over raw bytes of the float64 array of annotations
+    csv_bytes = (
+        ds._data.unwrap.sort_index(axis=0)
+        .sort_index(axis=1)
+        .to_csv(index=True)
+        .encode("utf-8")
+    )
+    h = hashlib.sha256(csv_bytes).hexdigest()
+
+    assert h == ANNOTATIONS_SHA256, (
+        "Annotation's hash changed.\n"
+        f"Got    {h}\n"
+        f"Expect {ANNOTATIONS_SHA256}\n\n"
+        "If this is an intentional dataset/content update, "
+        "replace EXPECTED_FIRST_ITEM_AUDIO_SHA256 with the new hash."
+    )
+
+
+def test_check_selection_table(ds: SpanishCarrionCrows, sample_indices: List[int]):
+    """Selection table should be a DataFrame with required columns and sane times."""
+    required = {
+        "Begin Time (s)",
+        "End Time (s)",
+        "Annotation",
+        "Detection Prob",
+        "Class Prob",
+        "RMS Amplitude"
+    }
+
+    for idx in sample_indices:
+        item = ds[idx]
+        assert "selection_table" in item, f"[{idx}] missing 'selection_table' key"
+        st = item["selection_table"]
+
+        assert isinstance(
+            st, pd.DataFrame
+        ), f"[{idx}] selection_table is not a DataFrame"
+        missing = required - set(st.columns)
+        assert (
+            not missing
+        ), f"[{idx}] selection_table missing columns: {sorted(missing)}"
+
+        if len(st) > 0:
+            assert not (
+                st["Begin Time (s)"] < 0
+            ).any(), f"[{idx}] negative begin times present"
+            durs = st["End Time (s)"] - st["Begin Time (s)"]
+            assert not durs.min() <= 0, f"[{idx}] events of dur <= 0"

--- a/tests/test_spanish_carrion_crows.py
+++ b/tests/test_spanish_carrion_crows.py
@@ -45,11 +45,11 @@ from esp_data.datasets import SpanishCarrionCrows
 # quit()
 # # # # #
 
-EXPECTED_LEN_ALL = 954  #
+EXPECTED_LEN_ALL = 953  #
 EXPECTED_FIRST_ITEM_AUDIO_SHA256 = (
     "1313ead69001c6f7bcd52672e90d51f3f138c73180afca19a7013d562b1877f9"
 )
-ANNOTATIONS_SHA256 = "ec39cccd782f6478dc22cc353fabcefc2a7efbb99e9734d5814b0e0c1ed3ccb2"
+ANNOTATIONS_SHA256 = "eb8f7f74193a0eedc611c2ae188583a8ab107d57afebc77db0697597ac8ae81c"
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_spanish_carrion_crows.py
+++ b/tests/test_spanish_carrion_crows.py
@@ -22,47 +22,36 @@ from esp_data.datasets import SpanishCarrionCrows
 
 # # Code to generate snapshot:
 # from esp_data.datasets import SpanishCarrionCrows
-# ds = SpanishCarrionCrows(split="all", sample_rate=16000, backend="pandas")
-
+# import hashlib
+# ds = SpanishCarrionCrows(split="all", sample_rate=16000, backend="polars")
 # print("len(ds) =", len(ds))
-
 # audio0 = ds[0]["audio"]
 # print("dtype:", audio0.dtype, "shape:", audio0.shape)
-
 # h = hashlib.sha256(audio0.tobytes()).hexdigest()
 # print("sha256:", h)
-
-# csv_bytes = (
-#         ds._data.unwrap.sort_index(axis=0)
-#         .sort_index(axis=1)
-#         .to_csv(index=True)
-#         .encode("utf-8")
-#     )
+# df = ds._data.unwrap
+# csv_bytes = df.sort(df.columns).write_csv().encode("utf-8")
 # h = hashlib.sha256(csv_bytes).hexdigest()
-
 # print("annotations sha256:", h)
-
 # quit()
 # # # # #
 
 EXPECTED_LEN_ALL = 953  #
 EXPECTED_FIRST_ITEM_AUDIO_SHA256 = (
-    "1313ead69001c6f7bcd52672e90d51f3f138c73180afca19a7013d562b1877f9"
+    "08b28fcc371250e424e2de0ac613e56d296659e0f3ccd55365e61a2629e988b7"
 )
-ANNOTATIONS_SHA256 = "eb8f7f74193a0eedc611c2ae188583a8ab107d57afebc77db0697597ac8ae81c"
+ANNOTATIONS_SHA256 = "ed692970908e8413ef9003130af29d083e4ebfa3d217315edad9d665aaf07009"
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture(scope="module")
-def ds() -> SpanishCarrionCrows:
-    """Load SpanishCarrionCrows dataset for testing."""
-    return SpanishCarrionCrows(split="all", sample_rate=16000, backend="pandas")
-
 
 @pytest.fixture(scope="module", autouse=True)
 def ds_polars() -> SpanishCarrionCrows:
     """Load SpanishCarrionCrows dataset for testing."""
-    return SpanishCarrionCrows(split="all", sample_rate=16000, backend="polars")
+    return SpanishCarrionCrows(split="all", sample_rate=16000, backend="polars", streaming=False)
+
+@pytest.fixture(scope="module", autouse=True)
+def ds_streaming() -> SpanishCarrionCrows:
+    """Load SpanishCarrionCrows dataset for testing."""
+    return SpanishCarrionCrows(split="all", sample_rate=16000, backend="polars", streaming=True)
 
 
 @pytest.fixture(scope="module")
@@ -73,13 +62,13 @@ def sample_indices(ds_polars: SpanishCarrionCrows) -> List[int]:
     return [rng.randrange(n) for _ in range(min(5, n))]
 
 
-def test_ds_not_empty(ds: SpanishCarrionCrows):
+def test_ds_not_empty(ds_polars: SpanishCarrionCrows):
     """Dataset should have at least one example."""
-    assert len(ds) > 0, "Dataset appears empty"
+    assert len(ds_polars) > 0, "Dataset appears empty"
 
-def test_get_available_labels(ds: SpanishCarrionCrows):
+def test_get_available_labels(ds_streaming: SpanishCarrionCrows):
     """Test get_available_labels for caller ID column."""
-    labels = ds.get_available_labels(anno_column="Annotation")
+    labels = ds_streaming.get_available_labels(anno_column="Annotation")
     assert isinstance(labels, list), "get_available_labels should return a list"
     assert len(labels) > 0, "Should have at least one caller ID"
     # Check that all labels can be converted to strings
@@ -95,25 +84,25 @@ def test_check_audio(ds_polars: SpanishCarrionCrows, sample_indices: List[int]):
 
         assert isinstance(audio, np.ndarray), f"[{idx}] audio is not a numpy array"
         assert (
-            audio.dtype == np.float64
-        ), f"[{idx}] audio dtype is {audio.dtype}, expected float64"
+            audio.dtype == np.float32
+        ), f"[{idx}] audio dtype is {audio.dtype}, expected float32"
         assert audio.size >= 10, f"[{idx}] audio too short (size={audio.size})"
         assert not np.any(np.isnan(audio)), f"[{idx}] audio contains NaN values"
         assert not np.all(audio == 0), f"[{idx}] audio is all zeros"
+        assert len(audio.shape) == 1, f"[{idx}] is not 1D, expected (N_samples,) but got shape={audio.shape}"
 
-
-def test_available_splits(ds: SpanishCarrionCrows) -> None:
+def test_available_splits(ds_streaming: SpanishCarrionCrows) -> None:
     """Test if available_splits returns correct split names."""
     # Available splits should contain these
     expected_splits = ["all"]
-    assert all(split in ds.available_splits for split in expected_splits)
+    assert all(split in ds_streaming.available_splits for split in expected_splits)
 
 
-def test_reference_item_stability(ds: SpanishCarrionCrows):
+def test_reference_item_stability(ds_polars: SpanishCarrionCrows):
     """
     Check that a canonical item (index 0) is bitwise-stable.
 
-    We hash the raw float64 audio buffer. This catches:
+    We hash the raw float32 audio buffer. This catches:
     - sample rate changes (resampling -> different samples)
     - channel handling changes (stereo->mono logic changed)
     - dtype changes
@@ -126,17 +115,17 @@ def test_reference_item_stability(ds: SpanishCarrionCrows):
     """
     # choose deterministic index
     idx = 0
-    item = ds[idx]
+    item = ds_polars[idx]
 
     # audio presence/type checks (defensive, so the hash failure message is clearer)
     assert "audio" in item, "[0] missing 'audio' key"
     audio = item["audio"]
     assert isinstance(audio, np.ndarray), "[0] audio is not a numpy array"
     assert (
-        audio.dtype == np.float64
-    ), f"[0] audio dtype is {audio.dtype}, expected float64"
+        audio.dtype == np.float32
+    ), f"[0] audio dtype is {audio.dtype}, expected float32"
 
-    # compute sha256 over raw bytes of the float64 array
+    # compute sha256 over raw bytes of the float32 array
     h = hashlib.sha256(audio.tobytes()).hexdigest()
 
     assert h == EXPECTED_FIRST_ITEM_AUDIO_SHA256, (
@@ -147,13 +136,9 @@ def test_reference_item_stability(ds: SpanishCarrionCrows):
         "replace EXPECTED_FIRST_ITEM_AUDIO_SHA256 with the new hash."
     )
 
-    # compute sha256 over raw bytes of the float64 array of annotations
-    csv_bytes = (
-        ds._data.unwrap.sort_index(axis=0)
-        .sort_index(axis=1)
-        .to_csv(index=True)
-        .encode("utf-8")
-    )
+    # compute sha256 over raw bytes of the float32 array of annotations
+    df = ds_polars._data.unwrap
+    csv_bytes = df.sort(df.columns).write_csv().encode("utf-8")
     h = hashlib.sha256(csv_bytes).hexdigest()
 
     assert h == ANNOTATIONS_SHA256, (
@@ -165,7 +150,7 @@ def test_reference_item_stability(ds: SpanishCarrionCrows):
     )
 
 
-def test_check_selection_table(ds: SpanishCarrionCrows, sample_indices: List[int]):
+def test_check_selection_table(ds_polars: SpanishCarrionCrows, sample_indices: List[int]):
     """Selection table should be a DataFrame with required columns and sane times."""
     required = {
         "Begin Time (s)",
@@ -177,7 +162,7 @@ def test_check_selection_table(ds: SpanishCarrionCrows, sample_indices: List[int
     }
 
     for idx in sample_indices:
-        item = ds[idx]
+        item = ds_polars[idx]
         assert "selection_table" in item, f"[{idx}] missing 'selection_table' key"
         st = item["selection_table"]
 

--- a/tests/test_spanish_carrion_crows_vox.py
+++ b/tests/test_spanish_carrion_crows_vox.py
@@ -1,0 +1,219 @@
+"""
+Unit tests for SpanishCarrionCrowsVox dataset.
+
+Run with:
+    pytest -q test_spanish_carrion_crows_vox.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from typing import List
+
+import numpy as np
+import pytest
+
+from esp_data.datasets import SpanishCarrionCrowsVox
+
+
+# --- Dataset snapshot ---
+#
+# Code to generate snapshot
+#
+# import hashlib
+# from esp_data.datasets import SpanishCarrionCrowsVox
+
+# ds = SpanishCarrionCrowsVox(split="all", sample_rate=16000, backend="pandas")
+
+# print("len(ds) =", len(ds))
+# # len(ds) = 54288
+
+# item0 = ds[0]
+# audio0 = item0["audio"]
+# print("dtype:", audio0.dtype, "shape:", audio0.shape)
+# h = hashlib.sha256(audio0.tobytes()).hexdigest()
+# print("audio sha256:", h)
+# # audio sha256: c5a94be195ea9c2d89a927a94e09c054c28a10886e04a972565240abb63aff2d
+
+# csv_bytes = (
+#     ds._data.unwrap.sort_index(axis=0)
+#     .sort_index(axis=1)
+#     .to_csv(index=True)
+#     .encode("utf-8")
+# )
+# h = hashlib.sha256(csv_bytes).hexdigest()
+# print("csv sha256:", h)
+# # csv sha256: 9ba2ccd223dc541f6cc4183b5181dbbcf68db09b03fe563c5765591a932e6dcb
+
+# quit()
+# ---------------------------------------------------------------------------
+
+EXPECTED_LEN_ALL = 54288
+EXPECTED_FIRST_ITEM_AUDIO_SHA256 = "c5a94be195ea9c2d89a927a94e09c054c28a10886e04a972565240abb63aff2d"
+EXPECTED_CSV_SHA256 = "9ba2ccd223dc541f6cc4183b5181dbbcf68db09b03fe563c5765591a932e6dcb"
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def ds() -> SpanishCarrionCrowsVox:
+    return SpanishCarrionCrowsVox(split="all", sample_rate=16000)
+
+
+@pytest.fixture(scope="module")
+def ds_pandas() -> SpanishCarrionCrowsVox:
+    return SpanishCarrionCrowsVox(split="all", sample_rate=16000, backend="pandas")
+
+
+@pytest.fixture(scope="module")
+def ds_denoised() -> SpanishCarrionCrowsVox:
+    return SpanishCarrionCrowsVox(split="all", sample_rate=16000, denoised=True)
+
+
+@pytest.fixture(scope="module")
+def ds_window(ds: SpanishCarrionCrowsVox) -> SpanishCarrionCrowsVox:
+    window_id = next(s for s in ds.available_splits if s != "all")
+    return SpanishCarrionCrowsVox(split=window_id, sample_rate=16000)
+
+
+@pytest.fixture(scope="module")
+def sample_indices(ds: SpanishCarrionCrowsVox) -> List[int]:
+    n = len(ds)
+    rng = random.Random(42)
+    return [rng.randrange(n) for _ in range(min(5, n))]
+
+
+def test_ds_not_empty(ds: SpanishCarrionCrowsVox):
+    assert len(ds) > 0, "Dataset appears empty"
+
+
+def test_window_split(ds: SpanishCarrionCrowsVox, ds_window: SpanishCarrionCrowsVox):
+    """Filtering by overlap_window_id should return a strict subset."""
+    assert 0 < len(ds_window) <= len(ds)
+    for item in ds_window:
+        assert item["overlap_window_id"] == ds_window.split
+
+
+def test_invalid_window_split_raises():
+    with pytest.raises(LookupError, match="overlap_window_id"):
+        SpanishCarrionCrowsVox(split=999999999)
+
+
+def test_check_audio(ds: SpanishCarrionCrowsVox, sample_indices: List[int]):
+    for idx in sample_indices:
+        item = ds[idx]
+        assert "audio" in item, f"[{idx}] missing 'audio' key"
+        audio = item["audio"]
+
+        assert isinstance(audio, np.ndarray), f"[{idx}] audio is not a numpy array"
+        assert audio.dtype == np.float32, f"[{idx}] audio dtype is {audio.dtype}, expected float32"
+        assert audio.size >= 10, f"[{idx}] audio too short (size={audio.size})"
+        assert not np.any(np.isnan(audio)), f"[{idx}] audio contains NaN values"
+        assert not np.all(audio == 0), f"[{idx}] audio is all zeros"
+
+
+def test_metadata_fields(ds: SpanishCarrionCrowsVox, sample_indices: List[int]):
+    required = {"audio", "sample_rate", "call_type", "focal_individual", "timestamp_start", "timestamp_end", "overlap_window_id"}
+    for idx in sample_indices:
+        item = ds[idx]
+        missing = required - set(item.keys())
+        assert not missing, f"[{idx}] item missing keys: {sorted(missing)}"
+
+        assert isinstance(item["sample_rate"], int), f"[{idx}] sample_rate should be int"
+        assert item["sample_rate"] == 16000, f"[{idx}] expected sample_rate=16000"
+        assert isinstance(item["call_type"], str), f"[{idx}] call_type should be str"
+        assert isinstance(item["focal_individual"], str), f"[{idx}] focal_individual should be str"
+
+
+def test_padding_extends_audio(ds: SpanishCarrionCrowsVox, sample_indices: List[int]):
+    ds_padded = SpanishCarrionCrowsVox(split="all", sample_rate=16000, padding_sec=0.5)
+    idx = sample_indices[0]
+    unpadded_len = ds[idx]["audio"].shape[0]
+    padded_len = ds_padded[idx]["audio"].shape[0]
+    assert padded_len >= unpadded_len, (
+        f"[{idx}] padded audio ({padded_len}) should be >= unpadded ({unpadded_len})"
+    )
+
+
+def test_denoised_audio_present(ds: SpanishCarrionCrowsVox, ds_denoised: SpanishCarrionCrowsVox):
+    success_idx = next(
+        (i for i, row in enumerate(ds._data) if row.get("derived.denoised_focal.success") is True),
+        None,
+    )
+    if success_idx is None:
+        pytest.skip("No successfully denoised rows found")
+    item = ds_denoised[success_idx]
+    assert "denoised_success" in item, "denoised_success key missing in denoised mode"
+    assert item["denoised_success"] is True
+    audio = item["audio"]
+    assert isinstance(audio, np.ndarray)
+    assert audio.dtype == np.float32
+    assert audio.size >= 10
+    assert not np.any(np.isnan(audio))
+
+
+def test_denoised_fallback_to_noisy(ds: SpanishCarrionCrowsVox):
+    """With fallback_to_noisy=True, failed rows should return audio with denoised_success=False."""
+    ds_fallback = SpanishCarrionCrowsVox(split="all", sample_rate=16000, denoised=True, fallback_to_noisy=True)
+    for i, row in enumerate(ds_fallback._data):
+        success = row.get("derived.denoised_focal.success", "True")
+        if isinstance(success, str):
+            success = success == "True"
+        if not success:
+            item = ds_fallback[i]
+            assert item["denoised_success"] is False
+            assert isinstance(item["audio"], np.ndarray)
+            assert item["audio"].dtype == np.float32
+            return
+    pytest.skip("No failed-denoising rows found in split")
+
+
+def test_denoised_failed_row_raises(ds: SpanishCarrionCrowsVox):
+    """Accessing a row with no denoised file in denoised mode should raise ValueError."""
+    ds_den = SpanishCarrionCrowsVox(split="all", sample_rate=16000, denoised=True)
+    # Find first row where denoised_focal.success is False by inspecting the raw data
+    for i, row in enumerate(ds_den._data):
+        success = row.get("derived.denoised_focal.success", "True")
+        if isinstance(success, str):
+            success = success == "True"
+        if not success:
+            with pytest.raises(ValueError, match="Denoised audio not available"):
+                ds_den[i]
+            return
+    pytest.skip("No failed-denoising rows found in split")
+
+
+@pytest.mark.skipif(
+    EXPECTED_FIRST_ITEM_AUDIO_SHA256 == "",
+    reason="Reference hash not yet populated — run snapshot code above first",
+)
+def test_reference_item_stability(ds_pandas: SpanishCarrionCrowsVox):
+    """Check that index-0 audio and the CSV are bitwise-stable."""
+    item = ds_pandas[0]
+
+    assert "audio" in item
+    audio = item["audio"]
+    assert isinstance(audio, np.ndarray)
+    assert audio.dtype == np.float32
+
+    h = hashlib.sha256(audio.tobytes()).hexdigest()
+    assert h == EXPECTED_FIRST_ITEM_AUDIO_SHA256, (
+        "First item audio hash changed.\n"
+        f"Got    {h}\n"
+        f"Expect {EXPECTED_FIRST_ITEM_AUDIO_SHA256}\n\n"
+        "If this is intentional, update EXPECTED_FIRST_ITEM_AUDIO_SHA256."
+    )
+
+    csv_bytes = (
+        ds_pandas._data.unwrap.sort_index(axis=0)
+        .sort_index(axis=1)
+        .to_csv(index=True)
+        .encode("utf-8")
+    )
+    h = hashlib.sha256(csv_bytes).hexdigest()
+    assert h == EXPECTED_CSV_SHA256, (
+        "CSV hash changed.\n"
+        f"Got    {h}\n"
+        f"Expect {EXPECTED_CSV_SHA256}\n\n"
+        "If this is intentional, update EXPECTED_CSV_SHA256."
+    )


### PR DESCRIPTION
A different version of the Spanish Carrion Crow datasets that only includes focal vocalizations (i.e., vocalizations made by an adult bird wearing a biologger), in time periods where we have more than one crow tagged. 

We have pre-computed audio clips for each focal vocalization, making it simpler than dataset #255 

Note that the full dataset has more focal vocalizations than this one, but we are subsetting to sections where there is synchronization between >1 bird in the same year/territory.