### PR TITLE
feat: add StreamingBackend protocol for streaming-only backends. (Webdataset)

### DIFF
--- a/alp_data/backends/__init__.py
+++ b/alp_data/backends/__init__.py
@@ -4,7 +4,7 @@ This module provides a protocol-based backend system that allows alp-data to wor
 with multiple data libraries through a common interface.
 
 Two protocols are defined:
-- StreamingBackend: For streaming-only data formats (e.g., WebDataset/tar files)
+- StreamingDataBackend: For streaming-only data formats (e.g., WebDataset/tar files)
   that only support iteration, not random access.
 - DataBackend: For in-memory data formats (e.g., pandas, polars DataFrames)
   that support both random access and iteration.
@@ -13,16 +13,13 @@ Two protocols are defined:
 from .backends import BackendType, get_backend
 from .pandas_backend import PandasBackend
 from .polars_backend import PolarsBackend
-from .protocol import DataBackend, StreamingBackend
+from .protocol import DataBackend, StreamingDataBackend
 
 __all__ = [
-    # Protocols
     "DataBackend",
-    "StreamingBackend",
-    # DataBackend implementations
+    "StreamingDataBackend",
     "PandasBackend",
     "PolarsBackend",
-    # Registry
     "BackendType",
     "get_backend",
 ]

--- a/alp_data/backends/__init__.py
+++ b/alp_data/backends/__init__.py
@@ -2,17 +2,27 @@
 
 This module provides a protocol-based backend system that allows alp-data to work
 with multiple data libraries through a common interface.
+
+Two protocols are defined:
+- StreamingBackend: For streaming-only data formats (e.g., WebDataset/tar files)
+  that only support iteration, not random access.
+- DataBackend: For in-memory data formats (e.g., pandas, polars DataFrames)
+  that support both random access and iteration.
 """
 
 from .backends import BackendType, get_backend
 from .pandas_backend import PandasBackend
 from .polars_backend import PolarsBackend
-from .protocol import DataBackend
+from .protocol import DataBackend, StreamingBackend
 
 __all__ = [
+    # Protocols
     "DataBackend",
+    "StreamingBackend",
+    # DataBackend implementations
     "PandasBackend",
     "PolarsBackend",
+    # Registry
     "BackendType",
     "get_backend",
 ]

--- a/alp_data/backends/backends.py
+++ b/alp_data/backends/backends.py
@@ -7,19 +7,19 @@ from typing import Literal, Type
 
 from alp_data.backends.pandas_backend import PandasBackend
 from alp_data.backends.polars_backend import PolarsBackend
-from alp_data.backends.protocol import DataBackend
+from alp_data.backends.protocol import DataBackend, StreamingBackend
 
 BackendType = Literal["pandas", "polars"]
 
 
 # We need to add new backends here when they are implemented
-_BACKEND_REGISTRY: dict[str, Type[DataBackend]] = {
+_BACKEND_REGISTRY: dict[str, Type[DataBackend | StreamingBackend]] = {
     "pandas": PandasBackend,
     "polars": PolarsBackend,
 }
 
 
-def get_backend(backend: BackendType) -> Type[DataBackend]:
+def get_backend(backend: BackendType) -> Type[DataBackend | StreamingBackend]:
     """Get the backend class for the specified backend type.
 
     Parameters
@@ -29,7 +29,7 @@ def get_backend(backend: BackendType) -> Type[DataBackend]:
 
     Returns
     -------
-    Type[DataBackend]
+    Type[DataBackend | StreamingBackend]
         The backend class (not an instance)
 
     Raises

--- a/alp_data/backends/backends.py
+++ b/alp_data/backends/backends.py
@@ -7,19 +7,19 @@ from typing import Literal, Type
 
 from alp_data.backends.pandas_backend import PandasBackend
 from alp_data.backends.polars_backend import PolarsBackend
-from alp_data.backends.protocol import DataBackend, StreamingBackend
+from alp_data.backends.protocol import DataBackend, StreamingDataBackend
 
 BackendType = Literal["pandas", "polars"]
 
 
 # We need to add new backends here when they are implemented
-_BACKEND_REGISTRY: dict[str, Type[DataBackend | StreamingBackend]] = {
+_BACKEND_REGISTRY: dict[str, Type[DataBackend | StreamingDataBackend]] = {
     "pandas": PandasBackend,
     "polars": PolarsBackend,
 }
 
 
-def get_backend(backend: BackendType) -> Type[DataBackend | StreamingBackend]:
+def get_backend(backend: BackendType) -> Type[DataBackend | StreamingDataBackend]:
     """Get the backend class for the specified backend type.
 
     Parameters
@@ -29,7 +29,7 @@ def get_backend(backend: BackendType) -> Type[DataBackend | StreamingBackend]:
 
     Returns
     -------
-    Type[DataBackend | StreamingBackend]
+    Type[DataBackend | StreamingDataBackend]
         The backend class (not an instance)
 
     Raises

--- a/alp_data/backends/protocol.py
+++ b/alp_data/backends/protocol.py
@@ -3,11 +3,196 @@
 This module defines the interface that all backend implementations must follow.
 It enables support for multiple data handling libraries (pandas, polars, etc.) through
 a common abstraction layer.
+
+Two protocols are defined:
+- StreamingBackend: For streaming-only data formats (e.g., WebDataset/tar files)
+  that only support iteration, not random access.
+- DataBackend: For in-memory data formats (e.g., pandas, polars DataFrames)
+  that support both random access and iteration.
 """
 
 from __future__ import annotations
 
 from typing import Any, Callable, Iterator, Literal, Protocol, overload
+
+
+class StreamingBackend(Protocol):
+    """Protocol defining the interface for streaming-only data backends.
+
+    This protocol is designed for data formats that only support sequential
+    iteration, such as WebDataset (tar files). These backends cannot support:
+    - Random access (__getitem__)
+    - Known length (__len__)
+    - Operations requiring full data scan (drop_duplicates, get_unique, histogram)
+    - Sampling operations (subsample_by_column, upsample_by_column, sample_rows)
+
+    Implementations should apply filtering and transformations lazily during iteration.
+    """
+
+    @property
+    def is_streaming(self) -> bool:
+        """Check if backend is in streaming mode.
+
+        For StreamingBackend implementations, this should always return True.
+
+        Returns
+        -------
+        bool
+            Always True for streaming backends
+        """
+        ...
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        """Iterate over samples as dictionaries.
+
+        This is the primary access method for streaming backends.
+
+        Yields
+        ------
+        dict[str, Any]
+            Dictionary for each sample mapping field names to values
+        """
+        ...
+
+    @property
+    def columns(self) -> list[str]:
+        """Get the list of column/field names.
+
+        Note: This may require peeking at the first sample, which could
+        have side effects depending on the implementation.
+
+        Returns
+        -------
+        list[str]
+            List of column/field names
+        """
+        ...
+
+    def column_exists(self, column: str) -> bool:
+        """Check if a column/field exists in the data.
+
+        Parameters
+        ----------
+        column : str
+            Column name to look for
+
+        Returns
+        -------
+        bool
+            True if column exists, False otherwise
+        """
+        ...
+
+    @property
+    def unwrap(self) -> Any:  # noqa ANN401
+        """Get the underlying data object.
+
+        This is useful when you need to access backend-specific functionality
+        or pass the data to functions that expect the native type.
+
+        Returns
+        -------
+        Any
+            The underlying data (e.g., wds.WebDataset)
+        """
+        ...
+
+    def filter_isin(
+        self,
+        column: str,
+        values: list[Any],
+        *,
+        negate: bool = False,
+    ) -> "StreamingBackend":
+        """Filter samples where column values are in (or not in) a list.
+
+        This filter is applied lazily during iteration.
+
+        Parameters
+        ----------
+        column : str
+            Column name to filter on
+        values : list[Any]
+            List of values to match
+        negate : bool, optional
+            If True, keep rows NOT in values list, by default False
+
+        Returns
+        -------
+        StreamingBackend
+            Self with filter configured (applied during iteration)
+        """
+        ...
+
+    def dropna(
+        self,
+        subset: list[str] | None = None,
+    ) -> "StreamingBackend":
+        """Remove samples with missing values.
+
+        This filter is applied lazily during iteration.
+
+        Parameters
+        ----------
+        subset : list[str] | None, optional
+            Column names to consider for null detection.
+            If None, check all columns, by default None
+
+        Returns
+        -------
+        StreamingBackend
+            Self with dropna configured (applied during iteration)
+        """
+        ...
+
+    def map_column(
+        self,
+        column: str,
+        mapping: dict[Any, Any],
+        output_column: str,
+        *,
+        default: Any | None = None,  # noqa ANN401
+    ) -> "StreamingBackend":
+        """Create a new column by mapping values from an existing column.
+
+        This transformation is applied lazily during iteration.
+
+        Parameters
+        ----------
+        column : str
+            Source column name
+        mapping : dict[Any, Any]
+            Dictionary mapping source values to output values
+        output_column : str
+            Name of the new column to create
+        default : Any, optional
+            Value to use for unmapped keys, by default None
+
+        Returns
+        -------
+        StreamingBackend
+            Self with mapping configured (applied during iteration)
+        """
+        ...
+
+    def apply_fn(
+        self,
+        fn: Callable[[dict[str, Any]], dict[str, Any]],
+    ) -> "StreamingBackend":
+        """Apply a custom function to each sample during iteration.
+
+        Parameters
+        ----------
+        fn : Callable[[dict[str, Any]], dict[str, Any]]
+            Function to apply. Should accept a sample dict and return
+            a transformed sample dict.
+
+        Returns
+        -------
+        StreamingBackend
+            Self with function configured (applied during iteration)
+        """
+        ...
 
 
 class DataBackend(Protocol):
@@ -92,6 +277,32 @@ class DataBackend(Protocol):
         -------
         DataBackend
             Backend instance wrapping the loaded data object
+        """
+        ...
+
+    @classmethod
+    def from_path(cls, path: str, *, streaming: bool = False, **kwargs: Any) -> "DataBackend":
+        """Load a tabular file, dispatching on extension.
+
+        Parameters
+        ----------
+        path : str
+            Path to a ``.parquet``, ``.csv``, ``.json``, ``.jsonl``,
+            or ``.ndjson`` file.
+        streaming : bool, optional
+            Whether to use streaming mode, by default False.
+        **kwargs : Any
+            Additional backend-specific arguments.
+
+        Returns
+        -------
+        DataBackend
+            Backend instance wrapping the loaded data.
+
+        Raises
+        ------
+        ValueError
+            If the file extension is not supported.
         """
         ...
 

--- a/alp_data/backends/protocol.py
+++ b/alp_data/backends/protocol.py
@@ -5,7 +5,7 @@ It enables support for multiple data handling libraries (pandas, polars, etc.) t
 a common abstraction layer.
 
 Two protocols are defined:
-- StreamingBackend: For streaming-only data formats (e.g., WebDataset/tar files)
+- StreamingDataBackend: For streaming-only data formats (e.g., WebDataset/tar files)
   that only support iteration, not random access.
 - DataBackend: For in-memory data formats (e.g., pandas, polars DataFrames)
   that support both random access and iteration.
@@ -16,7 +16,7 @@ from __future__ import annotations
 from typing import Any, Callable, Iterator, Literal, Protocol, overload
 
 
-class StreamingBackend(Protocol):
+class StreamingDataBackend(Protocol):
     """Protocol defining the interface for streaming-only data backends.
 
     This protocol is designed for data formats that only support sequential
@@ -33,7 +33,7 @@ class StreamingBackend(Protocol):
     def is_streaming(self) -> bool:
         """Check if backend is in streaming mode.
 
-        For StreamingBackend implementations, this should always return True.
+        For StreamingDataBackend implementations, this should always return True.
 
         Returns
         -------
@@ -103,7 +103,7 @@ class StreamingBackend(Protocol):
         values: list[Any],
         *,
         negate: bool = False,
-    ) -> "StreamingBackend":
+    ) -> "StreamingDataBackend":
         """Filter samples where column values are in (or not in) a list.
 
         This filter is applied lazily during iteration.
@@ -119,7 +119,7 @@ class StreamingBackend(Protocol):
 
         Returns
         -------
-        StreamingBackend
+        StreamingDataBackend
             Self with filter configured (applied during iteration)
         """
         ...
@@ -127,7 +127,7 @@ class StreamingBackend(Protocol):
     def dropna(
         self,
         subset: list[str] | None = None,
-    ) -> "StreamingBackend":
+    ) -> "StreamingDataBackend":
         """Remove samples with missing values.
 
         This filter is applied lazily during iteration.
@@ -140,7 +140,7 @@ class StreamingBackend(Protocol):
 
         Returns
         -------
-        StreamingBackend
+        StreamingDataBackend
             Self with dropna configured (applied during iteration)
         """
         ...
@@ -152,7 +152,7 @@ class StreamingBackend(Protocol):
         output_column: str,
         *,
         default: Any | None = None,  # noqa ANN401
-    ) -> "StreamingBackend":
+    ) -> "StreamingDataBackend":
         """Create a new column by mapping values from an existing column.
 
         This transformation is applied lazily during iteration.
@@ -170,7 +170,7 @@ class StreamingBackend(Protocol):
 
         Returns
         -------
-        StreamingBackend
+        StreamingDataBackend
             Self with mapping configured (applied during iteration)
         """
         ...
@@ -178,7 +178,7 @@ class StreamingBackend(Protocol):
     def apply_fn(
         self,
         fn: Callable[[dict[str, Any]], dict[str, Any]],
-    ) -> "StreamingBackend":
+    ) -> "StreamingDataBackend":
         """Apply a custom function to each sample during iteration.
 
         Parameters
@@ -189,7 +189,7 @@ class StreamingBackend(Protocol):
 
         Returns
         -------
-        StreamingBackend
+        StreamingDataBackend
             Self with function configured (applied during iteration)
         """
         ...


### PR DESCRIPTION
Defines StreamingBackend protocol for backends that support sequential iteration only (e.g., tar-based formats), alongside the existing DataBackend. Updates backend registry type hints to accept both protocol types.