### PR TITLE
Restore BirdSet train split entries

### DIFF
--- a/alp_data/datasets/birdset.py
+++ b/alp_data/datasets/birdset.py
@@ -10,6 +10,7 @@ from alp_data.backends import BackendType
 from alp_data.io import DATA_HOME, AnyPathT, anypath, audio_stereo_to_mono, read_audio
 
 _GCS_ROOT = f"{DATA_HOME}/birdset/v0.1.0/raw"
+_BIRDSET_TRAIN_ROOT = "gs://foundation-model-data/data/birdset-train"
 
 
 @register_dataset
@@ -66,6 +67,7 @@ class BirdSet(Dataset):
     Subsets: HSN, NBP, NES, PER, POW, SSW, SNE, UHH.
 
     - ``all``: Combined dataset across all subsets and splits.
+    - ``XCM-train``: Xeno-canto medium training split.
 
     References
     ----------
@@ -94,22 +96,31 @@ class BirdSet(Dataset):
         name="birdset",
         owner="marius; gagan; david",
         split_paths={
+            "HSN-train": f"{_BIRDSET_TRAIN_ROOT}/HSN/HSN_taxonomic.csv",
             "HSN-test": f"{_GCS_ROOT}/HSN_test_v2.csv",
             "HSN-test_5s": f"{_GCS_ROOT}/HSN_test_5s_v2.csv",
+            "NBP-train": f"{_BIRDSET_TRAIN_ROOT}/NBP/NBP_taxonomic.csv",
             "NBP-test": f"{_GCS_ROOT}/NBP_test_v2.csv",
             "NBP-test_5s": f"{_GCS_ROOT}/NBP_test_5s_v2.csv",
+            "NES-train": f"{_BIRDSET_TRAIN_ROOT}/NES/NES_taxonomic.csv",
             "NES-test": f"{_GCS_ROOT}/NES_test_v2.csv",
             "NES-test_5s": f"{_GCS_ROOT}/NES_test_5s_v2.csv",
+            "PER-train": f"{_BIRDSET_TRAIN_ROOT}/PER/PER_taxonomic.csv",
             "PER-test": f"{_GCS_ROOT}/PER_test_v2.csv",
             "PER-test_5s": f"{_GCS_ROOT}/PER_test_5s_v2.csv",
+            "POW-train": f"{_BIRDSET_TRAIN_ROOT}/POW/POW_taxonomic.csv",
             "POW-test": f"{_GCS_ROOT}/POW_test_v2.csv",
             "POW-test_5s": f"{_GCS_ROOT}/POW_test_5s_v2.csv",
+            "SSW-train": f"{_BIRDSET_TRAIN_ROOT}/SSW/SSW_taxonomic.csv",
             "SSW-test": f"{_GCS_ROOT}/SSW_test_v2.csv",
             "SSW-test_5s": f"{_GCS_ROOT}/SSW_test_5s_v2.csv",
+            "SNE-train": f"{_BIRDSET_TRAIN_ROOT}/SNE/SNE_taxonomic.csv",
             "SNE-test": f"{_GCS_ROOT}/SNE_test_v2.csv",
             "SNE-test_5s": f"{_GCS_ROOT}/SNE_test_5s_v2.csv",
+            "UHH-train": f"{_BIRDSET_TRAIN_ROOT}/UHH/UHH_taxonomic.csv",
             "UHH-test": f"{_GCS_ROOT}/UHH_test_v2.csv",
             "UHH-test_5s": f"{_GCS_ROOT}/UHH_test_5s_v2.csv",
+            "XCM": f"{_BIRDSET_TRAIN_ROOT}/XCM/XCM_taxonomic.csv",
             "all": f"{_GCS_ROOT}/birdset_all_v2.csv",
         },
         version="0.1.0",
@@ -118,7 +129,7 @@ class BirdSet(Dataset):
             "Pre-resampled audio available at 16 kHz and 32 kHz (WAV). "
             "Original audio is 32 kHz OGG from the BirdSet HuggingFace repository."
         ),
-        sources=["HSN", "NBP", "NES", "PER", "POW", "SSW", "SNE", "UHH"],
+        sources=["HSN", "NBP", "NES", "PER", "POW", "SSW", "SNE", "UHH", "XCM"],
         license="CC-BY-4.0, CC0",
     )
 

--- a/tests/unittests/datasets_tests/test_birdset.py
+++ b/tests/unittests/datasets_tests/test_birdset.py
@@ -68,9 +68,23 @@ def test_check_audio(ds: BirdSet, sample_indices: List[int]):
 def test_available_splits(ds: BirdSet) -> None:
     """Test if available_splits returns correct split names."""
     expected_splits = [
+        "HSN-train",
         "HSN-test", "HSN-test_5s",
+        "NBP-train",
+        "NBP-test", "NBP-test_5s",
+        "NES-train",
+        "NES-test", "NES-test_5s",
+        "PER-train",
         "PER-test", "PER-test_5s",
+        "POW-train",
         "POW-test", "POW-test_5s",
+        "SSW-train",
+        "SSW-test", "SSW-test_5s",
+        "SNE-train",
+        "SNE-test", "SNE-test_5s",
+        "UHH-train",
+        "UHH-test", "UHH-test_5s",
+        "XCM",
         "all",
     ]
     assert all(split in ds.available_splits for split in expected_splits)


### PR DESCRIPTION
## Summary
- restore BirdSet train split entries for HSN, NBP, NES, PER, POW, SNE, SSW, and UHH, plus the XCM split
- regenerate the existing BirdSet train split files under `gs://foundation-model-data/data/birdset-train/{SUBSET}/`
- use CSV train split files in `BirdSet`, with matching JSONL copies uploaded next to them
- keep audio in the existing Xeno-canto dataset; CSV train split rows point to bucket-relative `/xeno-canto/v0.1.0/raw/...` audio paths
- keep the default BirdSet audio root unchanged; only the train split metadata files live under `foundation-model-data`

## Regenerated train split files
Source split definitions were the historical BirdSet train JSONLs. Each row's `XC{id}` was matched against:

`gs://esp-ml-datasets/xeno-canto/v0.1.0/raw/all_20260203_v2.csv`

The generated rows include BirdSet label/prompt fields plus xeno-canto metadata. CSV audio path columns use bucket-relative Xeno-canto paths, for example:

- `audio_path`: `/xeno-canto/v0.1.0/raw/audio/...`
- `16khz_path`: `/xeno-canto/v0.1.0/raw/audio_16k/...`
- `32khz_path`: `/xeno-canto/v0.1.0/raw/audio_32k/...`

Recovered rows by subset:

- HSN: 4,813
- NBP: 19,645
- NES: 14,491
- PER: 15,079
- POW: 13,132
- SNE: 17,251
- SSW: 24,869
- UHH: 3,182
- XCM: 79,208

Total recovered: 191,670 rows. Dropped: 25,836 historical rows whose XC IDs are not present in current xeno-canto metadata.

## Validation
- uploaded all 9 regenerated CSV files to the existing `foundation-model-data` paths, next to the regenerated JSONL copies
- verified remote row counts for all uploaded CSV files
- verified remote NBP sample row has bucket-relative Xeno-canto audio paths
- `ALP_DATA_HOME=gs://esp-ml-datasets uv run python ... BirdSet(split="NBP-train", sample_rate=16000)` loads 19,645 rows and reads the first xeno-canto 16 kHz sample
- `ALP_DATA_HOME=gs://esp-ml-datasets uv run python ... BirdSet(split="NBP-test", sample_rate=16000)` loads 539 rows and reads the first BirdSet test sample
- `uv run ruff check alp_data/datasets/birdset.py`
- `uv run pytest tests/unittests/datasets_tests/test_birdset.py`