### PR TITLE
fix(backends): reject null-typed label lists

### DIFF
--- a/alp_data/backends/polars_backend.py
+++ b/alp_data/backends/polars_backend.py
@@ -1162,6 +1162,11 @@ class PolarsBackend(DataBackend):
         for f in input_features:
             if f not in df.columns:
                 raise ValueError(f"Input feature '{f}' does not exist in DataFrame.")
+            if df[f].dtype == pl.List(pl.Null):
+                raise ValueError(
+                    f"Column '{f}' has dtype List(Null); every list element is null. "
+                    "Populate the column with string labels."
+                )
             if not df[f].dtype.base_type() == pl.List:
                 # try to convert to list
                 # first, get the base type of the column

--- a/tests/test_multilabel_from_features.py
+++ b/tests/test_multilabel_from_features.py
@@ -155,6 +155,33 @@ def test_multilabel_from_features_with_extra_labels() -> None:
     assert df_out.unwrap["label"].to_list() == [[1], [0], [1], [2]]
 
 
+def test_multilabel_from_features_rejects_null_typed_list() -> None:
+    data = PolarsBackend(pl.DataFrame({"col1": [[None]]}))
+    t = MultiLabelFromFeatures(
+        features=["col1"],
+        label_map={"Minke whale": 0},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"Column 'col1' has dtype List\(Null\); every list element is null",
+    ):
+        t(data)
+
+
+def test_multilabel_from_features_allows_nulls_in_string_list() -> None:
+    data = PolarsBackend(pl.DataFrame({"col1": [["Minke whale", None]]}))
+    t = MultiLabelFromFeatures(
+        features=["col1"],
+        label_map={"Minke whale": 0},
+    )
+
+    df_out, meta = t(data)
+
+    assert df_out.unwrap["label"].to_list() == [[0]]
+    assert meta["label_map"] == {"Minke whale": 0}
+
+
 def test_multilabel_from_features_with_noncontiguous_indices() -> None:
     df = {"col1": ["banana", "apple", "banana", "orange"]}
     label_map = {"apple": 100, "banana": 101, "orange": 102}


### PR DESCRIPTION
## Summary

Fixes #294 by rejecting fully null-typed label lists before Polars reaches `replace_strict`.

- Detect `List(Null)` input columns during multilabel validation.
- Raise an actionable `ValueError` that names the malformed column.
- Preserve existing behavior for string lists that contain occasional null elements.

## Root cause

`List(Null).base_type()` is `List`, so the existing type check accepted the column. The downstream mapping expression then failed inside Polars because its list elements had no concrete value type.

## Validation

- `uv run pytest tests/test_multilabel_from_features.py tests/test_backends.py -q` — 51 passed
- `uv run ruff check --fix alp_data/backends/polars_backend.py`
- `uv run ruff format --check alp_data/backends/polars_backend.py`
- `git diff --check`

The full suite was also sampled. Its first failure was the unrelated cloud filesystem integration test because this hosted sandbox cannot resolve `storage.googleapis.com`.
