### PR TITLE
Add v0.2.0 (new dumps) to xeno-canto and iNaturalist via a version parameter

### DIFF
--- a/alp_data/datasets/inaturalist.py
+++ b/alp_data/datasets/inaturalist.py
@@ -7,7 +7,49 @@ import numpy as np
 
 from alp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
 from alp_data.backends import BackendType
+from alp_data.dataset import register_config
 from alp_data.io import DATA_HOME, AnyPathT, anypath, audio_stereo_to_mono, read_audio
+
+# Both versions keep their metadata under the v0.1.0 path, so data_root is shared
+# across versions (only the split CSVs differ).
+_RAW_ROOT = f"{DATA_HOME}/inaturalist/v0.1.0/raw"
+
+
+@register_config
+class INaturalistConfig(DatasetConfig):
+    """Configuration for the iNaturalist dataset.
+
+    Parameters
+    ----------
+    dataset_name : str
+        The name of the dataset. Must be "inaturalist".
+    split : str
+        The split to load. One of INaturalist.info.split_paths keys.
+    version : str | None
+        The version of the dataset to use. If None, uses DEFAULT_VERSION.
+        Available versions: "0.1.0", "0.2.0".
+    output_take_and_give : dict[str, str] | None
+        A dictionary mapping the original column names to the new column names.
+        It acts as a filter as well.
+    sample_rate : int | None
+        The sample rate to which audio files should be resampled.
+    data_root : str | AnyPathT | None
+        The root directory for the dataset. If None, uses the default for the
+        selected version.
+    backend : BackendType
+        The backend to use ("pandas" or "polars"), by default "polars".
+    streaming : bool
+        Whether to use streaming mode, by default False.
+    """
+
+    dataset_name: str = "inaturalist"
+    split: str = "train"
+    version: str | None = None
+    output_take_and_give: dict[str, str] | None = None
+    sample_rate: int | None = None
+    data_root: str | AnyPathT | None = None
+    backend: BackendType = "polars"
+    streaming: bool = False
 
 
 @register_dataset
@@ -23,7 +65,7 @@ class INaturalist(Dataset):
     following ESP's taxonomy app (GBIF backbone),
     including species scientific and common names, family, genus, order.
     There is additional metadata including location, date, and recordist information.
-    The current version 0.1.0 includes iNaturalist data up to Jun 2026 (20260616 dump).
+    Version 0.1.0 uses the 20260201 split; version 0.2.0 adds the Jun 2026 (20260616) dump.
 
     Available Metadata Fields
     -------------------------
@@ -114,21 +156,45 @@ class INaturalist(Dataset):
     >>> dataset_16k = INaturalist(split="train", sample_rate=16000, streaming=True)
     """
 
+    # Version registry with version-specific configurations. Both versions live
+    # under the v0.1.0 path, so only the split CSVs differ (data_root is shared).
+    VERSIONS = {
+        "0.1.0": {
+            "split_paths": {
+                "train": f"{_RAW_ROOT}/train_20260201_v3.csv",
+                "train_unseen": f"{_RAW_ROOT}/train_unseen_20260201_v3.csv",
+                "val": f"{_RAW_ROOT}/val_20260201_v3.csv",
+                "val_unseen": f"{_RAW_ROOT}/val_unseen_20260201_v3.csv",
+                "all": f"{_RAW_ROOT}/all_20260201_v3.csv",
+                "all_unseen": f"{_RAW_ROOT}/all_unseen_20260201_v3.csv",
+            },
+            "data_root": f"{_RAW_ROOT}/",
+        },
+        "0.2.0": {
+            "split_paths": {
+                "train": f"{_RAW_ROOT}/train_20260616_v1.csv",
+                "train_unseen": f"{_RAW_ROOT}/train_unseen_20260616_v1.csv",
+                "val": f"{_RAW_ROOT}/val_20260616_v1.csv",
+                "val_unseen": f"{_RAW_ROOT}/val_unseen_20260616_v1.csv",
+                "all": f"{_RAW_ROOT}/all_20260616_v1.csv",
+                "all_unseen": f"{_RAW_ROOT}/all_unseen_20260616_v1.csv",
+            },
+            "data_root": f"{_RAW_ROOT}/",
+        },
+    }
+
+    # Default version (0.1.0 for backward compatibility).
+    DEFAULT_VERSION = "0.1.0"
+
     info = DatasetInfo(
         name="inaturalist",
         owner="gagan; david",
-        split_paths={
-            "train": f"{DATA_HOME}/inaturalist/v0.1.0/raw/train_20260616_v1.csv",
-            "train_unseen": f"{DATA_HOME}/inaturalist/v0.1.0/raw/train_unseen_20260616_v1.csv",
-            "val": f"{DATA_HOME}/inaturalist/v0.1.0/raw/val_20260616_v1.csv",
-            "val_unseen": f"{DATA_HOME}/inaturalist/v0.1.0/raw/val_unseen_20260616_v1.csv",
-            "all": f"{DATA_HOME}/inaturalist/v0.1.0/raw/all_20260616_v1.csv",
-            "all_unseen": f"{DATA_HOME}/inaturalist/v0.1.0/raw/all_unseen_20260616_v1.csv",
-        },
+        split_paths={},  # Populated per version in __init__.
         version="0.1.0",
         description="iNaturalist audio dataset with taxonomic metadata. "
         "Available at original (variable) sample rates and 32kHz (pre-resampled). "
-        "Pre-resampled audio uses librosa's kaiser_best resampling method.",
+        "Pre-resampled audio uses librosa's kaiser_best resampling method. "
+        "v0.1.0 uses the 20260201 split; v0.2.0 uses the Jun 2026 (20260616) dump.",
         sources=["iNaturalist"],
         license="CC BY-NC 4.0, CC BY 4.0, CC0 1.0",
     )
@@ -145,6 +211,7 @@ class INaturalist(Dataset):
     def __init__(
         self,
         split: str = "train",
+        version: str | None = None,
         output_take_and_give: dict[str, str] = None,
         sample_rate: int | None = None,
         data_root: str | AnyPathT | None = None,
@@ -157,6 +224,9 @@ class INaturalist(Dataset):
         ----------
         split : str, default="train"
             The split to load. One of info.split_paths keys.
+        version : str, optional
+            The version of the dataset to use. If None, uses DEFAULT_VERSION.
+            Available versions: "0.1.0" (20260201 split), "0.2.0" (20260616 dump).
         output_take_and_give : dict[str, str], optional
             A dictionary mapping the original column names to the new column names.
         sample_rate : int, optional
@@ -174,17 +244,38 @@ class INaturalist(Dataset):
             The backend to use ("pandas" or "polars"), by default "polars"
         streaming : bool, optional
             Whether to use streaming mode, by default False
+
+        Raises
+        ------
+        ValueError
+            If the specified version is not available.
         """
         super().__init__(output_take_and_give, backend=backend, streaming=streaming)
+        # Copy class-level DatasetInfo to avoid cross-instance mutation (versions/splits).
+        self.info = self.info.model_copy(deep=True)
+
+        # Handle version selection.
+        if version is None:
+            version = self.DEFAULT_VERSION
+        if version not in self.VERSIONS:
+            raise ValueError(
+                f"Version '{version}' is not available. "
+                f"Available versions: {list(self.VERSIONS.keys())}"
+            )
+        self.version = version
+        self.version_config = self.VERSIONS[version]
+        self.info.split_paths = self.version_config["split_paths"]
+        self.info.version = version
+
         self.split = split
         self._data = None
         self._load()
         self.sample_rate = sample_rate
 
         if data_root is None:
-            self.data_root = anypath(f"{DATA_HOME}/inaturalist/v0.1.0/raw/")
+            self.data_root = anypath(self.version_config["data_root"])
         else:
-            self.data_root = data_root
+            self.data_root = anypath(data_root)
 
     @property
     def columns(self) -> list[str]:
@@ -233,12 +324,12 @@ class INaturalist(Dataset):
         self._data = self._backend_class.from_csv(location, streaming=self._streaming)
 
     @classmethod
-    def from_config(cls, dataset_config: DatasetConfig) -> tuple["INaturalist", dict[str, Any]]:
+    def from_config(cls, dataset_config: INaturalistConfig) -> tuple["INaturalist", dict[str, Any]]:
         """Create a Dataset instance from a configuration dictionary.
 
         Parameters
         ----------
-        dataset_config : DatasetConfig
+        dataset_config : INaturalistConfig
             Configuration dictionary containing dataset parameters.
 
         Returns
@@ -252,6 +343,7 @@ class INaturalist(Dataset):
 
         ds = cls(
             split=cfg["split"],
+            version=cfg.get("version"),
             output_take_and_give=cfg["output_take_and_give"],
             data_root=cfg["data_root"],
             sample_rate=cfg["sample_rate"],
@@ -381,12 +473,13 @@ class INaturalist(Dataset):
             A string representation of the dataset including its name, version,
             and basic statistics if data is loaded.
         """
-        base_info = f"{self.info.name} (v{self.info.version})"
+        base_info = f"{self.info.name} (v{self.version})"
 
         return (
             f"{base_info}\n"
             f"Description: {self.info.description}\n"
             f"Sources: {', '.join(self.info.sources)}\n"
             f"License: {self.info.license}\n"
+            f"Available versions: {', '.join(self.VERSIONS.keys())}\n"
             f"Available splits: {', '.join(self.info.split_paths.keys())}"
         )

--- a/alp_data/datasets/inaturalist.py
+++ b/alp_data/datasets/inaturalist.py
@@ -23,7 +23,7 @@ class INaturalist(Dataset):
     following ESP's taxonomy app (GBIF backbone),
     including species scientific and common names, family, genus, order.
     There is additional metadata including location, date, and recordist information.
-    The current version 0.1.0 includes iNaturalist data up to July 2025.
+    The current version 0.1.0 includes iNaturalist data up to Jun 2026 (20260616 dump).
 
     Available Metadata Fields
     -------------------------
@@ -118,12 +118,12 @@ class INaturalist(Dataset):
         name="inaturalist",
         owner="gagan; david",
         split_paths={
-            "train": f"{DATA_HOME}/inaturalist/v0.1.0/raw/train_20260201_v3.csv",
-            "train_unseen": f"{DATA_HOME}/inaturalist/v0.1.0/raw/train_unseen_20260201_v3.csv",
-            "val": f"{DATA_HOME}/inaturalist/v0.1.0/raw/val_20260201_v3.csv",
-            "val_unseen": f"{DATA_HOME}/inaturalist/v0.1.0/raw/val_unseen_20260201_v3.csv",
-            "all": f"{DATA_HOME}/inaturalist/v0.1.0/raw/all_20260201_v3.csv",
-            "all_unseen": f"{DATA_HOME}/inaturalist/v0.1.0/raw/all_unseen_20260201_v3.csv",
+            "train": f"{DATA_HOME}/inaturalist/v0.1.0/raw/train_20260616_v1.csv",
+            "train_unseen": f"{DATA_HOME}/inaturalist/v0.1.0/raw/train_unseen_20260616_v1.csv",
+            "val": f"{DATA_HOME}/inaturalist/v0.1.0/raw/val_20260616_v1.csv",
+            "val_unseen": f"{DATA_HOME}/inaturalist/v0.1.0/raw/val_unseen_20260616_v1.csv",
+            "all": f"{DATA_HOME}/inaturalist/v0.1.0/raw/all_20260616_v1.csv",
+            "all_unseen": f"{DATA_HOME}/inaturalist/v0.1.0/raw/all_unseen_20260616_v1.csv",
         },
         version="0.1.0",
         description="iNaturalist audio dataset with taxonomic metadata. "

--- a/alp_data/datasets/xeno_canto.py
+++ b/alp_data/datasets/xeno_canto.py
@@ -92,6 +92,8 @@ class XenoCanto(Dataset):
         - ``behavior``: Behavior being recorded (e.g., "calling song")
         - ``sex``: Sex of the recorded animal(s)
         - ``lifeStage``: Life stage (e.g., "adult")
+        - ``quality``: Xeno-canto recording quality rating from ``A`` (highest) to
+          ``E`` (lowest), or ``"no score"`` when the recording is unrated
         - ``recordedBy``: Name of the recordist
 
     **Location:**

--- a/alp_data/datasets/xeno_canto.py
+++ b/alp_data/datasets/xeno_canto.py
@@ -94,6 +94,8 @@ class XenoCanto(Dataset):
         - ``lifeStage``: Life stage (e.g., "adult")
         - ``quality``: Xeno-canto recording quality rating from ``A`` (highest) to
           ``E`` (lowest), or ``"no score"`` when the recording is unrated
+        - ``playback_used``: Whether playback was used to attract the animal during
+          recording (``yes`` / ``no`` / ``unknown``)
         - ``recordedBy``: Name of the recordist
 
     **Location:**

--- a/alp_data/datasets/xeno_canto.py
+++ b/alp_data/datasets/xeno_canto.py
@@ -7,7 +7,49 @@ import numpy as np
 
 from alp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
 from alp_data.backends import BackendType
+from alp_data.dataset import register_config
 from alp_data.io import DATA_HOME, AnyPathT, anypath, audio_stereo_to_mono, read_audio
+
+# Both versions keep their metadata under the v0.1.0 path, so data_root is shared
+# across versions (only the split CSVs differ).
+_RAW_ROOT = f"{DATA_HOME}/xeno-canto/v0.1.0/raw"
+
+
+@register_config
+class XenoCantoConfig(DatasetConfig):
+    """Configuration for the Xeno-canto dataset.
+
+    Parameters
+    ----------
+    dataset_name : str
+        The name of the dataset. Must be "xeno-canto".
+    split : str
+        The split to load. One of XenoCanto.info.split_paths keys.
+    version : str | None
+        The version of the dataset to use. If None, uses DEFAULT_VERSION.
+        Available versions: "0.1.0", "0.2.0".
+    output_take_and_give : dict[str, str] | None
+        A dictionary mapping the original column names to the new column names.
+        It acts as a filter as well.
+    sample_rate : int | None
+        The sample rate to which audio files should be resampled.
+    data_root : str | AnyPathT | None
+        The root directory for the dataset. If None, uses the default for the
+        selected version.
+    backend : BackendType
+        The backend to use ("pandas" or "polars"), by default "polars".
+    streaming : bool
+        Whether to use streaming mode, by default False.
+    """
+
+    dataset_name: str = "xeno-canto"
+    split: str = "train"
+    version: str | None = None
+    output_take_and_give: dict[str, str] | None = None
+    sample_rate: int | None = None
+    data_root: str | AnyPathT | None = None
+    backend: BackendType = "polars"
+    streaming: bool = False
 
 
 @register_dataset
@@ -115,22 +157,45 @@ class XenoCanto(Dataset):
     >>> dataset_16k = XenoCanto(split="train", sample_rate=16000, streaming=True)
     """
 
+    # Version registry with version-specific configurations. Both versions live
+    # under the v0.1.0 path, so only the split CSVs differ (data_root is shared).
+    VERSIONS = {
+        "0.1.0": {
+            "split_paths": {
+                "train": f"{_RAW_ROOT}/train_20260203_v2.csv",
+                "validation": f"{_RAW_ROOT}/val_20260203_v2.csv",
+                "all": f"{_RAW_ROOT}/all_20260203_v2.csv",
+                "train_unseen": f"{_RAW_ROOT}/train_unseen_20260203_v2.csv",
+                "validation_unseen": f"{_RAW_ROOT}/val_unseen_20260203_v2.csv",
+                "all_unseen": f"{_RAW_ROOT}/all_unseen_20260203_v2.csv",
+            },
+            "data_root": f"{_RAW_ROOT}/",
+        },
+        "0.2.0": {
+            "split_paths": {
+                "train": f"{_RAW_ROOT}/train_20260622_v1.csv",
+                "validation": f"{_RAW_ROOT}/val_20260622_v1.csv",
+                "all": f"{_RAW_ROOT}/all_20260622_v1.csv",
+                "train_unseen": f"{_RAW_ROOT}/train_unseen_20260622_v1.csv",
+                "validation_unseen": f"{_RAW_ROOT}/val_unseen_20260622_v1.csv",
+                "all_unseen": f"{_RAW_ROOT}/all_unseen_20260622_v1.csv",
+            },
+            "data_root": f"{_RAW_ROOT}/",
+        },
+    }
+
+    # Default version (0.1.0 for backward compatibility).
+    DEFAULT_VERSION = "0.1.0"
+
     info = DatasetInfo(
         name="xeno-canto",
         owner="david; gagan",
-        split_paths={
-            "train": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/train_20260622_v1.csv",
-            "validation": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/val_20260622_v1.csv",
-            "all": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/all_20260622_v1.csv",
-            "train_unseen": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/train_unseen_20260622_v1.csv",
-            "validation_unseen": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/val_unseen_20260622_v1.csv",
-            "all_unseen": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/all_unseen_20260622_v1.csv",
-        },
+        split_paths={},  # Populated per version in __init__.
         version="0.1.0",
         description="Xeno-canto audio dataset with taxonomic metadata. "
         "Available at original (variable) sample rates and 32kHz (pre-resampled). "
         "Pre-resampled audio uses librosa's kaiser_best resampling method. "
-        "Xeno-canto dump as of Jun 2026 (20260622). "
+        "v0.1.0 uses the 20260203 split; v0.2.0 uses the Jun 2026 (20260622) dump. "
         "Train/val split is 90%/10% with random seed 42.",
         sources=["Xeno-canto"],
         license="CC BY-NC-SA 4.0, CC BY-NC 4.0, CC BY-SA, CC0",
@@ -148,6 +213,7 @@ class XenoCanto(Dataset):
     def __init__(
         self,
         split: str = "train",
+        version: str | None = None,
         output_take_and_give: dict[str, str] = None,
         sample_rate: int | None = None,
         data_root: str | AnyPathT | None = None,
@@ -160,6 +226,9 @@ class XenoCanto(Dataset):
         ----------
         split : str, default="train"
             The split to load. One of info.split_paths keys.
+        version : str, optional
+            The version of the dataset to use. If None, uses DEFAULT_VERSION.
+            Available versions: "0.1.0" (20260203 split), "0.2.0" (20260622 dump).
         output_take_and_give : dict[str, str], optional
             A dictionary mapping the original column names to the new column names.
         sample_rate : int, optional
@@ -177,17 +246,38 @@ class XenoCanto(Dataset):
             The backend to use ("pandas" or "polars"), by default "polars"
         streaming : bool, optional
             Whether to use streaming mode, by default False
+
+        Raises
+        ------
+        ValueError
+            If the specified version is not available.
         """
         super().__init__(output_take_and_give, backend=backend, streaming=streaming)
+        # Copy class-level DatasetInfo to avoid cross-instance mutation (versions/splits).
+        self.info = self.info.model_copy(deep=True)
+
+        # Handle version selection.
+        if version is None:
+            version = self.DEFAULT_VERSION
+        if version not in self.VERSIONS:
+            raise ValueError(
+                f"Version '{version}' is not available. "
+                f"Available versions: {list(self.VERSIONS.keys())}"
+            )
+        self.version = version
+        self.version_config = self.VERSIONS[version]
+        self.info.split_paths = self.version_config["split_paths"]
+        self.info.version = version
+
         self.split = split
         self._data = None
         self._load()
         self.sample_rate = sample_rate
 
         if data_root is None:
-            self.data_root = anypath(f"{DATA_HOME}/xeno-canto/v0.1.0/raw/")
-            self._data_root_32k = anypath(f"{DATA_HOME}/xeno-canto/v0.1.0/raw/audio_32k/")
-            self._data_root_16k = anypath(f"{DATA_HOME}/xeno-canto/v0.1.0/raw/audio_16k/")
+            self.data_root = anypath(self.version_config["data_root"])
+            self._data_root_32k = anypath(f"{_RAW_ROOT}/audio_32k/")
+            self._data_root_16k = anypath(f"{_RAW_ROOT}/audio_16k/")
         else:
             self.data_root = anypath(data_root)
             self._data_root_32k = anypath(data_root)
@@ -240,12 +330,12 @@ class XenoCanto(Dataset):
         self._data = self._backend_class.from_csv(location, streaming=self._streaming)
 
     @classmethod
-    def from_config(cls, dataset_config: DatasetConfig) -> tuple["XenoCanto", dict[str, Any]]:
+    def from_config(cls, dataset_config: XenoCantoConfig) -> tuple["XenoCanto", dict[str, Any]]:
         """Create a Dataset instance from a configuration dictionary.
 
         Parameters
         ----------
-        dataset_config : DatasetConfig
+        dataset_config : XenoCantoConfig
             Configuration dictionary containing dataset parameters.
 
         Returns
@@ -259,6 +349,7 @@ class XenoCanto(Dataset):
 
         ds = cls(
             split=cfg["split"],
+            version=cfg.get("version"),
             output_take_and_give=cfg["output_take_and_give"],
             data_root=cfg["data_root"],
             sample_rate=cfg["sample_rate"],
@@ -396,12 +487,13 @@ class XenoCanto(Dataset):
             A string representation of the dataset including its name, version,
             and basic statistics if data is loaded.
         """
-        base_info = f"{self.info.name} (v{self.info.version})"
+        base_info = f"{self.info.name} (v{self.version})"
 
         return (
             f"{base_info}\n"
             f"Description: {self.info.description}\n"
             f"Sources: {', '.join(self.info.sources)}\n"
             f"License: {self.info.license}\n"
+            f"Available versions: {', '.join(self.VERSIONS.keys())}\n"
             f"Available splits: {', '.join(self.info.split_paths.keys())}"
         )

--- a/alp_data/datasets/xeno_canto.py
+++ b/alp_data/datasets/xeno_canto.py
@@ -119,18 +119,18 @@ class XenoCanto(Dataset):
         name="xeno-canto",
         owner="david; gagan",
         split_paths={
-            "train": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/train_20260203_v2.csv",
-            "validation": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/val_20260203_v2.csv",
-            "all": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/all_20260203_v2.csv",
-            "train_unseen": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/train_unseen_20260203_v2.csv",
-            "validation_unseen": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/val_unseen_20260203_v2.csv",
-            "all_unseen": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/all_unseen_20260203_v2.csv",
+            "train": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/train_20260622_v1.csv",
+            "validation": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/val_20260622_v1.csv",
+            "all": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/all_20260622_v1.csv",
+            "train_unseen": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/train_unseen_20260622_v1.csv",
+            "validation_unseen": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/val_unseen_20260622_v1.csv",
+            "all_unseen": f"{DATA_HOME}/xeno-canto/v0.1.0/raw/all_unseen_20260622_v1.csv",
         },
         version="0.1.0",
         description="Xeno-canto audio dataset with taxonomic metadata. "
         "Available at original (variable) sample rates and 32kHz (pre-resampled). "
         "Pre-resampled audio uses librosa's kaiser_best resampling method. "
-        "Xeno-canto dump as of Oct 2025. "
+        "Xeno-canto dump as of Jun 2026 (20260622). "
         "Train/val split is 90%/10% with random seed 42.",
         sources=["Xeno-canto"],
         license="CC BY-NC-SA 4.0, CC BY-NC 4.0, CC BY-SA, CC0",


### PR DESCRIPTION
## What

Adds an audioset-style `version` parameter to the Xeno-canto and iNaturalist datasets so the new dumps are available **without dropping access to the existing data**.

- **`0.1.0`** (default) — the existing splits (`*_20260203_v2` / `*_20260201_v3`). Behaviour is unchanged for existing callers.
- **`0.2.0`** — the new Jun 2026 dumps (Xeno-canto `20260622`, iNaturalist `20260616`), filtered and normalized (see below).

Implemented the same way as `AudioSet`: a `VERSIONS` registry, a registered `XenoCantoConfig` / `INaturalistConfig` carrying `version`, and version selection in `__init__` / `from_config`. Both versions keep their metadata under the `v0.1.0/raw/` path, so `data_root` is shared and **no `_process` changes are needed**.

```python
XenoCanto(split="all")                     # -> 0.1.0 (existing data)
XenoCanto(split="all", version="0.2.0")    # -> new dump
```

Docs also gain two Xeno-canto metadata fields present in the new dump: `quality` (A–E / "no score") and `playback_used` (yes/no/unknown).

## How 0.2.0 was prepared (offline, data-only)

The `0.2.0` split CSVs are filtered/normalized copies of the raw dumps (`*_v1.csv`):
- rows missing a 32 kHz path are dropped
- rows that did not link to the GBIF backbone (`gbif_link_ok == False`) are dropped — for Xeno-canto this removes ~26.5k "Mystery"/soundscape/synonym recordings that carry no taxonomic class; iNaturalist has none
- iNaturalist's absolute, mixed-bucket (`esp-data-ingestion` / `esp-ml-datasets`) 32 kHz/16 kHz paths are normalized to paths relative to the raw root, so the loader resolves them against a single `data_root` with no read-time path handling
- Xeno-canto's `playback_used` column (added upstream after this snapshot was cut) is joined in by `xc_id` from the undated `all.csv` — 100% coverage of the snapshot's rows

They are staged as `*_v1.csv` in `esp-data-ingestion` and need to be copied into `DATA_HOME`.

## Copy job (only needed for v0.2.0)

`0.1.0` already resolves against data present in `DATA_HOME`, so the default path works today. `0.2.0` needs the following into `DATA_HOME` (`esp-data-274503`):

**CSVs:**
```
gsutil -m cp "gs://esp-data-ingestion/xeno-canto/v0.1.0/raw/*_20260622_v1.csv"  gs://esp-data-274503/xeno-canto/v0.1.0/raw/
gsutil -m cp "gs://esp-data-ingestion/inaturalist/v0.1.0/raw/*_20260616_v1.csv" gs://esp-data-274503/inaturalist/v0.1.0/raw/
```

**Audio (raw / 16k / 32k):**
```
# xeno-canto
gsutil -m rsync -r gs://esp-data-ingestion/xeno-canto/v0.1.0/raw/audio/     gs://esp-data-274503/xeno-canto/v0.1.0/raw/audio/
gsutil -m rsync -r gs://esp-data-ingestion/xeno-canto/v0.1.0/raw/audio_16k/ gs://esp-data-274503/xeno-canto/v0.1.0/raw/audio_16k/
gsutil -m rsync -r gs://esp-data-ingestion/xeno-canto/v0.1.0/raw/audio_32k/ gs://esp-data-274503/xeno-canto/v0.1.0/raw/audio_32k/

# iNaturalist (note: older 32k audio lives under audio_32khz/, not audio_32k/)
gsutil -m rsync -r gs://esp-data-ingestion/inaturalist/v0.1.0/raw/audio/     gs://esp-data-274503/inaturalist/v0.1.0/raw/audio/
gsutil -m rsync -r gs://esp-data-ingestion/inaturalist/v0.1.0/raw/audio_16k/ gs://esp-data-274503/inaturalist/v0.1.0/raw/audio_16k/
gsutil -m rsync -r gs://esp-data-ingestion/inaturalist/v0.1.0/raw/audio_32k/ gs://esp-data-274503/inaturalist/v0.1.0/raw/audio_32k/
gsutil -m rsync -r gs://esp-ml-datasets/inaturalist/v0.1.0/raw/audio_32khz/  gs://esp-data-274503/inaturalist/v0.1.0/raw/audio_32khz/
```

## Delta 0.1.0 -> 0.2.0 (`all` split, after filters)

**Xeno-canto:** 596,526 -> 744,242 rows (+24.8%); 10,799 -> 11,748 species. New `playback_used` breakdown on the 0.2.0 `all` split: no 628,936 / unknown 76,906 / yes 38,360.

| class | rows (old->new) | species (old->new) |
|---|---|---|
| Aves (birds) | 588,141 -> 700,638 | 9,733 -> 9,891 (+158) |
| Insecta | 5,035 -> 33,792 | 423 -> 1,008 (+585) |
| Amphibia | 1,836 -> 3,388 | 508 -> 679 (+171) |
| Mammalia | 1,514 -> 6,424 | 135 -> 170 (+35) |

**iNaturalist:** 709,217 -> 785,629 rows (+10.8%); 9,168 -> 9,465 species (birds +161, amphibians +37, insects +50, mammals +30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)