### PR TITLE
Fix -rw_timeout placement; downscope GCS tokens to per-bucket read-only

### DIFF
--- a/alp_data/io/auth.py
+++ b/alp_data/io/auth.py
@@ -3,19 +3,19 @@
 Provides access-token retrieval for authenticating GCS REST/HTTP requests
 (e.g. the ffmpeg range-read path in `alp_data.io.read_utils`).
 
-Tokens handed out by this module are *downscoped* via a GCP Credential Access
-Boundary: each token is only valid for read-only access
-(`roles/storage.objectViewer`) to the single bucket it was requested for, and
-is rejected by every other GCP service and bucket. This limits the blast
-radius when a token leaves the process (e.g. on the ffmpeg command line,
-where it is visible to co-tenants via `ps` on shared hosts): a leaked token
-grants at most short-lived read access to the one bucket that was already
-being read.
+Tokens are *downscoped* through a GCP Credential Access Boundary: each token
+only grants read-only access (`roles/storage.objectViewer`) to the single
+bucket it was requested for. This limits the blast radius when a token leaves
+the process (e.g. on the ffmpeg command line, visible via `ps` on shared
+hosts): a leaked token gives at most short-lived read access to the one
+bucket that was already being read. The full-identity source credentials
+never leave the process.
 
-Source credentials are cached at module level so the Application Default
-Credentials lookup happens once per session; downscoped credentials are
-cached per bucket and refreshed (a token exchange with the GCP STS endpoint)
-only when they expire.
+Caching: the source credentials are resolved once per session; downscoped
+credentials are cached per bucket and re-exchanged (one STS call) only on
+expiry. A session with no ambient credentials at all is remembered as
+credential-less; other auth failures back off for
+`_AUTH_RETRY_BACKOFF_SECONDS` before re-attempting.
 """
 
 import logging
@@ -27,23 +27,18 @@ from google.auth.transport.requests import Request
 
 logger = logging.getLogger("alp_data")
 
-# Module-level cache of the source (full-identity) Google credentials.
-# Reused across calls so the ADC lookup only happens once per session. The
-# source credentials never leave the process; only downscoped tokens do.
+# Full-identity source credentials, resolved once per session.
 _source_credentials = None
 
-# Per-bucket cache of downscoped credentials. Each entry is refreshed
-# independently when its token expires.
+# Downscoped credentials, cached per bucket.
 _downscoped_credentials_by_bucket: dict[str, downscoped.Credentials] = {}
 
-# A way to tell if a client is authenticated: Application Default
-# Credentials lookup fails, we stop re-attempting it (it is relatively expensive)
-# and treat the environment as credential-less for the rest of the session.
+# Sticky verdict for a session with no ambient credentials at all (the ADC
+# lookup is relatively expensive, so it is not re-attempted).
 _gcs_credentials_unavailable = False
 
-# Backoff for failures with otherwise-present credentials (e.g. a network blip
-# or blocked STS endpoint during refresh/exchange): skip re-attempts until this
-# monotonic deadline, so hot read loops don't pay a failed network call per read.
+# Deadline (monotonic) before which failed refresh/exchange attempts are not
+# retried, so hot read loops don't pay a failed network call per read.
 _AUTH_RETRY_BACKOFF_SECONDS = 60.0
 _auth_failure_backoff_until = 0.0
 
@@ -53,7 +48,7 @@ class GCSAuthError(Exception):
 
 
 def _bucket_access_boundary(bucket: str) -> downscoped.CredentialAccessBoundary:
-    """Build a read-only Credential Access Boundary for a single bucket.
+    """Build a boundary granting `roles/storage.objectViewer` on `bucket` only.
 
     Parameters
     ----------
@@ -63,7 +58,7 @@ def _bucket_access_boundary(bucket: str) -> downscoped.CredentialAccessBoundary:
     Returns
     -------
     downscoped.CredentialAccessBoundary
-        A boundary granting `roles/storage.objectViewer` on `bucket` only.
+        The single-bucket, read-only access boundary.
     """
     return downscoped.CredentialAccessBoundary(
         rules=[
@@ -79,11 +74,7 @@ def get_gcs_token(bucket: str) -> str:
     """Fetch a valid access token downscoped to read-only access on `bucket`.
 
     Relies on the caller having authenticated with GCP, e.g. via
-    `gcloud auth application-default login` or a service account. The ambient
-    credentials are exchanged (via the GCP STS endpoint) for a token that is
-    only valid for `roles/storage.objectViewer` on the given bucket, so the
-    returned token can safely be passed to subprocesses. Source credentials
-    and per-bucket downscoped credentials are cached at module level.
+    `gcloud auth application-default login` or a service account.
 
     Parameters
     ----------
@@ -112,8 +103,6 @@ def get_gcs_token(bucket: str) -> str:
             )
             _downscoped_credentials_by_bucket[bucket] = credentials
         if not credentials.valid:
-            # Refreshes the source credentials if needed, then re-runs the
-            # STS token exchange for this bucket's boundary.
             credentials.refresh(Request())
         return credentials.token
     except Exception as e:
@@ -127,23 +116,16 @@ def get_gcs_token(bucket: str) -> str:
 def get_gcs_token_if_available(bucket: str) -> str | None:
     """Return a bucket-scoped GCS token if ambient credentials exist, else None.
 
-    A valid token works for both public and private buckets,
-    so we send one whenever credentials are
-    available and fall back to anonymous access only when they are not.
+    A valid token works for both public and private buckets, so we send one
+    whenever credentials are available and fall back to anonymous access only
+    when they are not. Only a failed ADC lookup (no ambient credentials at
+    all) is remembered for the session; other failures back off for
+    `_AUTH_RETRY_BACKOFF_SECONDS` and are then re-attempted.
 
     Parameters
     ----------
     bucket : str
         Name of the GCS bucket the token must grant read access to.
-
-    The credential-less verdict is only cached (sticky for the session) when
-    Application Default Credentials discovery itself fails — i.e. the
-    environment has no ambient credentials. A failure while refreshing or
-    downscoping an otherwise-working credential (e.g. a network blip or a
-    blocked STS endpoint) returns None and pauses re-attempts for
-    `_AUTH_RETRY_BACKOFF_SECONDS`, so transient errors recover quickly while
-    persistent ones cost one failed network call per backoff window instead
-    of one per read.
 
     Returns
     -------

--- a/alp_data/io/auth.py
+++ b/alp_data/io/auth.py
@@ -1,22 +1,39 @@
 """Google Cloud Storage authentication helpers.
 
 Provides access-token retrieval for authenticating GCS REST/HTTP requests
-(e.g. the ffmpeg range-read path in `alp_data.io.read_utils`). Credentials are
-cached at module level so a token is only fetched once per session and
-refreshed when it expires.
+(e.g. the ffmpeg range-read path in `alp_data.io.read_utils`).
+
+Tokens handed out by this module are *downscoped* via a GCP Credential Access
+Boundary: each token is only valid for read-only access
+(`roles/storage.objectViewer`) to the single bucket it was requested for, and
+is rejected by every other GCP service and bucket. This limits the blast
+radius when a token leaves the process (e.g. on the ffmpeg command line,
+where it is visible to co-tenants via `ps` on shared hosts): a leaked token
+grants at most short-lived read access to the one bucket that was already
+being read.
+
+Source credentials are cached at module level so the Application Default
+Credentials lookup happens once per session; downscoped credentials are
+cached per bucket and refreshed (a token exchange with the GCP STS endpoint)
+only when they expire.
 """
 
 import logging
 
 import google.auth
+from google.auth import downscoped
 from google.auth.transport.requests import Request
 
 logger = logging.getLogger("alp_data")
 
-# Module-level cache of Google credentials.
-# Reused across calls so the token is
-# only refreshed once per session (and again whenever it expires).
-_gcs_credentials = None
+# Module-level cache of the source (full-identity) Google credentials.
+# Reused across calls so the ADC lookup only happens once per session. The
+# source credentials never leave the process; only downscoped tokens do.
+_source_credentials = None
+
+# Per-bucket cache of downscoped credentials. Each entry is refreshed
+# independently when its token expires.
+_downscoped_credentials_by_bucket: dict[str, downscoped.Credentials] = {}
 
 # A way to tell if a client is authenticated: Application Default
 # Credentials lookup fails, we stop re-attempting it (it is relatively expensive)
@@ -28,30 +45,70 @@ class GCSAuthError(Exception):
     """Raised when Google Cloud credentials cannot be obtained or refreshed."""
 
 
-def get_gcs_token() -> str:
-    """Fetch a valid access token using Google Application Default Credentials.
+def _bucket_access_boundary(bucket: str) -> downscoped.CredentialAccessBoundary:
+    """Build a read-only Credential Access Boundary for a single bucket.
+
+    Parameters
+    ----------
+    bucket : str
+        Name of the GCS bucket the boundary should grant access to.
+
+    Returns
+    -------
+    downscoped.CredentialAccessBoundary
+        A boundary granting `roles/storage.objectViewer` on `bucket` only.
+    """
+    return downscoped.CredentialAccessBoundary(
+        rules=[
+            downscoped.AccessBoundaryRule(
+                available_resource=f"//storage.googleapis.com/projects/_/buckets/{bucket}",
+                available_permissions=["inRole:roles/storage.objectViewer"],
+            )
+        ]
+    )
+
+
+def get_gcs_token(bucket: str) -> str:
+    """Fetch a valid access token downscoped to read-only access on `bucket`.
 
     Relies on the caller having authenticated with GCP, e.g. via
-    `gcloud auth application-default login` or a service account. The
-    credentials are cached in _gcs_credentials.
+    `gcloud auth application-default login` or a service account. The ambient
+    credentials are exchanged (via the GCP STS endpoint) for a token that is
+    only valid for `roles/storage.objectViewer` on the given bucket, so the
+    returned token can safely be passed to subprocesses. Source credentials
+    and per-bucket downscoped credentials are cached at module level.
+
+    Parameters
+    ----------
+    bucket : str
+        Name of the GCS bucket the token must grant read access to.
 
     Returns
     -------
     str
-        A valid access token for authenticating requests to Google Cloud.
+        A valid access token restricted to read-only access on `bucket`.
 
     Raises
     ------
     GCSAuthError
-        If credentials cannot be obtained or refreshed.
+        If credentials cannot be obtained, downscoped, or refreshed.
     """
-    global _gcs_credentials
+    global _source_credentials
     try:
-        if _gcs_credentials is None:
-            _gcs_credentials, _ = google.auth.default()
-        if not _gcs_credentials.valid:
-            _gcs_credentials.refresh(Request())
-        return _gcs_credentials.token
+        if _source_credentials is None:
+            _source_credentials, _ = google.auth.default()
+        credentials = _downscoped_credentials_by_bucket.get(bucket)
+        if credentials is None:
+            credentials = downscoped.Credentials(
+                source_credentials=_source_credentials,
+                credential_access_boundary=_bucket_access_boundary(bucket),
+            )
+            _downscoped_credentials_by_bucket[bucket] = credentials
+        if not credentials.valid:
+            # Refreshes the source credentials if needed, then re-runs the
+            # STS token exchange for this bucket's boundary.
+            credentials.refresh(Request())
+        return credentials.token
     except Exception as e:
         raise GCSAuthError(
             f"Error authenticating with Google Cloud: {e}.\n"
@@ -60,23 +117,29 @@ def get_gcs_token() -> str:
         ) from e
 
 
-def get_gcs_token_if_available() -> str | None:
-    """Return a GCS access token if ambient credentials exist, otherwise None.
+def get_gcs_token_if_available(bucket: str) -> str | None:
+    """Return a bucket-scoped GCS token if ambient credentials exist, else None.
 
     A valid token works for both public and private buckets,
     so we send one whenever credentials are
     available and fall back to anonymous access only when they are not.
 
+    Parameters
+    ----------
+    bucket : str
+        Name of the GCS bucket the token must grant read access to.
+
     Returns
     -------
     str or None
-        A valid access token, or None if no ambient credentials are available.
+        A valid access token restricted to read-only access on `bucket`, or
+        None if no ambient credentials are available.
     """
     global _gcs_credentials_unavailable
     if _gcs_credentials_unavailable:
         return None
     try:
-        return get_gcs_token()
+        return get_gcs_token(bucket)
     except GCSAuthError:
         _gcs_credentials_unavailable = True
         return None

--- a/alp_data/io/auth.py
+++ b/alp_data/io/auth.py
@@ -19,6 +19,7 @@ only when they expire.
 """
 
 import logging
+import time
 
 import google.auth
 from google.auth import downscoped
@@ -39,6 +40,12 @@ _downscoped_credentials_by_bucket: dict[str, downscoped.Credentials] = {}
 # Credentials lookup fails, we stop re-attempting it (it is relatively expensive)
 # and treat the environment as credential-less for the rest of the session.
 _gcs_credentials_unavailable = False
+
+# Backoff for failures with otherwise-present credentials (e.g. a network blip
+# or blocked STS endpoint during refresh/exchange): skip re-attempts until this
+# monotonic deadline, so hot read loops don't pay a failed network call per read.
+_AUTH_RETRY_BACKOFF_SECONDS = 60.0
+_auth_failure_backoff_until = 0.0
 
 
 class GCSAuthError(Exception):
@@ -129,17 +136,31 @@ def get_gcs_token_if_available(bucket: str) -> str | None:
     bucket : str
         Name of the GCS bucket the token must grant read access to.
 
+    The credential-less verdict is only cached (sticky for the session) when
+    Application Default Credentials discovery itself fails — i.e. the
+    environment has no ambient credentials. A failure while refreshing or
+    downscoping an otherwise-working credential (e.g. a network blip or a
+    blocked STS endpoint) returns None and pauses re-attempts for
+    `_AUTH_RETRY_BACKOFF_SECONDS`, so transient errors recover quickly while
+    persistent ones cost one failed network call per backoff window instead
+    of one per read.
+
     Returns
     -------
     str or None
         A valid access token restricted to read-only access on `bucket`, or
         None if no ambient credentials are available.
     """
-    global _gcs_credentials_unavailable
+    global _gcs_credentials_unavailable, _auth_failure_backoff_until
     if _gcs_credentials_unavailable:
+        return None
+    if time.monotonic() < _auth_failure_backoff_until:
         return None
     try:
         return get_gcs_token(bucket)
     except GCSAuthError:
-        _gcs_credentials_unavailable = True
+        if _source_credentials is None:  # no ambient credentials at all
+            _gcs_credentials_unavailable = True
+        else:
+            _auth_failure_backoff_until = time.monotonic() + _AUTH_RETRY_BACKOFF_SECONDS
         return None

--- a/alp_data/io/read_utils.py
+++ b/alp_data/io/read_utils.py
@@ -105,28 +105,6 @@ def _gcs_path_to_url(file_path: str | AnyPathT) -> str:
     return f"https://storage.googleapis.com/{path_str}"
 
 
-def _gcs_bucket_name(file_path: str | AnyPathT) -> str:
-    """Extract the bucket name from a GCS path.
-
-    Accepts paths with or without the ``gs://`` prefix, mirroring
-    `_gcs_path_to_url`.
-
-    Parameters
-    ----------
-    file_path : str or AnyPathT
-        The GCS path to extract the bucket name from.
-
-    Returns
-    -------
-    str
-        The bucket name (the first path component).
-    """
-    path_str = str(file_path)
-    if path_str.startswith("gs://"):
-        path_str = path_str[len("gs://") :]
-    return path_str.lstrip("/").split("/", 1)[0]
-
-
 def _read_audio_ffmpeg(
     file_path: str | AnyPathT,
     start_time: float = 0.0,
@@ -179,7 +157,7 @@ def _read_audio_ffmpeg(
         process the audio, or their output cannot be parsed/decoded.
     """
     gcs_url = _gcs_path_to_url(file_path)
-    bucket = _gcs_bucket_name(file_path)
+    bucket = anypath(file_path).bucket
 
     # SECURITY NOTE
     # When authenticated, the bearer token is passed on the ffprobe/ffmpeg command

--- a/alp_data/io/read_utils.py
+++ b/alp_data/io/read_utils.py
@@ -105,6 +105,28 @@ def _gcs_path_to_url(file_path: str | AnyPathT) -> str:
     return f"https://storage.googleapis.com/{path_str}"
 
 
+def _gcs_bucket_name(file_path: str | AnyPathT) -> str:
+    """Extract the bucket name from a GCS path.
+
+    Accepts paths with or without the ``gs://`` prefix, mirroring
+    `_gcs_path_to_url`.
+
+    Parameters
+    ----------
+    file_path : str or AnyPathT
+        The GCS path to extract the bucket name from.
+
+    Returns
+    -------
+    str
+        The bucket name (the first path component).
+    """
+    path_str = str(file_path)
+    if path_str.startswith("gs://"):
+        path_str = path_str[len("gs://") :]
+    return path_str.lstrip("/").split("/", 1)[0]
+
+
 def _read_audio_ffmpeg(
     file_path: str | AnyPathT,
     start_time: float = 0.0,
@@ -138,6 +160,8 @@ def _read_audio_ffmpeg(
         - True: always access anonymously, sending no ``Authorization`` header
           (for public objects, e.g. to avoid sending a token).
         - False: always authenticate, raising if credentials are unavailable.
+        Tokens are downscoped to read-only access on the file's bucket before
+        being passed to ffmpeg (see `alp_data.io.auth`).
 
     Returns
     -------
@@ -155,22 +179,25 @@ def _read_audio_ffmpeg(
         process the audio, or their output cannot be parsed/decoded.
     """
     gcs_url = _gcs_path_to_url(file_path)
+    bucket = _gcs_bucket_name(file_path)
 
-    # SECURITY RISK (FIXME)
+    # SECURITY NOTE
     # When authenticated, the bearer token is passed on the ffprobe/ffmpeg command
     # line, which is visible to co-tenants via ``ps``/``/proc`` on shared hosts.
-    # This is an accepted risk (tokens are short-lived); Anonymous reads send no token.
+    # To limit the blast radius, the token is downscoped (see `alp_data.io.auth`)
+    # to short-lived read-only access on this one bucket — it grants nothing else.
+    # Anonymous reads send no token at all.
     headers_args: list[str] = []
     if anonymous is True:
         pass  # Explicit anonymous access: send no Authorization header.
     elif anonymous is False:
         try:
-            token = get_gcs_token()
+            token = get_gcs_token(bucket)
         except GCSAuthError as e:
             raise FFmpegSegmentError("missing GCS credentials", str(e)) from e
         headers_args = ["-headers", f"Authorization: Bearer {token}\r\n"]
     else:  # anonymous is None: authenticate if possible, else go anonymous.
-        token = get_gcs_token_if_available()
+        token = get_gcs_token_if_available(bucket)
         if token is not None:
             headers_args = ["-headers", f"Authorization: Bearer {token}\r\n"]
 

--- a/alp_data/io/read_utils.py
+++ b/alp_data/io/read_utils.py
@@ -214,19 +214,22 @@ def _read_audio_ffmpeg(
     if input_sr is not None and input_sr != sample_rate:
         logger.warning(f"Input sample rate {input_sr} doesn't match file sample rate {sample_rate}")
 
-    command = ["ffmpeg", *headers_args, "-ss", str(start_time), "-i", gcs_url]
+    # -rw_timeout must precede -i to apply to the HTTP input; ffmpeg silently
+    # ignores options placed after the output ("Trailing option(s) found").
+    command = [
+        "ffmpeg",
+        *headers_args,
+        "-rw_timeout",
+        "30000000",  # 30s timeout for GCS requests
+        "-ss",
+        str(start_time),
+        "-i",
+        gcs_url,
+    ]
     if end_time is not None:
         command += ["-t", str(end_time - start_time)]
     # Output raw PCM float32 to stdout, preserving native channel layout.
-    command += [
-        "-f",
-        "f32le",
-        "-acodec",
-        "pcm_f32le",
-        "pipe:1",
-        "-rw_timeout",
-        "30000000",  # 30s timeout for GCS requests
-    ]
+    command += ["-f", "f32le", "-acodec", "pcm_f32le", "pipe:1"]
 
     try:
         result = subprocess.run(command, check=True, capture_output=True)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,28 +1,111 @@
 """Unitary tests of Google Cloud Storage authentication helpers."""
 
+import urllib.error
+import urllib.request
+
+import pytest
+from google.auth import downscoped
+
 import alp_data.io.auth as auth
 from alp_data.io.auth import GCSAuthError, get_gcs_token, get_gcs_token_if_available
+
+TEST_BUCKET = "esp-ci-cd-tests"
+
+
+def _http_status(url: str, headers: dict[str, str]) -> int:
+    """Return the HTTP status of a GET request, without raising on 4xx.
+
+    Parameters
+    ----------
+    url : str
+        The URL to request.
+    headers : dict[str, str]
+        HTTP headers to send with the request.
+
+    Returns
+    -------
+    int
+        The HTTP status code of the response.
+    """
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.status
+    except urllib.error.HTTPError as e:
+        return e.code
 
 
 def test_get_gcs_token() -> None:
     """get_gcs_token returns a non-empty access token from ambient credentials."""
-    token = get_gcs_token()
+    token = get_gcs_token(TEST_BUCKET)
     assert isinstance(token, str)
     assert len(token) > 0
 
 
-def test_maybe_get_gcs_token_no_credentials(monkeypatch) -> None:
+def test_get_gcs_token_is_downscoped_to_bucket() -> None:
+    """The token works for reads on its bucket but nothing else.
+
+    The token is exchanged through a Credential Access Boundary, so it must
+    be able to read objects in `TEST_BUCKET` while being rejected by other
+    GCP services — even ones the underlying identity can access.
+    """
+    token = get_gcs_token(TEST_BUCKET)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    # In boundary: a ranged object read (what the ffmpeg path performs).
+    status = _http_status(
+        f"https://storage.googleapis.com/{TEST_BUCKET}"
+        "/esp-data-tests/some_subfolder/nri-battlesounds.mp3",
+        headers={**headers, "Range": "bytes=0-9"},
+    )
+    assert status in (200, 206)
+
+    # Out of boundary: any non-storage service must reject the token.
+    status = _http_status(
+        "https://secretmanager.googleapis.com/v1/projects/esp-data-274503/secrets",
+        headers=headers,
+    )
+    assert status in (401, 403)
+
+
+def test_downscoped_credentials_cached_per_bucket(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each bucket gets its own cached downscoped credentials, built once."""
+    built = []
+
+    class _FakeCredentials:
+        def __init__(
+            self,
+            source_credentials: object,
+            credential_access_boundary: downscoped.CredentialAccessBoundary,
+        ) -> None:
+            resource = credential_access_boundary.rules[0].available_resource
+            built.append(resource)
+            self.token = f"token-for-{resource.rsplit('/', 1)[-1]}"
+            self.valid = True
+
+    monkeypatch.setattr(auth, "_source_credentials", object())
+    monkeypatch.setattr(auth, "_downscoped_credentials_by_bucket", {})
+    monkeypatch.setattr(auth.downscoped, "Credentials", _FakeCredentials)
+
+    assert get_gcs_token("bucket-a") == "token-for-bucket-a"
+    assert get_gcs_token("bucket-a") == "token-for-bucket-a"
+    assert get_gcs_token("bucket-b") == "token-for-bucket-b"
+    # bucket-a's credentials were reused, not rebuilt.
+    assert len(built) == 2
+
+
+def test_maybe_get_gcs_token_no_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
     """Auto path returns None and caches the verdict when no credentials exist."""
     calls = {"n": 0}
 
-    def _no_creds() -> str:
+    def _no_creds(bucket: str) -> str:
         calls["n"] += 1
         raise GCSAuthError("no ambient credentials")
 
     monkeypatch.setattr(auth, "_gcs_credentials_unavailable", False)
     monkeypatch.setattr(auth, "get_gcs_token", _no_creds)
 
-    assert get_gcs_token_if_available() is None
+    assert get_gcs_token_if_available(TEST_BUCKET) is None
     # Sticky verdict: the second call must not re-attempt the ADC lookup.
-    assert get_gcs_token_if_available() is None
+    assert get_gcs_token_if_available(TEST_BUCKET) is None
     assert calls["n"] == 1

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -102,10 +102,49 @@ def test_maybe_get_gcs_token_no_credentials(monkeypatch: pytest.MonkeyPatch) -> 
         calls["n"] += 1
         raise GCSAuthError("no ambient credentials")
 
+    monkeypatch.setattr(auth, "_source_credentials", None)
     monkeypatch.setattr(auth, "_gcs_credentials_unavailable", False)
+    monkeypatch.setattr(auth, "_auth_failure_backoff_until", 0.0)
     monkeypatch.setattr(auth, "get_gcs_token", _no_creds)
 
     assert get_gcs_token_if_available(TEST_BUCKET) is None
     # Sticky verdict: the second call must not re-attempt the ADC lookup.
     assert get_gcs_token_if_available(TEST_BUCKET) is None
     assert calls["n"] == 1
+
+
+def test_maybe_get_gcs_token_transient_failure_backs_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refresh/exchange failure backs off instead of disabling auth for the session.
+
+    When source credentials exist but a token refresh or STS exchange fails
+    (e.g. a network blip or blocked STS endpoint), the auto path must not
+    cache a credential-less verdict, must not re-attempt on every call (hot
+    read loops would pay a failed network call per read), and must re-attempt
+    once the backoff window has passed.
+    """
+    calls = {"n": 0}
+
+    def _failing_exchange(bucket: str) -> str:
+        calls["n"] += 1
+        raise GCSAuthError("STS exchange failure")
+
+    # Source credentials were obtained earlier in the session.
+    monkeypatch.setattr(auth, "_source_credentials", object())
+    monkeypatch.setattr(auth, "_gcs_credentials_unavailable", False)
+    monkeypatch.setattr(auth, "_auth_failure_backoff_until", 0.0)
+    monkeypatch.setattr(auth, "get_gcs_token", _failing_exchange)
+
+    assert get_gcs_token_if_available(TEST_BUCKET) is None
+    assert calls["n"] == 1
+    assert auth._gcs_credentials_unavailable is False
+
+    # Within the backoff window: no re-attempt, still None.
+    assert get_gcs_token_if_available(TEST_BUCKET) is None
+    assert calls["n"] == 1
+
+    # After the backoff window passes, the next call re-attempts.
+    monkeypatch.setattr(auth, "_auth_failure_backoff_until", 0.0)
+    assert get_gcs_token_if_available(TEST_BUCKET) is None
+    assert calls["n"] == 2


### PR DESCRIPTION
Targets #310's branch (follow-up to the review discussion there). Three commits:

## 1. Fix `-rw_timeout` placement on the ffmpeg decode command

ffmpeg's CLI parsing is positional: options placed after the last output (`pipe:1`) are trailing options and are silently ignored (ffmpeg logs "Trailing option(s) found in the command" and continues). So the 30s `-rw_timeout` added on the decode command had no effect — a GCS connection that stalls silently mid-transfer would still hang the read indefinitely. The ffprobe placement was already correct.

This moves the pair into the input options (before `-i`), with a comment explaining the positional constraint.

**Verification** (local, ffmpeg 8.1.2):
- Against a deliberately stalling HTTP server (accepts the connection, sends headers + a few bytes, then goes silent), routed through the real `_read_audio_ffmpeg` path: previously hung until killed; with this fix it raises `FFmpegSegmentError("ffmpeg decode failed")` at 30.2s, reaching the existing warn-once → download-fallback path.

## 2. Downscope GCS tokens to per-bucket read-only

The raw ADC token carries the caller's full identity. Before handing a token to ffmpeg, `auth.py` now exchanges it through a [GCP Credential Access Boundary](https://cloud.google.com/iam/docs/downscoping-short-lived-credentials) so the token only grants `roles/storage.objectViewer` on the single bucket being read, for at most the source token's lifetime.

- The bucket is derived from the `gs://` path — no configuration, no bucket allowlist to maintain.
- Downscoped credentials are cached per bucket; the STS exchange happens once per (bucket, token lifetime). Source credentials are cached as before and never leave the process.
- The gcsfs download/fallback path is unchanged (in-process credentials, full identity as before).
- Exchange failures surface as `GCSAuthError` and flow into the existing fallback machinery.

New tests: a live assertion that the token can read its own bucket (HTTP 206 ranged GET) but is rejected by non-storage services (401/403), and a unit test of the per-bucket credential cache.

**Verification**: `ruff check` / `ruff format --check` clean; `pytest tests/test_auth.py tests/test_read_audio.py`: 36 passed (the read_audio suite exercises the downscoped tokens end-to-end against GCS via the ffmpeg path).

## 3. Back off on auth failures instead of caching a credential-less verdict

The sticky `_gcs_credentials_unavailable` flag previously flipped on *any* `GCSAuthError` in the auto path, so a transient STS/network failure mid-session would silently downgrade all subsequent reads to anonymous (losing the ffmpeg fast path for private buckets for the rest of the process).

Now the credential-less verdict only sticks when ADC discovery itself fails (no ambient credentials at all). Failures with otherwise-present credentials — a network blip, a blocked STS endpoint, a revoked credential — set a 60s backoff instead: transient errors recover within a minute, while persistent ones cost one failed network call per backoff window rather than one per read in hot dataloader loops. Tests pin the sticky verdict, the backoff, and the post-backoff re-attempt.
