### PR TITLE
Add VFPA SRKW standard split to DCLDE2026

### DIFF
--- a/alp_data/datasets/dclde2026.py
+++ b/alp_data/datasets/dclde2026.py
@@ -62,7 +62,6 @@ PROVENANCE_COLUMNS = [
 ]
 
 _DCLDE_DATA_ROOT = f"{DATA_HOME}/dclde2026/v0.1.0/raw/2026/dclde_2026_killer_whales"
-_VFPA_CSV_ROOT = "gs://foundation-model-data/data/dclde2026/splits"
 
 
 @register_dataset
@@ -164,7 +163,7 @@ class DCLDE2026(Dataset):
         owner="david",
         split_paths={
             "all": f"{_DCLDE_DATA_ROOT}/processed_enriched_v2.csv",
-            "vfpa_srkw_standard": f"{_VFPA_CSV_ROOT}/vfpa_srkw_standard.csv",
+            "vfpa_srkw_standard": f"{_DCLDE_DATA_ROOT}/vfpa_srkw_standard.csv",
         },
         version="0.1.0",
         description="DCLDE 2026 killer whale dataset with species, ecotype, call type, "

--- a/alp_data/datasets/dclde2026.py
+++ b/alp_data/datasets/dclde2026.py
@@ -61,6 +61,11 @@ PROVENANCE_COLUMNS = [
     "provider",
 ]
 
+_DCLDE_DATA_ROOT = (
+    f"{DATA_HOME}/dclde2026/v0.1.0/raw/2026/dclde_2026_killer_whales"
+)
+_FOUNDATION_MODEL_DATA_ROOT = "gs://foundation-model-data/data"
+
 
 @register_dataset
 class DCLDE2026(Dataset):
@@ -93,6 +98,8 @@ class DCLDE2026(Dataset):
     Splits
     ---------
     - "all": All data (default)
+    - "vfpa_srkw_standard": VFPA SRKW standard S-call segments used for
+      vocal repertoire classification
 
     Available tasks
     ---------------
@@ -158,7 +165,10 @@ class DCLDE2026(Dataset):
         name="dclde2026",
         owner="david",
         split_paths={
-            "all": f"{DATA_HOME}/dclde2026/v0.1.0/raw/2026/dclde_2026_killer_whales/processed_enriched_v2.csv",  # noqa: E501
+            "all": f"{_DCLDE_DATA_ROOT}/processed_enriched_v2.csv",
+            "vfpa_srkw_standard": (
+                f"{_FOUNDATION_MODEL_DATA_ROOT}/dclde2026/splits/vfpa_srkw_standard.csv"
+            ),
         },
         version="0.1.0",
         description="DCLDE 2026 killer whale dataset with species, ecotype, call type, "
@@ -200,7 +210,7 @@ class DCLDE2026(Dataset):
             CSV; otherwise audio is resampled on-the-fly.
         data_root : str | AnyPathT | None
             Root directory containing provider audio subdirectories.
-            If None, defaults to the parent directory of the split CSV path.
+            If None, defaults to the DCLDE 2026 data root.
         backend : BackendType
             The backend to use ("pandas" or "polars"), by default "polars".
         streaming : bool
@@ -223,7 +233,7 @@ class DCLDE2026(Dataset):
         self._load()
 
         if self.data_root is None:
-            self.data_root = anypath(self.info.split_paths[self.split]).parent
+            self.data_root = anypath(_DCLDE_DATA_ROOT)
 
     @property
     def columns(self) -> list[str]:

--- a/alp_data/datasets/dclde2026.py
+++ b/alp_data/datasets/dclde2026.py
@@ -61,9 +61,7 @@ PROVENANCE_COLUMNS = [
     "provider",
 ]
 
-_DCLDE_DATA_ROOT = (
-    f"{DATA_HOME}/dclde2026/v0.1.0/raw/2026/dclde_2026_killer_whales"
-)
+_DCLDE_DATA_ROOT = f"{DATA_HOME}/dclde2026/v0.1.0/raw/2026/dclde_2026_killer_whales"
 _VFPA_CSV_ROOT = "gs://foundation-model-data/data/dclde2026/splits"
 
 

--- a/alp_data/datasets/dclde2026.py
+++ b/alp_data/datasets/dclde2026.py
@@ -64,7 +64,7 @@ PROVENANCE_COLUMNS = [
 _DCLDE_DATA_ROOT = (
     f"{DATA_HOME}/dclde2026/v0.1.0/raw/2026/dclde_2026_killer_whales"
 )
-_FOUNDATION_MODEL_DATA_ROOT = "gs://foundation-model-data/data"
+_VFPA_CSV_ROOT = "gs://foundation-model-data/data/dclde2026/splits"
 
 
 @register_dataset
@@ -166,9 +166,7 @@ class DCLDE2026(Dataset):
         owner="david",
         split_paths={
             "all": f"{_DCLDE_DATA_ROOT}/processed_enriched_v2.csv",
-            "vfpa_srkw_standard": (
-                f"{_FOUNDATION_MODEL_DATA_ROOT}/dclde2026/splits/vfpa_srkw_standard.csv"
-            ),
+            "vfpa_srkw_standard": f"{_VFPA_CSV_ROOT}/vfpa_srkw_standard.csv",
         },
         version="0.1.0",
         description="DCLDE 2026 killer whale dataset with species, ecotype, call type, "

--- a/tests/unittests/datasets_tests/test_dclde2026.py
+++ b/tests/unittests/datasets_tests/test_dclde2026.py
@@ -8,6 +8,7 @@ Run with:
 from __future__ import annotations
 
 import random
+from io import StringIO
 from typing import List
 
 import numpy as np
@@ -20,15 +21,20 @@ from alp_data.datasets.dclde2026 import (
     PROVENANCE_COLUMNS,
     SPECIES_LABELS,
 )
+from alp_data.io.filesystem import filesystem_from_path
 from alp_data.utils import create_hash
 
-
 EXPECTED_LEN_ALL = 9883
+EXPECTED_LEN_VFPA_SRKW_STANDARD = 1336
 EXPECTED_FIRST_ITEM_AUDIO_SHA256 = (
     "87cbf23a8a86233ca55c6263bed7c25bdf4cd61ec69c91b602bc90f8b74fad92"
 )
 ANNOTATIONS_SHA256 = "715975d12bf739e576239c06f267251f6936b1a2c3b08165d23efbd9fbc7b1ec"
+VFPA_SRKW_STANDARD_SHA256 = (
+    "97de2b0b18a661b08261fc758c5f12265c82dbbc120e76844732e21657166317"
+)
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(scope="module")
 def ds_pandas() -> DCLDE2026:
@@ -40,6 +46,18 @@ def ds_pandas() -> DCLDE2026:
         Dataset instance with pandas backend.
     """
     return DCLDE2026(split="all", sample_rate=16000, backend="pandas")
+
+
+@pytest.fixture(scope="module")
+def ds_vfpa_srkw_standard() -> DCLDE2026:
+    """Load DCLDE2026 VFPA SRKW standard split with pandas backend.
+
+    Returns
+    -------
+    DCLDE2026
+        Dataset instance for the VFPA SRKW standard call-type split.
+    """
+    return DCLDE2026(split="vfpa_srkw_standard", sample_rate=16000, backend="pandas")
 
 
 @pytest.fixture(scope="module")
@@ -81,8 +99,36 @@ def test_dataset_length_matches_expected(ds_pandas: DCLDE2026) -> None:
 
 def test_available_splits(ds_pandas: DCLDE2026) -> None:
     """Test if available_splits returns correct split names."""
-    expected_splits = ["all"]
+    expected_splits = ["all", "vfpa_srkw_standard"]
     assert all(split in ds_pandas.available_splits for split in expected_splits)
+
+
+def test_vfpa_srkw_standard_split(ds_vfpa_srkw_standard: DCLDE2026) -> None:
+    """VFPA SRKW standard split should match the traced custom dataset."""
+    assert len(ds_vfpa_srkw_standard) == EXPECTED_LEN_VFPA_SRKW_STANDARD
+
+    split_path = ds_vfpa_srkw_standard.info.split_paths["vfpa_srkw_standard"]
+    h = create_hash(filesystem_from_path(split_path).cat(split_path))
+    assert h == VFPA_SRKW_STANDARD_SHA256
+
+    df = ds_vfpa_srkw_standard._data.unwrap
+    assert set(df["provider"]) == {"JASCO_VFPA", "JASCO_VFPA_ONC"}
+    assert {"window_start_sec", "window_end_sec"}.issubset(df.columns)
+
+    selection_tables = [
+        pd.read_csv(StringIO(selection_table), sep="\t", keep_default_na=False)
+        for selection_table in df["selection_table"]
+    ]
+    call_types = pd.concat(selection_tables, ignore_index=True)["call_type"]
+    assert call_types.nunique() == 27
+    assert len(call_types) == EXPECTED_LEN_VFPA_SRKW_STANDARD
+
+    first_selection = selection_tables[0]
+    assert len(first_selection) == 1
+    assert first_selection["Begin Time (s)"].iloc[0] == 0
+    assert first_selection["End Time (s)"].iloc[0] == pytest.approx(
+        df["window_end_sec"].iloc[0] - df["window_start_sec"].iloc[0]
+    )
 
 
 def test_check_audio(ds_pandas: DCLDE2026, sample_indices: List[int]) -> None:


### PR DESCRIPTION
  ## Summary
  - Adds `vfpa_srkw_standard` split to `DCLDE2026`, used in "what matters" 
  - Points the split to `gs://foundation-model-data/data/dclde2026/splits/vfpa_srkw_standard.csv` but it can be copied in the standard data path
  - Uses `_VFPA_CSV_ROOT` to keep the DCLDE dataset code changes minimal
  - Keeps DCLDE audio resolution rooted at the existing DCLDE data location

  ## Validation
  - Recreated the split from the old `representation-learning` VFPA custom dataset semantics:
    - `JASCO_VFPA` + `JASCO_VFPA_ONC`
    - `SRKW`
    - 27 standard S-call labels
    - 1,336 event windows
  - Compared against the old `VFPAKillerWhales` loader:
    - all 1,336 `filename/start/end/call_type` signatures match
    - sampled audio outputs have matching lengths and near-identical waveforms
  - Ran:
    - `uv run ruff check --fix alp_data/datasets/dclde2026.py tests/unittests/datasets_tests/test_dclde2026.py`
    - `uv run pytest -q tests/unittests/datasets_tests/test_dclde2026.py -q`

