### PR TITLE
feat: add Dataset.save_to, Dataset.from_path, and GenericDataset. (Webdataset)

### DIFF
--- a/esp_data/__init__.py
+++ b/esp_data/__init__.py
@@ -6,6 +6,7 @@ from .dataset import (
     Dataset,
     DatasetConfig,
     DatasetInfo,
+    GenericDatasetConfig,
     dataset_class_from_name,
     dataset_from_config,
     list_registered_datasets,
@@ -48,6 +49,8 @@ from .datasets import (
     XenoCantoAnnotatedJeantet23,
     ZebraFinchJulieElie,
 )
+from .exporters import export_dataset
+from .generic_dataset import GenericDataset
 
 __all__ = [
     "dataset_from_config",
@@ -56,6 +59,7 @@ __all__ = [
     "DatasetConfig",
     "ConcatConfig",
     "ChainedDatasetConfig",
+    "GenericDatasetConfig",
     "list_registered_datasets",
     "print_registered_datasets",
     "dataset_class_from_name",
@@ -64,6 +68,7 @@ __all__ = [
     "dataset_class_from_name",
     "ConcatenatedDataset",
     "ChainedDataset",
+    "export_dataset",
     "AnimalSoundArchive",
     "AnimalSpeak",
     "GiantOtters",
@@ -100,6 +105,5 @@ __all__ = [
     "DCLDE2026",
     "DinardoDolphinWhistles",
     "GibbonSolos",
-    "export_dataset",
+    "GenericDataset",
 ]
-from .exporters import export_dataset

--- a/esp_data/backends/pandas_backend.py
+++ b/esp_data/backends/pandas_backend.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import inspect
 import warnings
+from functools import partial
 from typing import Any, Callable, Iterator, Literal
 
 import pandas as pd
+
+from esp_data.io import anypath
 
 from .protocol import DataBackend
 
@@ -197,6 +200,48 @@ class PandasBackend(DataBackend):
             )
         df = pd.read_parquet(path, **filtered_kwargs)
         return cls(df, streaming=False)
+
+    @classmethod
+    def from_path(cls, path: str, *, streaming: bool = False, **kwargs: Any) -> "PandasBackend":
+        """Load a tabular file, dispatching on extension.
+
+        Parameters
+        ----------
+        path : str
+            Path to a ``.parquet``, ``.csv``, ``.json``, ``.jsonl``,
+            or ``.ndjson`` file.
+        streaming : bool, optional
+            Whether to use streaming (chunked) mode, by default False.
+        **kwargs : Any
+            Forwarded to the underlying reader.
+
+        Returns
+        -------
+        PandasBackend
+            Backend instance wrapping the loaded data.
+
+        Raises
+        ------
+        ValueError
+            If the file extension is not supported.
+        """
+        dir_path = anypath(path)
+        for file in dir_path.iterdir():
+            if file.suffix.lower() in {".parquet", ".csv", ".json", ".jsonl", ".ndjson"}:
+                path = file
+                break
+        p = str(path).lower()
+        if p.endswith(".parquet"):
+            return cls.from_parquet(path, streaming=streaming, **kwargs)
+        if p.endswith(".csv"):
+            return cls.from_csv(path, streaming=streaming, **kwargs)
+        if p.endswith(".json") or p.endswith(".jsonl") or p.endswith(".ndjson"):
+            lines = p.endswith(".jsonl") or p.endswith(".ndjson")
+            return cls.from_json(path, lines=lines, streaming=streaming, **kwargs)
+        raise ValueError(
+            f"Unsupported file extension for PandasBackend.from_path: {path!r}. "
+            "Supported: .parquet, .csv, .json, .jsonl, .ndjson"
+        )
 
     @property
     def is_streaming(self) -> bool:
@@ -960,8 +1005,6 @@ class PandasBackend(DataBackend):
             If the function does not return a pandas DataFrame
         """
         self._ensure_not_streaming("apply_fn")
-        from functools import partial
-
         fn = partial(fn, **fn_kwargs)
         new_df = self._df.apply(fn, **apply_kwargs)
         if not isinstance(new_df, pd.DataFrame):

--- a/esp_data/backends/polars_backend.py
+++ b/esp_data/backends/polars_backend.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import inspect
 import logging
 import warnings
+from functools import partial
 from typing import Any, Callable, Iterator, Literal
 
 import polars as pl
+
+from esp_data.io import anypath
 
 from .protocol import DataBackend
 
@@ -207,6 +210,48 @@ class PolarsBackend(DataBackend):
         else:
             df = pl.read_parquet(path, **filtered_kwargs)
             return cls(df, streaming=False)
+
+    @classmethod
+    def from_path(cls, path: str, *, streaming: bool = False, **kwargs: Any) -> "PolarsBackend":
+        """Load a tabular file, dispatching on extension.
+
+        Parameters
+        ----------
+        path : str
+            Path to a directory containing ``.parquet``, ``.csv``, ``.json``, ``.jsonl``,
+            or ``.ndjson`` file.
+        streaming : bool, optional
+            Whether to use streaming (LazyFrame) mode, by default False.
+        **kwargs : Any
+            Forwarded to the underlying reader.
+
+        Returns
+        -------
+        PolarsBackend
+            Backend instance wrapping the loaded data.
+
+        Raises
+        ------
+        ValueError
+            If the file extension is not supported.
+        """
+        dir_path = anypath(path)
+        for file in dir_path.iterdir():
+            if file.suffix.lower() in {".parquet", ".csv", ".json", ".jsonl", ".ndjson"}:
+                path = file
+                break
+        p = str(file).lower()
+        if p.endswith(".parquet"):
+            return cls.from_parquet(path, streaming=streaming, **kwargs)
+        if p.endswith(".csv"):
+            return cls.from_csv(path, streaming=streaming, **kwargs)
+        if p.endswith(".json") or p.endswith(".jsonl") or p.endswith(".ndjson"):
+            lines = p.endswith(".jsonl") or p.endswith(".ndjson")
+            return cls.from_json(path, lines=lines, streaming=streaming, **kwargs)
+        raise ValueError(
+            f"Unsupported file extension for PolarsBackend.from_path: {path!r}. "
+            "Supported: .parquet, .csv, .json, .jsonl, .ndjson"
+        )
 
     @property
     def is_streaming(self) -> bool:
@@ -1111,8 +1156,6 @@ class PolarsBackend(DataBackend):
         self._ensure_not_streaming("apply_fn")
 
         # use partial to bind fn_kwargs to fn
-        from functools import partial
-
         fn_partial = partial(fn, **fn_kwargs)
         df = self._ensure_collected()
         # Apply function row-wise and create new column

--- a/esp_data/dataset.py
+++ b/esp_data/dataset.py
@@ -71,6 +71,7 @@ class DatasetConfig(BaseModel):
     data_root: str | None = None
     streaming: bool = False
     backend: BackendType = "polars"
+    data_location: str | None = None
 
     @field_validator("transformations", mode="before")
     @classmethod
@@ -172,6 +173,28 @@ class ChainedDatasetConfig(BaseModel):
 
     dataset_name: str = "chained_dataset"
     datasets: list[DatasetConfig]
+
+
+class GenericDatasetConfig(BaseModel):
+    """Configuration for loading a dataset from a path via :class:`GenericDataset`.
+
+    The backend and streaming mode are determined automatically from the
+    ``info.yaml`` written alongside the data during ``save_to``.
+
+    Attributes
+    ----------
+    path : str
+        Source path (local or cloud) to load from.
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        str_strip_whitespace=True,
+        extra="forbid",
+    )
+
+    dataset_name: str = "generic_dataset"
+    path: str
 
 
 class DatasetInfo(BaseModel):
@@ -469,6 +492,120 @@ class Dataset(ABC):
         """
         pass
 
+    def save_to(self, path: str, format: str = "webdataset", **kwargs: Any) -> dict[str, Any]:
+        """Save the dataset to a file.
+
+        Supports different output formats (e.g. "webdataset", "csv", "parquet") via the `format`
+        argument.
+        Writes data files and an ``config.yaml``containing `info: DatasetInfo` and additional
+        parameters such as `backend`,`streaming`,`sample_rate`, etc to the specified path.
+
+        Everything can be loaded back automatically by
+        `Dataset.from_path` into a `GenericDataset`.
+
+        Parameters
+        ----------
+        path : str
+            Destination path (supports local and cloud paths)
+        format : str, optional
+            Output format. Supported: ``"webdataset"``.
+            By default ``"webdataset"``.
+        **kwargs : Any
+            Additional arguments passed to the underlying backend writer.
+            For ``"webdataset"``: accepts ``encoder_fn``, ``num_samples_per_shard``,
+            ``max_workers``, ``compression``, ``shuffle``.
+
+        Returns
+        -------
+        dict[str, Any]
+            Export summary with keys: ``total_shards``, ``total_processed``,
+            ``total_failed``, ``output_path``, ``compression``.
+
+        Raises
+        ------
+        RuntimeError
+            If no data is loaded yet.
+        """
+        if self._data is None:
+            raise RuntimeError("No data loaded. Call _load() first.")
+        from esp_data.exporters import export_dataset
+
+        summary = export_dataset(self, path, format=format, **kwargs)
+
+        self._write_config(path, format)
+        return summary
+
+    def _write_config(self, path: str, backend: BackendType) -> None:
+        """Write configuration to ``config.yaml`` in the destination directory.
+
+        ``split_paths`` is replaced with a single entry pointing to ``path``
+        (only the exported split lives there). ``sample_rate`` is added when
+        set on the dataset instance.
+
+        Parameters
+        ----------
+        path : str
+            Destination directory (local or cloud) where ``config.yaml`` is written.
+        backend : BackendType
+            The backend used for the dataset.
+        """
+        import yaml
+
+        from esp_data.io import anypath
+        from esp_data.io.filesystem import filesystem_from_path
+
+        resolved = anypath(path)
+        config_dict = {}
+        config_dict["info"] = self.info.model_dump()
+
+        # Only the exported split is present in this directory.
+        split_name = getattr(self, "split", "default")
+        config_dict["info"]["split_paths"] = {split_name: str(resolved)}
+
+        # Preserve sample_rate so reloaders know what rate was used.
+        sample_rate = getattr(self, "sample_rate", None)
+        if sample_rate is not None:
+            config_dict["sample_rate"] = sample_rate
+
+        # Record backend so from_path can reload without the user specifying it.
+        config_dict["backend"] = backend
+        config_dict["streaming"] = self._streaming
+
+        config_path = resolved / "config.yaml"
+        fs = filesystem_from_path(config_path)
+        content = yaml.dump(config_dict, default_flow_style=False, allow_unicode=True)
+        with fs.open(str(config_path), "w") as f:
+            f.write(content)
+
+    @classmethod
+    def from_path(
+        cls,
+        path: str | AnyPathT,
+        **kwargs: Any,
+    ) -> "Dataset":
+        """Load a dataset from a path exported by `save_to`.
+
+        The backend and streaming mode are read from ``config.yaml`` written by
+        `save_to`. No manual ``backend`` or ``streaming`` arguments are needed.
+
+        Parameters
+        ----------
+        path : str | AnyPathT
+            Source path (local or cloud) — the directory produced by `save_to`.
+        **kwargs : Any
+            Additional arguments forwarded to the backend's ``from_path``
+            (e.g. ``data_processor`` for the webdataset backend).
+
+        Returns
+        -------
+        GenericDataset
+            Dataset instance loaded from the given path.
+        """
+        # Imported here to avoid circular import: generic_dataset imports Dataset
+        from esp_data.generic_dataset import GenericDataset
+
+        return GenericDataset(path, **kwargs)
+
     def apply_transformations(
         self, transformations: list[RegisteredTransformConfigs]
     ) -> dict[str, Any]:
@@ -613,25 +750,39 @@ def print_registered_datasets() -> None:
         print(dataset_class.info.model_dump_json(indent=2))
 
 
-def _make_dataset_from_config(dataset_config: DatasetConfig | ConcatConfig) -> Dataset:
+def _make_dataset_from_config(
+    dataset_config: DatasetConfig | ConcatConfig | GenericDatasetConfig,
+) -> tuple[Dataset, dict[str, Any]]:
     """Create a dataset instance from the given configuration.
 
     Parameters
     ----------
-    dataset_config : DatasetConfig | ConcatConfig
-        The configuration for the dataset to create. This can be either a
-        DatasetConfig or a ConcatConfig.
+    dataset_config : DatasetConfig | ConcatConfig | GenericDatasetConfig
+        The configuration for the dataset to create.
 
     Returns
     -------
-    Dataset
-        The dataset instance created from the configuration.
+    tuple[Dataset, dict[str, Any]]
+        The dataset instance and transformation metadata dict.
 
     Raises
     ------
     KeyError
         If the dataset is not registered
     """
+    if isinstance(dataset_config, GenericDatasetConfig):
+        from esp_data.generic_dataset import GenericDataset
+
+        return GenericDataset.from_config(dataset_config)
+
+    if isinstance(dataset_config, DatasetConfig) and dataset_config.data_location:
+        ds = Dataset.from_path(
+            dataset_config.data_location,
+            backend=dataset_config.backend,
+            streaming=dataset_config.streaming,
+        )
+        return ds, {}
+
     _dataset_class = _dataset_registry.get(dataset_config.dataset_name, None)
     if _dataset_class is None:
         raise KeyError(f"Dataset '{dataset_config.dataset_name}' is not registered.")
@@ -640,7 +791,9 @@ def _make_dataset_from_config(dataset_config: DatasetConfig | ConcatConfig) -> D
 
 
 def dataset_from_config(
-    dataset_config: DatasetConfig | ConcatConfig | ChainedDatasetConfig | AnyPathT | str,
+    dataset_config: (
+        DatasetConfig | ConcatConfig | ChainedDatasetConfig | GenericDatasetConfig | AnyPathT | str
+    ),
     key: str | None = None,
 ) -> tuple[Dataset, dict[str, Any]]:
     """Load a single dataset or a dataset collection from a configuration.
@@ -680,8 +833,9 @@ def dataset_from_config(
     KeyError
         If the specified key does not match any dataset configuration in the data.
     """
-    if isinstance(dataset_config, (DatasetConfig, ConcatConfig, ChainedDatasetConfig)):
-        # If a DatasetConfig is passed, we can directly create the dataset
+    if isinstance(
+        dataset_config, (DatasetConfig, ConcatConfig, ChainedDatasetConfig, GenericDatasetConfig)
+    ):
         return _make_dataset_from_config(dataset_config)
 
     data = read_yaml(dataset_config)
@@ -692,8 +846,8 @@ def dataset_from_config(
         data = data[key]
 
     if isinstance(data, dict):
-        if "dataset" in data or "concat" in data or "chain" in data:
-            if sum(k in data for k in ("concat", "dataset", "chain")) > 1:
+        if "dataset" in data or "concat" in data or "chain" in data or "generic" in data:
+            if sum(k in data for k in ("concat", "dataset", "chain", "generic")) > 1:
                 raise ValueError("Configuration cannot contain multiple dataset types at once.")
 
             if "dataset" in data:
@@ -709,9 +863,13 @@ def dataset_from_config(
                 cfg = data["chain"]
                 return _make_dataset_from_config(ChainedDatasetConfig.model_validate(cfg))
 
+            elif "generic" in data:
+                cfg = data["generic"]
+                return _make_dataset_from_config(GenericDatasetConfig.model_validate(cfg))
+
             else:
                 raise ValueError(
-                    "Configuration must contain either 'dataset','concat' or 'chain' key."
+                    "Configuration must contain either 'dataset', 'concat', 'chain', or 'generic' key."  # noqa: E501
                 )
         else:
             raise ValueError(
@@ -723,4 +881,5 @@ def dataset_from_config(
     1. A DatasetConfig represented as the value of a dict with a single 'dataset' key
     2. A ConcatConfig represented as the value of a dict with a single 'concat' key
     3. A ChainedDatasetConfig represented as the value of a dict with a single 'chain' key
+    4. A GenericDatasetConfig represented as the value of a dict with a single 'generic' key
     """)

--- a/esp_data/generic_dataset.py
+++ b/esp_data/generic_dataset.py
@@ -1,0 +1,126 @@
+"""Generic dataset backed by any supported backend."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Iterator, Sequence
+
+from esp_data.dataset import Dataset, DatasetInfo, GenericDatasetConfig, register_dataset
+from esp_data.io import AnyPathT, anypath, filesystem_from_path, read_yaml
+
+logger = logging.getLogger(__name__)
+
+
+@register_dataset
+class GenericDataset(Dataset):
+    """A dataset loaded directly from a path rather than a registered source.
+
+    Wraps any supported backend (polars, pandas, webdataset) with a minimal
+    Dataset interface. Intended as the return type of `Dataset.from_path` and
+    as a config-driven loader via `GenericDatasetConfig`.
+
+    Unlike named dataset classes (e.g. `AnuraSetStrong`), `GenericDataset`
+    performs no custom per-sample processing — `__iter__` and `__getitem__`
+    yield rows directly from the backend.
+
+    If a ``config.yaml`` file exists alongside the data (in the same directory),
+    its contents are used to populate `info`.
+    """
+
+    info = DatasetInfo(
+        name="generic_dataset",
+        owner="ESP Data Team",
+        split_paths={"default": "virtual://generic"},
+        version="0.1.0",
+        description="A dataset loaded from a local or cloud path.",
+        sources=["Unknown"],
+        license="Unknown",
+    )
+
+    def __init__(
+        self,
+        path: str | AnyPathT,
+        **kwargs: Any,
+    ) -> None:
+        """Load a dataset from a path that points to a directory.
+
+        The backend and streaming mode are determined from
+        ``config.yaml`` (written by `Dataset.save_to`) which must be present.
+        If not found, raises an error since the backend cannot be inferred.
+
+        Parameters
+        ----------
+        path : str | AnyPathT
+            Source path (local or cloud).
+        **kwargs : Any
+            Additional arguments forwarded to the backend's ``from_path``
+            (e.g. ``data_processor`` for the webdataset backend).
+
+        Raises
+        ------
+        ValueError
+            If no ``config.yaml`` is found.
+        """
+        self.path = anypath(path)
+        fs = filesystem_from_path(self.path)
+        info_path = self.path / "config.yaml"
+        if fs.exists(info_path):
+            config_dict = read_yaml(info_path)
+            self.info = DatasetInfo(**config_dict["info"])
+        else:
+            raise ValueError(
+                f"No config.yaml found at {info_path}. Cannot infer backend or streaming mode."
+            )
+
+        super().__init__(backend=config_dict["backend"], streaming=config_dict["streaming"])
+
+        self._data = self._backend_class.from_path(self.path, streaming=self._streaming, **kwargs)
+
+    @property
+    def available_splits(self) -> Sequence[str]:
+        return list(self.info.split_paths.keys())
+
+    @property
+    def columns(self) -> Sequence[str]:
+        return self._data.columns
+
+    def _load(self) -> None:
+        pass
+
+    def __len__(self) -> int:
+        if self._streaming:
+            raise NotImplementedError(
+                "Length is not available for streaming backends. Iterate instead."
+            )
+        return len(self._data)
+
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        if self._streaming:
+            raise RuntimeError(
+                "Random access is not supported for streaming backends. Iterate instead."
+            )
+        return self._data[idx]
+
+    def __iter__(self) -> Iterator[Dict[str, Any]]:
+        yield from self._data
+
+    def __str__(self) -> str:
+        return f"GenericDataset(name={self.info.name}, version={self.info.version})"
+
+    @classmethod
+    def from_config(  # type: ignore[override]
+        cls, dataset_config: GenericDatasetConfig
+    ) -> tuple["GenericDataset", dict[str, Any]]:
+        """Create a GenericDataset from a :class:`GenericDatasetConfig`.
+
+        Parameters
+        ----------
+        dataset_config : GenericDatasetConfig
+            Configuration specifying path, backend, and streaming mode.
+
+        Returns
+        -------
+        tuple[GenericDataset, dict]
+            Dataset instance and empty metadata dict.
+        """
+        return cls(dataset_config.path), {}

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,5 +1,8 @@
 """Unit tests for the dataset module."""
 
+import io
+import json
+import tarfile
 from pathlib import Path
 from typing import Any, Dict, Literal
 
@@ -12,6 +15,7 @@ from esp_data import (
     Dataset,
     DatasetConfig,
     DatasetInfo,
+    GenericDataset,
     dataset_from_config,
     list_registered_datasets,
     print_registered_datasets,
@@ -303,3 +307,139 @@ def test_wrong_collection_from_config():
 
     with pytest.raises(ValueError, match="Invalid configuration format."):
         dataset_from_config("tests/samples/test_wrong_config.yml", key="config3")
+
+
+# ---------------------------------------------------------------------------
+# GenericDataset / Dataset.from_path / Dataset.save_to
+# ---------------------------------------------------------------------------
+
+_SAMPLE_ROWS = [{"id": i, "name": f"item_{i}"} for i in range(5)]
+
+
+def _make_parquet(tmp_path: Path) -> Path:
+    path = tmp_path / "data.parquet"
+    pd.DataFrame(_SAMPLE_ROWS).to_parquet(str(path), index=False)
+    return path
+
+
+def _make_csv(tmp_path: Path) -> Path:
+    path = tmp_path / "data.csv"
+    pd.DataFrame(_SAMPLE_ROWS).to_csv(str(path), index=False)
+    return path
+
+
+def _make_json(tmp_path: Path) -> Path:
+    path = tmp_path / "data.jsonl"
+    with open(path, "w") as f:
+        for row in _SAMPLE_ROWS:
+            f.write(json.dumps(row) + "\n")
+    return path
+
+
+def _make_webdataset_dir(tmp_path: Path) -> Path:
+    wds_dir = tmp_path / "wds"
+    wds_dir.mkdir()
+    tar_path = wds_dir / "shard_0000.tar"
+    with tarfile.open(tar_path, "w") as tar:
+        for row in _SAMPLE_ROWS:
+            key = f"sample_{row['id']:04d}"
+            data = json.dumps(row, indent=2).encode("utf-8")
+            info = tarfile.TarInfo(name=f"{key}.sample.json")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+    return wds_dir
+
+def _make_config_yaml(tmp_path: Path, backend: str, streaming: bool) -> Path:
+    info = {
+        "name": "test_dataset",
+        "owner": "test_owner",
+        "split_paths": {"train": "data.parquet"},
+        "version": "1.0.0",
+        "description": "Test dataset",
+        "sources": ["test"],
+        "license": "CC0",
+    }
+    config = {
+        "info": info,
+        "backend": backend,
+        "streaming": streaming,
+    }
+    path = tmp_path / "config.yaml"
+    with open(path, "w") as f:
+        yaml.dump(config, f)
+    return path
+
+
+def test_from_path_parquet(tmp_path):
+    """Dataset.from_path loads parquet and returns GenericDataset."""
+    _make_parquet(tmp_path)
+    _make_config_yaml(tmp_path, backend="polars", streaming=False)
+    ds = Dataset.from_path(tmp_path)
+    assert isinstance(ds, GenericDataset)
+    assert len(ds) == 5
+    rows = list(ds)
+    assert {r["id"] for r in rows} == {0, 1, 2, 3, 4}
+
+
+def test_from_path_csv(tmp_path):
+    """Dataset.from_path loads CSV and returns GenericDataset."""
+    _make_csv(tmp_path)
+    _make_config_yaml(tmp_path, backend="polars", streaming=False)
+
+    ds = Dataset.from_path(tmp_path)
+    assert isinstance(ds, GenericDataset)
+    assert len(ds) == 5
+
+
+def test_from_path_jsonl(tmp_path):
+    """Dataset.from_path loads JSON lines and returns GenericDataset."""
+    _make_json(tmp_path)
+    _make_config_yaml(tmp_path, backend="polars", streaming=False)
+    ds = Dataset.from_path(tmp_path)
+    assert isinstance(ds, GenericDataset)
+    assert len(ds) == 5
+
+
+def test_from_path_webdataset(tmp_path):
+    """Dataset.from_path loads webdataset directory and returns GenericDataset."""
+    from esp_data.backends.webdataset_utils import json_decoder
+
+    wds_dir = _make_webdataset_dir(tmp_path)
+    _make_config_yaml(wds_dir, backend="webdataset", streaming=True)
+    ds = Dataset.from_path(str(wds_dir), data_processor=json_decoder)
+    assert isinstance(ds, GenericDataset)
+    rows = [row for row in ds]
+    assert len(rows) == 5
+    assert {r["id"] for r in rows} == {0, 1, 2, 3, 4}
+
+
+def test_from_path_webdataset_no_len(tmp_path):
+    """GenericDataset wrapping webdataset raises on __len__ and __getitem__."""
+    from esp_data.backends.webdataset_utils import json_decoder
+
+    wds_dir = _make_webdataset_dir(tmp_path)
+    _make_config_yaml(wds_dir, backend="webdataset", streaming=True)
+    ds = Dataset.from_path(str(wds_dir), data_processor=json_decoder)
+    with pytest.raises(NotImplementedError):
+        len(ds)
+    with pytest.raises(RuntimeError):
+        ds[0]
+
+
+def test_from_path_reads_config_yaml(tmp_path):
+    """Dataset.from_path populates info from config.yaml if present."""
+    _make_parquet(tmp_path)
+    _make_config_yaml(tmp_path, backend="polars", streaming=False)
+    ds = Dataset.from_path(str(tmp_path))
+    assert ds.info.name == "test_dataset"
+    assert ds.info.version == "1.0.0"
+
+
+def test_dataset_save_to_no_data_raises(tmp_path):
+    """Dataset.save_to raises RuntimeError when _data is None."""
+    _make_parquet(tmp_path)
+    _make_config_yaml(tmp_path, backend="polars", streaming=False)
+    ds = Dataset.from_path(str(tmp_path))
+    ds._data = None
+    with pytest.raises(RuntimeError, match="No data loaded"):
+        ds.save_to(str(tmp_path / "out"))


### PR DESCRIPTION
Adds save_to/from_path to tabular backends (pandas, polars) and Dataset class, enabling round-trip persistence. Introduces GenericDataset for loading arbitrary file types (parquet, csv, json, webdataset) via a unified path-based API with auto-detection from config.yaml.