### PR TITLE
Add four strongly-labeled soundscape datasets (Dartmouth, PteroSet, Indian Fauna Type-A, Xeno-canto Strong)

### DIFF
--- a/alp_data/datasets/__init__.py
+++ b/alp_data/datasets/__init__.py
@@ -11,6 +11,7 @@ from .birdeep import Birdeep
 from .birdset import BirdSet
 from .chiffchaff_id import ChiffchaffId
 from .corvid_wascher import CorvidWascher
+from .dartmouth_avian_soundscapes import DartmouthAvianSoundscapes
 from .dclde2026 import DCLDE2026
 from .dinardo_dolphin_whistles import DinardoDolphinWhistles
 from .esp_raincoast import ESPRaincoast
@@ -19,6 +20,7 @@ from .giant_otters import GiantOtters
 from .gibbon_solos import GibbonSolos
 from .hawaiian_birds import HawaiianBirds
 from .inaturalist import INaturalist
+from .indian_fauna_strong import IndianFaunaStrong
 from .infant_marmosets_vox import InfantMarmosetsVox
 from .insectset_459 import InsectSet459
 from .littleowl_id import LittleOwlId
@@ -26,6 +28,7 @@ from .macaques_coo_calls import MacaquesCooCalls
 from .nocturnal_bird_migration import NocturnalBirdMigration
 from .pipit_id import PipitId
 from .powdermill import Powdermill
+from .pteroset import PteroSet
 from .subsegmentation import Subsegmentation
 from .superb_starling import SuperbStarling
 from .voxaboxen import Voxaboxen, VoxaboxenEvents
@@ -33,6 +36,7 @@ from .wabad import WABAD
 from .watkins import Watkins
 from .xeno_canto import XenoCanto
 from .xeno_canto_annotated_jeantet_23 import XenoCantoAnnotatedJeantet23
+from .xeno_canto_strong import XenoCantoStrong
 from .zebra_finch_julie_elie import ZebraFinchJulieElie
 
 __all__ = [
@@ -73,4 +77,8 @@ __all__ = [
     "CorvidWascher",
     "DCLDE2026",
     "Watkins",
+    "DartmouthAvianSoundscapes",
+    "PteroSet",
+    "IndianFaunaStrong",
+    "XenoCantoStrong",
 ]

--- a/alp_data/datasets/_windowing.py
+++ b/alp_data/datasets/_windowing.py
@@ -1,0 +1,74 @@
+"""Shared helpers for datasets that support windowed reads.
+
+Several strong-detection datasets accept `window_start_sec` / `window_end_sec`
+on a row and read only that segment (see `alp_data.datasets.dclde2026`, whose
+manifest ships those columns). Their selection tables hold recording-absolute
+times, so a windowed read has to re-base the table onto the returned audio or
+the two disagree.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+BEGIN = "Begin Time (s)"
+END = "End Time (s)"
+
+
+def window_selection_table(st: pd.DataFrame, window_start: float, duration: float) -> pd.DataFrame:
+    """Re-base a recording-absolute selection table onto a windowed read.
+
+    Events that do not overlap the window are dropped; the rest are shifted so
+    their times are relative to the start of the returned audio, and clipped to
+    it. All other columns are left untouched, so identity columns such as
+    `Selection` or `event_index` still say which of the recording's events a
+    row refers to.
+
+    Parameters
+    ----------
+    st : pd.DataFrame
+        Selection table with recording-absolute `Begin Time (s)` and
+        `End Time (s)`. A table missing those columns is returned unchanged.
+    window_start : float
+        Start of the window, in seconds from the start of the recording.
+    duration : float
+        Duration of the audio actually returned, in seconds. Used in place of
+        the requested window end so a window running past the end of the file
+        is handled correctly.
+
+    Returns
+    -------
+    pd.DataFrame
+        The windowed selection table, with times relative to the window.
+    """
+    if BEGIN not in st.columns or END not in st.columns:
+        return st
+    window_end = window_start + duration
+    st = st[(st[END] > window_start) & (st[BEGIN] < window_end)].copy()
+    st[BEGIN] = (st[BEGIN] - window_start).clip(lower=0.0)
+    st[END] = (st[END] - window_start).clip(upper=duration)
+    return st
+
+
+def clip_selection_table(st: pd.DataFrame, duration: float) -> pd.DataFrame:
+    """Drop events that begin past the end of the decoded audio.
+
+    The guard WABAD and DCLDE2026 apply to unwindowed reads, kept here so every
+    dataset in this family spells it the same way.
+
+    Parameters
+    ----------
+    st : pd.DataFrame
+        Selection table with recording-absolute times. A table missing
+        `Begin Time (s)` is returned unchanged.
+    duration : float
+        Duration of the decoded audio, in seconds.
+
+    Returns
+    -------
+    pd.DataFrame
+        The clipped selection table.
+    """
+    if BEGIN not in st.columns:
+        return st
+    return st[st[BEGIN] < duration].copy()

--- a/alp_data/datasets/dartmouth_avian_soundscapes.py
+++ b/alp_data/datasets/dartmouth_avian_soundscapes.py
@@ -1,0 +1,350 @@
+"""Dartmouth Avian Soundscapes dataset."""
+
+from __future__ import annotations
+
+from io import StringIO
+from typing import Any, Iterator
+
+import librosa
+import numpy as np
+import pandas as pd
+
+from alp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
+from alp_data.backends import BackendType
+from alp_data.datasets._windowing import clip_selection_table, window_selection_table
+from alp_data.io import AnyPathT, anypath, audio_stereo_to_mono, read_audio
+
+# Staged in the ingestion bucket. Moves under DATA_HOME (as WABAD and
+# most datasets resolve) when this lands; the loader picks the new
+# location up from this one constant.
+_RAW_ROOT = "gs://esp-data-ingestion/dartmouth-avian-soundscapes/v0.1.0"
+SPECIES_INFO_PATH = f"{_RAW_ROOT}/species_labels.csv"
+
+
+@register_dataset
+class DartmouthAvianSoundscapes(Dataset):
+    """Dartmouth Avian Soundscapes Dataset.
+
+    Description
+    -----------
+    A large-scale, stratified, fully annotated acoustic forest soundscape
+    dataset of avian vocalisations from eastern North America. Each entry is a
+    10-minute soundscape recording plus a selection table; each row of the
+    selection table is a time/frequency-bounded acoustic event annotated by
+    expert ornithologists. Species labels are coerced to GBIF canonical
+    scientific names (in the ``Species`` column), while the original 4-letter
+    AOU code is retained in the ``Species Code`` column for traceability.
+
+    The collection contains 1,302 ten-minute recordings (~183,000 annotated
+    vocalisations) of 96 bird species (plus a few mammal and unknown labels)
+    recorded across four protected areas in the northeastern United States
+    (Acadia NP, Hubbard Brook Experimental Forest, Katahdin Woods and Waters
+    NM, and Marsh-Billings-Rockefeller NHP) during the 2022 and 2023 breeding
+    seasons. Annotations were produced in Raven Pro 1.6 over three review
+    rounds. Originally included in alp-data for use as a zero-shot bird
+    detection evaluation dataset.
+
+    Splits
+    ------
+    The recordings are organised into three sub-datasets, each exposed as a
+    split, plus a combined ``all`` split:
+
+        - ``acad`` : DatasetACAD — Acadia NP (396 recordings)
+        - ``mabi`` : DatasetMABI — Marsh-Billings-Rockefeller NHP (477)
+        - ``simr`` : DatasetSIMR — point-count survey recordings (429)
+        - ``all``  : all three combined (1,302)
+
+    Pre-resampled Audio
+    -------------------
+    Originals are 32 kHz mono FLAC. Pre-resampled audio is available at 16 kHz
+    and 32 kHz (16-bit PCM WAV). When ``sample_rate`` matches one of these
+    rates, the pre-resampled files are loaded directly (no on-the-fly
+    resampling). For any other target rate, audio is resampled on-the-fly using
+    librosa's ``kaiser_best`` method.
+
+    References
+    ----------
+    https://zenodo.org/records/20038954
+    DOI: 10.5281/zenodo.20038954
+    """
+
+    info = DatasetInfo(
+        name="dartmouth_avian_soundscapes",
+        owner="david",
+        split_paths={
+            "all": f"{_RAW_ROOT}/all.csv",
+            "acad": f"{_RAW_ROOT}/acad.csv",
+            "mabi": f"{_RAW_ROOT}/mabi.csv",
+            "simr": f"{_RAW_ROOT}/simr.csv",
+        },
+        version="0.1.0",
+        description=(
+            "Large-scale, stratified, fully annotated acoustic forest soundscape "
+            "dataset of avian vocalisations from eastern North America. 1,302 "
+            "ten-minute soundscape recordings (~183k expert-annotated "
+            "vocalisations) of 96 bird species from four northeastern US "
+            "protected areas, with Raven Pro selection tables. Species coerced to "
+            "GBIF canonical names; raw 4-letter AOU codes retained. Originals at "
+            "32 kHz; pre-resampled 16 kHz and 32 kHz versions available."
+        ),
+        sources=["https://zenodo.org/records/20038954"],
+        license="CC-BY-4.0",
+    )
+
+    _sample_rate_paths: dict[int, str] = {16000: "16khz_path", 32000: "32khz_path"}
+    _originals_path_column = "audio_fp"
+
+    def __init__(
+        self,
+        split: str = "all",
+        output_take_and_give: dict[str, str] | None = None,
+        sample_rate: int | None = 16000,
+        data_root: str | AnyPathT | None = None,
+        backend: BackendType = "pandas",
+        streaming: bool = False,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        split : str
+            Split to load (key in info.split_paths): ``all``/``acad``/``mabi``/``simr``.
+        output_take_and_give : dict[str, str] | None
+            Optional mapping of original → new output keys (filters columns as well).
+        sample_rate : int | None
+            If set, audio is resampled to this rate.
+        data_root : str | AnyPathT | None
+            Optional root directory to prepend to each row's audio path.
+        backend : BackendType, optional
+            The backend to use ("pandas" or "polars"), by default "pandas".
+        streaming : bool, optional
+            Whether to use streaming mode, by default False.
+        """
+        super().__init__(output_take_and_give, backend=backend, streaming=streaming)
+        self.split = split
+        self._data = None
+        self.annotation_columns = ["Species"]
+        self.unknown_label = "Unknown"
+        self.sample_rate = sample_rate
+
+        self.full_dataset_available_labels = None  # placeholder for labels if split == all
+
+        self._load()
+
+        if data_root is None:
+            self.data_root = anypath(self.info.split_paths[self.split]).parent
+        else:
+            self.data_root = anypath(data_root)
+
+    @property
+    def columns(self) -> list[str]:
+        return list(self._data.columns) if self._data is not None else []
+
+    @property
+    def available_splits(self) -> list[str]:
+        return list(self.info.split_paths.keys())
+
+    @property
+    def available_sample_rates(self) -> list[int]:
+        """Return pre-resampled sample rates whose path columns exist in the data."""
+        return [sr for sr, col in self._sample_rate_paths.items() if col in self._data.columns]
+
+    def _load(self) -> None:
+        if self.split not in self.info.split_paths:
+            raise LookupError(
+                f"Invalid split: {self.split}. Expected one of {list(self.info.split_paths.keys())}"
+            )
+        location = self.info.split_paths[self.split]
+        self._data = self._backend_class.from_csv(
+            location,
+            streaming=self._streaming,
+            keep_default_na=False,
+            na_values=[""],
+        )
+
+    def __len__(self) -> int:
+        """Return the number of samples in the dataset.
+
+        Returns
+        -------
+        int
+            Number of samples in the current split.
+
+        Raises
+        ------
+        RuntimeError
+            If no split has been loaded yet.
+        """
+        if self._data is None:
+            raise RuntimeError("No split has been loaded yet. Call _load() first.")
+        if self._streaming:
+            raise NotImplementedError(
+                "Length is not available in streaming mode. Iterate over the dataset instead."
+            )
+        return len(self._data)
+
+    def _process(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Process a single row of the dataset.
+
+        When the row contains ``window_start_sec`` / ``window_end_sec`` (set by
+        a caller or transform), only the corresponding audio
+        segment is loaded from disk/GCS instead of the full recording.
+
+        Parameters
+        ----------
+        row : dict[str, Any]
+            A dictionary representing a single row of the dataset.
+
+        Returns
+        -------
+        dict[str, Any]
+            The processed row.
+        """
+        use_presampled = False
+        if self.sample_rate is not None and self.sample_rate in self._sample_rate_paths:
+            path_column = self._sample_rate_paths[self.sample_rate]
+            if path_column in row and row[path_column] is not None and row[path_column] != "":
+                audio_path = anypath(self.data_root) / row[path_column]
+                use_presampled = True
+
+        if not use_presampled:
+            audio_path = anypath(self.data_root) / row[self._originals_path_column]
+
+        window_start = row.get("window_start_sec")
+        window_end = row.get("window_end_sec")
+
+        if window_start is not None and window_end is not None:
+            audio, sr = read_audio(
+                audio_path, start_time=float(window_start), end_time=float(window_end)
+            )
+        else:
+            audio, sr = read_audio(audio_path)
+
+        audio = audio_stereo_to_mono(audio, mono_method="average").astype(np.float32)
+
+        if not use_presampled and self.sample_rate is not None and sr != self.sample_rate:
+            audio = librosa.resample(
+                y=audio,
+                orig_sr=sr,
+                target_sr=self.sample_rate,
+                scale=True,
+                res_type="kaiser_best",
+            )
+            sr = self.sample_rate
+
+        row["audio"] = audio
+        row["sample_rate"] = sr
+
+        raw_st = row.get("selection_table")
+        if raw_st is not None:
+            if isinstance(raw_st, str):
+                st = pd.read_csv(StringIO(raw_st), sep="\t")
+            elif isinstance(raw_st, pd.DataFrame):
+                st = raw_st
+            else:
+                st = pd.DataFrame()
+
+            audio_dur = len(audio) / float(sr)
+            if window_start is not None and window_end is not None:
+                st = window_selection_table(st, float(window_start), audio_dur)
+            else:
+                st = clip_selection_table(st, audio_dur)
+            row["selection_table"] = st
+
+        if self.output_take_and_give:
+            item = {}
+            for old_key, new_key in self.output_take_and_give.items():
+                item[new_key] = row[old_key]
+            return item
+
+        return row
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        """Get a specific sample from the dataset.
+
+        Parameters
+        ----------
+        idx : int
+            Index of the sample to get.
+
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary containing the audio, sample rate, and selection table.
+        """
+        row = self._data[idx]
+        return self._process(row)
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        """Iterate over samples in the dataset.
+
+        Yields
+        ------
+        dict[str, Any]
+            Each sample in the dataset.
+        """
+        for row in self._data:
+            yield self._process(row)
+
+    @classmethod
+    def from_config(
+        cls, dataset_config: DatasetConfig
+    ) -> tuple["DartmouthAvianSoundscapes", dict[str, Any]]:
+        """Create a Dataset instance from a configuration dictionary.
+
+        Parameters
+        ----------
+        dataset_config : DatasetConfig
+            Configuration dictionary containing dataset parameters.
+
+        Returns
+        -------
+        tuple[DartmouthAvianSoundscapes, dict[str, Any]]
+            A tuple containing the dataset instance and metadata. If the
+            dataset_config contains transformations, they will be applied and
+            the metadata will be returned as dict, otherwise an empty dict.
+        """
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
+        ds = cls(
+            split=cfg["split"],
+            output_take_and_give=cfg["output_take_and_give"],
+            data_root=cfg["data_root"],
+            sample_rate=cfg["sample_rate"],
+            backend=cfg["backend"],
+            streaming=cfg["streaming"],
+        )
+
+        if dataset_config.transformations:
+            meta = ds.apply_transformations(dataset_config.transformations)
+            return ds, meta
+
+        return ds, {}
+
+    def get_available_labels(self, anno_column: str | None = "Species") -> list[str]:
+        """Return all possible species labels.
+
+        Returns
+        -------
+        list[str]
+            A list of all the available labels for ``anno_column``.
+        """
+        if self.split == "all":
+            if self.full_dataset_available_labels is None:
+                self.full_dataset_available_labels = pd.read_csv(SPECIES_INFO_PATH)[
+                    "Species"
+                ].to_list()
+            return self.full_dataset_available_labels
+        else:
+            available_labels = set()
+            for row in self._data:
+                st = pd.read_csv(StringIO(row["selection_table"]), sep="\t")
+                available_labels.update(st[anno_column].astype(str).tolist())
+            return sorted(available_labels)
+
+    def __str__(self) -> str:
+        base = f"{self.info.name} (v{self.info.version})"
+        return (
+            f"{base}\n"
+            f"Sources: {self.info.sources}\n"
+            f"License: {self.info.license}\n"
+            f"Available splits: {', '.join(self.info.split_paths.keys())}"
+        )

--- a/alp_data/datasets/indian_fauna_strong.py
+++ b/alp_data/datasets/indian_fauna_strong.py
@@ -1,0 +1,312 @@
+"""India Ecoacoustics Network (IEN) Type-A strong detection dataset."""
+
+from __future__ import annotations
+
+from io import StringIO
+from typing import Any, Iterator
+
+import librosa
+import numpy as np
+import pandas as pd
+
+from alp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
+from alp_data.backends import BackendType
+from alp_data.datasets._windowing import clip_selection_table, window_selection_table
+from alp_data.io import AnyPathT, anypath, audio_stereo_to_mono, read_audio
+
+# Staged in the ingestion bucket. Moves under DATA_HOME (as WABAD and
+# most datasets resolve) when this lands; the loader picks the new
+# location up from this one constant.
+_RAW_ROOT = "gs://esp-data-ingestion/indian-fauna/v0.1.0/typeA"
+_ST_COLUMNS = [
+    "Selection",
+    "Begin Time (s)",
+    "End Time (s)",
+    "Low Freq (Hz)",
+    "High Freq (Hz)",
+    "Species",
+]
+
+
+@register_dataset
+class IndianFaunaStrong(Dataset):
+    """India Ecoacoustics Network — Type-A strong detection (Raven boxes).
+
+    Description
+    -----------
+    Ramesh, Singh et al. (2025/2026), "A large-scale crowd-sourced annotated
+    acoustic dataset of Indian fauna" (bioRxiv ``10.64898/2026.07.20.739496``,
+    data CC-BY-NC-4.0). Type-A = strong labels: Raven-style time+frequency
+    bounding boxes on full-length recordings, contributed by participatory
+    scientists across 25 Indian states. 402 annotated taxa / 36,718 boxes over
+    1,703 recordings spanning four classes — Aves (dominant), Amphibia (a large
+    share of boxes), Mammalia, and Insecta. WABAD-shaped: one row per recording
+    with a ``selection_table`` (``Selection, Begin Time (s), End Time (s), Low
+    Freq (Hz), High Freq (Hz), Species``); a file may contain several species.
+
+    Crowd-sourced ⇒ variable native sample rate (8-384 kHz; mostly 44-48 kHz)
+    and duration (2 s-60 min). Source scientific names are already
+    GBIF-resolved; per-file ``target_species``/``class`` come from the release's
+    ``taxa_info``. 16 kHz + 32 kHz mono mirrors are provided (32 kHz recommended).
+
+    Nyquist caveat
+    --------------
+    At the 16 kHz stack Nyquist: Aves 81% of boxes fully in band, Insecta 79%,
+    Mammalia 73% (≈15% fully ultrasonic = bats, lost), Amphibia boxes are
+    full-band (their frequency extent is not meaningful). All classes have ~100%
+    of boxes with their low edge in band, so time-presence detection is viable
+    throughout; frequency-bbox targets should filter ``High Freq (Hz) <= 16000``
+    and exclude the full-band amphibian boxes.
+
+    Splits
+    ------
+    Single ``all`` split.
+
+    Loader behaviour
+    ----------------
+    Windowed reads via ``window_start_sec`` / ``window_end_sec``, set by a
+    caller or a transform. The selection table is re-based onto the window:
+    non-overlapping events are dropped, the rest shifted and clipped so their
+    times line up with the returned audio. ``annotation_columns = ["Species"]``.
+
+    Known gaps
+    ----------
+    Two items are outstanding and tracked for a follow-up; neither affects the
+    16 kHz or 32 kHz read paths.
+
+    - **No native-rate audio.** ``audio_fp`` points at the 32 kHz mirror
+      because the originals were never staged. Native rates run 8-384 kHz, so
+      the roughly 15% of Mammalia boxes that are fully ultrasonic cannot be
+      reached at all until they are. The other three datasets in this family
+      (`DartmouthAvianSoundscapes`, `PteroSet`, `XenoCantoStrong`) all point at
+      true originals.
+    - **Labels are not normalised through this repo's GBIF converter.** They
+      come from the upstream release's own ``taxa_info``, so ``Species`` mixes
+      ranks: species binomials alongside genera (``Corvus``), families
+      (``Gryllidae``), classes (``Aves``, ``Insecta``), subspecies trinomials,
+      one common name (``Dugong``, 320 events) and one non-taxon value
+      (``Camera``). Filter to binomials at your own risk -- doing so silently
+      drops the ``Dugong`` events. The other three resolve cleanly.
+
+    References
+    ----------
+    https://zenodo.org/records/18743214 . License: CC-BY-NC-4.0.
+    """
+
+    info = DatasetInfo(
+        name="indian_fauna_strong",
+        owner="david",
+        split_paths={
+            "all": f"{_RAW_ROOT}/indian_fauna_strong_all.csv",
+        },
+        version="0.1.0",
+        description=(
+            "India Ecoacoustics Network Type-A strong detection: crowd-sourced Raven "
+            "time+freq boxes on full recordings, 402 taxa / 36,718 boxes / 1,703 recs "
+            "across Aves/Amphibia/Mammalia/Insecta and 25 Indian states. WABAD-shaped."
+        ),
+        sources=["https://zenodo.org/records/18743214"],
+        license="CC-BY-NC-4.0",
+    )
+
+    _sample_rate_paths: dict[int, str] = {16000: "16khz_path", 32000: "32khz_path"}
+    _originals_path_column = "audio_fp"
+    _mixup_group = "indian_fauna"
+
+    def __init__(
+        self,
+        split: str = "all",
+        output_take_and_give: dict[str, str] | None = None,
+        sample_rate: int | None = 32000,
+        data_root: str | AnyPathT | None = None,
+        backend: BackendType = "pandas",
+        streaming: bool = False,
+    ) -> None:
+        """Initialise the IndianFaunaStrong dataset.
+
+        Parameters
+        ----------
+        split : str
+            Split to load (key in `info.split_paths`).
+        output_take_and_give : dict[str, str] | None
+            Optional mapping of original -> new output keys (filters columns).
+        sample_rate : int | None
+            Target sample rate. 16 kHz / 32 kHz load the pre-resampled mirror
+            directly; other rates resample on the fly. ``None`` returns source.
+        data_root : str | AnyPathT | None
+            Root prepended to each row's relative audio path. Defaults to the
+            manifest's parent directory on GCS.
+        backend : BackendType
+            ``"pandas"`` or ``"polars"``.
+        streaming : bool
+            Whether to use streaming mode.
+        """
+        super().__init__(output_take_and_give, backend=backend, streaming=streaming)
+        self.split = split
+        self._data = None
+        self.annotation_columns = ["Species"]
+        self.unknown_label = "Unknown"
+        self.sample_rate = sample_rate
+
+        self._load()
+
+        if data_root is None:
+            self.data_root = anypath(self.info.split_paths[self.split]).parent
+        else:
+            self.data_root = anypath(data_root)
+
+    @property
+    def columns(self) -> list[str]:
+        return list(self._data.columns) if self._data is not None else []
+
+    @property
+    def available_splits(self) -> list[str]:
+        return list(self.info.split_paths.keys())
+
+    @property
+    def available_sample_rates(self) -> list[int]:
+        """Return pre-resampled sample rates whose path columns exist."""
+        return [sr for sr, col in self._sample_rate_paths.items() if col in self._data.columns]
+
+    def _load(self) -> None:
+        if self.split not in self.info.split_paths:
+            raise LookupError(
+                f"Invalid split: {self.split}. Expected one of {list(self.info.split_paths.keys())}"
+            )
+        self._data = self._backend_class.from_csv(
+            self.info.split_paths[self.split],
+            streaming=self._streaming,
+            keep_default_na=False,
+            na_values=[""],
+        )
+
+    def __len__(self) -> int:
+        if self._data is None:
+            raise RuntimeError("No split has been loaded yet. Call _load() first.")
+        if self._streaming:
+            raise NotImplementedError("Length is not available in streaming mode.")
+        return len(self._data)
+
+    def _process(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Load audio + parsed selection table for one recording.
+
+        When ``window_start_sec`` / ``window_end_sec`` are present (set by the
+        caller or transform), only that segment is read.
+
+        Returns
+        -------
+        dict[str, Any]
+            The row with ``audio``, ``sample_rate`` and a parsed
+            ``selection_table`` DataFrame.
+        """
+        use_presampled = False
+        if self.sample_rate is not None and self.sample_rate in self._sample_rate_paths:
+            path_column = self._sample_rate_paths[self.sample_rate]
+            if path_column in row and row[path_column] not in (None, ""):
+                audio_path = anypath(self.data_root) / row[path_column]
+                use_presampled = True
+
+        if not use_presampled:
+            audio_path = anypath(self.data_root) / row[self._originals_path_column]
+
+        window_start = row.get("window_start_sec")
+        window_end = row.get("window_end_sec")
+        if window_start is not None and window_end is not None:
+            audio, sr = read_audio(
+                audio_path, start_time=float(window_start), end_time=float(window_end)
+            )
+        else:
+            audio, sr = read_audio(audio_path)
+
+        audio = audio_stereo_to_mono(audio, mono_method="average").astype(np.float32)
+
+        if not use_presampled and self.sample_rate is not None and sr != self.sample_rate:
+            audio = librosa.resample(
+                y=audio,
+                orig_sr=sr,
+                target_sr=self.sample_rate,
+                scale=True,
+                res_type="kaiser_best",
+            )
+            sr = self.sample_rate
+
+        row["audio"] = audio
+        row["sample_rate"] = sr
+        row["mixup_group"] = self._mixup_group
+
+        # Selection table parsed with pandas (polars' rayon pool deadlocks
+        # after fork() in DataLoader workers).
+        raw_st = row.get("selection_table")
+        if raw_st is None or raw_st == "":
+            st = pd.DataFrame(columns=_ST_COLUMNS)
+        elif isinstance(raw_st, str):
+            st = pd.read_csv(StringIO(raw_st), sep="\t", keep_default_na=False, na_values=[""])
+        elif isinstance(raw_st, pd.DataFrame):
+            st = raw_st
+        else:
+            st = pd.DataFrame(columns=_ST_COLUMNS)
+
+        audio_dur = len(audio) / float(sr)
+        if window_start is not None and window_end is not None:
+            st = window_selection_table(st, float(window_start), audio_dur).reset_index(drop=True)
+        else:
+            st = clip_selection_table(st, audio_dur).reset_index(drop=True)
+        row["selection_table"] = st
+
+        if self.output_take_and_give:
+            return {new: row[old] for old, new in self.output_take_and_give.items()}
+        return row
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        return self._process(self._data[idx])
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        for row in self._data:
+            yield self._process(row)
+
+    @classmethod
+    def from_config(
+        cls, dataset_config: DatasetConfig
+    ) -> tuple["IndianFaunaStrong", dict[str, Any]]:
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
+        ds = cls(
+            split=cfg["split"],
+            output_take_and_give=cfg["output_take_and_give"],
+            data_root=cfg["data_root"],
+            sample_rate=cfg["sample_rate"],
+            backend=cfg["backend"],
+            streaming=cfg["streaming"],
+        )
+        if dataset_config.transformations:
+            meta = ds.apply_transformations(dataset_config.transformations)
+            return ds, meta
+        return ds, {}
+
+    def get_available_labels(self, anno_column: str = "Species") -> list[str]:
+        """Return the species label vocabulary present in the selection tables.
+
+        Returns
+        -------
+        list[str]
+            Sorted unique ``Species`` values across all recordings.
+        """
+        labels: set[str] = set()
+        for row in self._data:
+            raw = row.get("selection_table")
+            if not raw:
+                continue
+            st = pd.read_csv(StringIO(raw), sep="\t", keep_default_na=False, na_values=[""])
+            if "Species" in st.columns:
+                labels.update(str(s) for s in st["Species"].dropna().unique() if str(s))
+        return sorted(labels)
+
+    def __str__(self) -> str:
+        base = f"{self.info.name} (v{self.info.version})"
+        n = len(self) if self._data is not None and not self._streaming else "?"
+        return (
+            f"{base}\n"
+            f"Recordings: {n}\n"
+            f"Sources: {self.info.sources}\n"
+            f"License: {self.info.license}\n"
+            f"Available splits: {', '.join(self.info.split_paths.keys())}"
+        )

--- a/alp_data/datasets/pteroset.py
+++ b/alp_data/datasets/pteroset.py
@@ -1,0 +1,350 @@
+"""PteroSet dataset."""
+
+from __future__ import annotations
+
+from io import StringIO
+from typing import Any, Iterator
+
+import librosa
+import numpy as np
+import pandas as pd
+
+from alp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
+from alp_data.backends import BackendType
+from alp_data.datasets._windowing import clip_selection_table, window_selection_table
+from alp_data.io import AnyPathT, anypath, audio_stereo_to_mono, read_audio
+
+# Staged in the ingestion bucket. Moves under DATA_HOME (as WABAD and
+# most datasets resolve) when this lands; the loader picks the new
+# location up from this one constant.
+_RAW_ROOT = "gs://esp-data-ingestion/pteroset/v0.1.0"
+SPECIES_INFO_PATH = f"{_RAW_ROOT}/species_labels.csv"
+
+
+@register_dataset
+class PteroSet(Dataset):
+    """PteroSet Dataset.
+
+    Description
+    -----------
+    A strongly annotated passive-acoustic-monitoring dataset for tropical bird
+    monitoring from two Colombian regions (Putumayo and Magdalena). Each entry
+    is a passive-acoustic recording plus a selection table; each row of the
+    selection table is a time/frequency-bounded acoustic event annotated by
+    experts in Raven Pro. Every event is a bird vocalisation
+    (``Identification`` = ``AVEVOC``); the subset identified to species carries
+    a GBIF canonical name in the ``Species`` column (others are ``Unknown``).
+    The original PteroSet species code is retained in ``Species Code``.
+
+    The collection contains 563 recordings (~73.6 hours, 15,372 annotated
+    events, 6,702 identified to 168 species), recorded as 10-second clips every
+    30 minutes over 24-hour cycles across five monitoring projects in 2023-2025.
+
+    Splits
+    ------
+    Recordings are grouped by monitoring project, each exposed as a split, plus
+    a combined ``all`` split:
+
+        - ``map1`` : Magdalena (46 recordings)
+        - ``ppa1`` : Putumayo, project 1 (108)
+        - ``ppa2`` : Putumayo, project 2 (137)
+        - ``ppa3`` : Putumayo, project 3 (151)
+        - ``ppa4`` : Putumayo, project 4 (121)
+        - ``all``  : all five combined (563)
+
+    Pre-resampled Audio
+    -------------------
+    Originals are 192 kHz mono WAV. Pre-resampled audio is available at 16 kHz
+    and 32 kHz (16-bit PCM WAV). When ``sample_rate`` matches one of these
+    rates, the pre-resampled files are loaded directly (no on-the-fly
+    resampling). For any other target rate, audio is resampled on-the-fly using
+    librosa's ``kaiser_best`` method.
+
+    References
+    ----------
+    https://zenodo.org/records/19137071
+    https://github.com/microsoft/PteroSet
+    arXiv:2605.20578
+    """
+
+    info = DatasetInfo(
+        name="pteroset",
+        owner="david",
+        split_paths={
+            "all": f"{_RAW_ROOT}/all.csv",
+            "map1": f"{_RAW_ROOT}/map1.csv",
+            "ppa1": f"{_RAW_ROOT}/ppa1.csv",
+            "ppa2": f"{_RAW_ROOT}/ppa2.csv",
+            "ppa3": f"{_RAW_ROOT}/ppa3.csv",
+            "ppa4": f"{_RAW_ROOT}/ppa4.csv",
+        },
+        version="0.1.0",
+        description=(
+            "PteroSet — a strongly annotated passive-acoustic dataset for "
+            "tropical bird monitoring from Colombia. 563 recordings (~73.6 h, "
+            "15,372 expert Raven-annotated events, 6,702 to 168 species) across "
+            "five monitoring projects, with time-frequency selection tables. "
+            "Species coerced to GBIF canonical names; raw PteroSet codes "
+            "retained. Originals at 192 kHz; pre-resampled 16 kHz and 32 kHz "
+            "versions available."
+        ),
+        sources=["https://zenodo.org/records/19137071"],
+        license="CC-BY-4.0",
+    )
+
+    _sample_rate_paths: dict[int, str] = {16000: "16khz_path", 32000: "32khz_path"}
+    _originals_path_column = "audio_fp"
+
+    def __init__(
+        self,
+        split: str = "all",
+        output_take_and_give: dict[str, str] | None = None,
+        sample_rate: int | None = 16000,
+        data_root: str | AnyPathT | None = None,
+        backend: BackendType = "pandas",
+        streaming: bool = False,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        split : str
+            Split to load (key in info.split_paths): ``all`` or one of
+            ``map1``/``ppa1``/``ppa2``/``ppa3``/``ppa4``.
+        output_take_and_give : dict[str, str] | None
+            Optional mapping of original → new output keys (filters columns as well).
+        sample_rate : int | None
+            If set, audio is resampled to this rate.
+        data_root : str | AnyPathT | None
+            Optional root directory to prepend to each row's audio path.
+        backend : BackendType, optional
+            The backend to use ("pandas" or "polars"), by default "pandas".
+        streaming : bool, optional
+            Whether to use streaming mode, by default False.
+        """
+        super().__init__(output_take_and_give, backend=backend, streaming=streaming)
+        self.split = split
+        self._data = None
+        self.annotation_columns = ["Species"]
+        self.unknown_label = "Unknown"
+        self.sample_rate = sample_rate
+
+        self.full_dataset_available_labels = None  # placeholder for labels if split == all
+
+        self._load()
+
+        if data_root is None:
+            self.data_root = anypath(self.info.split_paths[self.split]).parent
+        else:
+            self.data_root = anypath(data_root)
+
+    @property
+    def columns(self) -> list[str]:
+        return list(self._data.columns) if self._data is not None else []
+
+    @property
+    def available_splits(self) -> list[str]:
+        return list(self.info.split_paths.keys())
+
+    @property
+    def available_sample_rates(self) -> list[int]:
+        """Return pre-resampled sample rates whose path columns exist in the data."""
+        return [sr for sr, col in self._sample_rate_paths.items() if col in self._data.columns]
+
+    def _load(self) -> None:
+        if self.split not in self.info.split_paths:
+            raise LookupError(
+                f"Invalid split: {self.split}. Expected one of {list(self.info.split_paths.keys())}"
+            )
+        location = self.info.split_paths[self.split]
+        self._data = self._backend_class.from_csv(
+            location,
+            streaming=self._streaming,
+            keep_default_na=False,
+            na_values=[""],
+        )
+
+    def __len__(self) -> int:
+        """Return the number of samples in the dataset.
+
+        Returns
+        -------
+        int
+            Number of samples in the current split.
+
+        Raises
+        ------
+        RuntimeError
+            If no split has been loaded yet.
+        """
+        if self._data is None:
+            raise RuntimeError("No split has been loaded yet. Call _load() first.")
+        if self._streaming:
+            raise NotImplementedError(
+                "Length is not available in streaming mode. Iterate over the dataset instead."
+            )
+        return len(self._data)
+
+    def _process(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Process a single row of the dataset.
+
+        When the row contains ``window_start_sec`` / ``window_end_sec`` (set by
+        a caller or transform), only the corresponding audio
+        segment is loaded from disk/GCS instead of the full recording.
+
+        Parameters
+        ----------
+        row : dict[str, Any]
+            A dictionary representing a single row of the dataset.
+
+        Returns
+        -------
+        dict[str, Any]
+            The processed row.
+        """
+        use_presampled = False
+        if self.sample_rate is not None and self.sample_rate in self._sample_rate_paths:
+            path_column = self._sample_rate_paths[self.sample_rate]
+            if path_column in row and row[path_column] is not None and row[path_column] != "":
+                audio_path = anypath(self.data_root) / row[path_column]
+                use_presampled = True
+
+        if not use_presampled:
+            audio_path = anypath(self.data_root) / row[self._originals_path_column]
+
+        window_start = row.get("window_start_sec")
+        window_end = row.get("window_end_sec")
+
+        if window_start is not None and window_end is not None:
+            audio, sr = read_audio(
+                audio_path, start_time=float(window_start), end_time=float(window_end)
+            )
+        else:
+            audio, sr = read_audio(audio_path)
+
+        audio = audio_stereo_to_mono(audio, mono_method="average").astype(np.float32)
+
+        if not use_presampled and self.sample_rate is not None and sr != self.sample_rate:
+            audio = librosa.resample(
+                y=audio,
+                orig_sr=sr,
+                target_sr=self.sample_rate,
+                scale=True,
+                res_type="kaiser_best",
+            )
+            sr = self.sample_rate
+
+        row["audio"] = audio
+        row["sample_rate"] = sr
+
+        raw_st = row.get("selection_table")
+        if raw_st is not None:
+            if isinstance(raw_st, str):
+                st = pd.read_csv(StringIO(raw_st), sep="\t")
+            elif isinstance(raw_st, pd.DataFrame):
+                st = raw_st
+            else:
+                st = pd.DataFrame()
+
+            audio_dur = len(audio) / float(sr)
+            if window_start is not None and window_end is not None:
+                st = window_selection_table(st, float(window_start), audio_dur)
+            else:
+                st = clip_selection_table(st, audio_dur)
+            row["selection_table"] = st
+
+        if self.output_take_and_give:
+            item = {}
+            for old_key, new_key in self.output_take_and_give.items():
+                item[new_key] = row[old_key]
+            return item
+
+        return row
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        """Get a specific sample from the dataset.
+
+        Parameters
+        ----------
+        idx : int
+            Index of the sample to get.
+
+        Returns
+        -------
+        dict[str, Any]
+            A dictionary containing the audio, sample rate, and selection table.
+        """
+        row = self._data[idx]
+        return self._process(row)
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        """Iterate over samples in the dataset.
+
+        Yields
+        ------
+        dict[str, Any]
+            Each sample in the dataset.
+        """
+        for row in self._data:
+            yield self._process(row)
+
+    @classmethod
+    def from_config(cls, dataset_config: DatasetConfig) -> tuple["PteroSet", dict[str, Any]]:
+        """Create a Dataset instance from a configuration dictionary.
+
+        Parameters
+        ----------
+        dataset_config : DatasetConfig
+            Configuration dictionary containing dataset parameters.
+
+        Returns
+        -------
+        tuple[PteroSet, dict[str, Any]]
+            A tuple containing the dataset instance and metadata. If the
+            dataset_config contains transformations, they will be applied and
+            the metadata will be returned as dict, otherwise an empty dict.
+        """
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
+        ds = cls(
+            split=cfg["split"],
+            output_take_and_give=cfg["output_take_and_give"],
+            data_root=cfg["data_root"],
+            sample_rate=cfg["sample_rate"],
+            backend=cfg["backend"],
+            streaming=cfg["streaming"],
+        )
+
+        if dataset_config.transformations:
+            meta = ds.apply_transformations(dataset_config.transformations)
+            return ds, meta
+
+        return ds, {}
+
+    def get_available_labels(self, anno_column: str | None = "Species") -> list[str]:
+        """Return all possible species labels.
+
+        Returns
+        -------
+        list[str]
+            A list of all the available labels for ``anno_column``.
+        """
+        if self.split == "all":
+            if self.full_dataset_available_labels is None:
+                self.full_dataset_available_labels = pd.read_csv(SPECIES_INFO_PATH)[
+                    "Species"
+                ].to_list()
+            return self.full_dataset_available_labels
+        else:
+            available_labels = set()
+            for row in self._data:
+                st = pd.read_csv(StringIO(row["selection_table"]), sep="\t")
+                available_labels.update(st[anno_column].astype(str).tolist())
+            return sorted(available_labels)
+
+    def __str__(self) -> str:
+        base = f"{self.info.name} (v{self.info.version})"
+        return (
+            f"{base}\n"
+            f"Sources: {self.info.sources}\n"
+            f"License: {self.info.license}\n"
+            f"Available splits: {', '.join(self.info.split_paths.keys())}"
+        )

--- a/alp_data/datasets/xeno_canto_strong.py
+++ b/alp_data/datasets/xeno_canto_strong.py
@@ -1,0 +1,395 @@
+"""Xeno-canto strongly-annotated subset (event-level human annotations).
+
+The XC project hosts a curated set of soundscape recordings where human
+annotators have marked the start/end of individual vocalizations and
+labelled each event with the segment-level ``scientific_name``. This
+dataset is shaped to match `WABAD` exactly —
+one row per audio file, with all events for that file embedded in an
+inline ``selection_table`` TSV — so the existing
+windowed-read + annotation transform chain works unchanged.
+
+Built from three GCS-resident CSVs in the xeno-canto v0.1.0 pipeline:
+``xc_annotation_segments.csv`` (per-event), ``xc_annotated_extras.csv``
+(per-recording GBIF + paths), ``xc_annotated_recordings.csv`` (per-rec
+duration). See ``scripts/data_preprocessing_scripts/xeno_canto_strong/
+build_xc_strong.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from io import StringIO
+from typing import Any
+
+import librosa
+import numpy as np
+import pandas as pd
+
+from alp_data import Dataset, DatasetConfig, DatasetInfo, register_dataset
+from alp_data.backends import BackendType
+from alp_data.datasets._windowing import clip_selection_table, window_selection_table
+from alp_data.io import AnyPathT, anypath, audio_stereo_to_mono, read_audio
+
+# Staged in the ingestion bucket. Moves under DATA_HOME (as WABAD and
+# most datasets resolve) when this lands; the loader picks the new
+# location up from this one constant.
+_RAW_ROOT = "gs://esp-data-ingestion/xeno-canto/v0.1.0/raw"
+
+
+@register_dataset
+class XenoCantoStrong(Dataset):
+    """Xeno-canto event-level strongly-annotated dataset (WABAD-shaped).
+
+    Description
+    -----------
+    21,300 audio files from xeno-canto's human-annotated subset (mostly
+    soundscape recordings; XC's per-file focal ``recording_scientific_name``
+    is the catch-all ``Sonus naturalis`` for ~99% of these files, but
+    each file carries 1-73 annotated events with true species labels in
+    its ``selection_table`` TSV — 68,755 events / 811 unique segment-
+    level species in total).
+
+    The schema mirrors `WABAD` so the existing
+    windowed-read + annotation pipeline
+    works without modification: each row is one audio file with
+    ``audio_fp``, ``16khz_path``, ``32khz_path``, ``audio_duration``,
+    and an inline ``selection_table`` TSV whose columns are
+    ``Begin Time (s)``, ``End Time (s)``, ``Low Freq (Hz)``,
+    ``High Freq (Hz)``, ``Species``, ``sound_type``, ``sex``,
+    ``life_stage``, ``annotator``.
+
+    Columns
+    -------
+    xc_id : int
+        Xeno-canto recording id (numeric, no XC prefix).
+    audio_fp : str
+        Relative path to the original audio (e.g. ``audio/XC65654.mp3``).
+    16khz_path, 32khz_path : str
+        Relative paths to pre-resampled mirrors.
+    audio_duration : float
+        Clip duration in seconds (parsed from XC ``length``).
+    selection_table : str
+        TSV string holding all event annotations for this file.
+    n_events : int
+        Number of events embedded in ``selection_table``.
+    recording_scientific_name : str
+        File-level focal species (mostly ``Sonus naturalis``); the true
+        per-event labels live inside ``selection_table.Species``.
+    recording_species_common : str
+        File-level common name (mostly empty for soundscapes).
+    kingdom, phylum, class, order, family, genus : str
+        File-level (focal) GBIF taxonomy.
+    gbifID, taxonKey, speciesKey : str
+        File-level GBIF identifiers.
+    latitudeDecimal, longitudeDecimal, country_code, locality, continent :
+        Geographic context for the recording.
+    eventDate, year, month, day : str
+        Recording date.
+    recordedBy, rightsHolder : str
+        Attribution.
+    license, media_license, license_url, media_license_url : str
+        Per-recording licensing. Mostly CC-BY-NC-SA-4.0.
+    source_dataset : str
+        Constant ``"xeno_canto_strong"``.
+
+    Splits
+    ------
+    - ``all``: every file (21,300 rows). No held-out subset yet — the
+      caller is expected to apply leakage filters via the YAML chain
+      (e.g. ``drop_where_column_contains`` for BEANS-Zero held-out taxa,
+      following the iNaturalist / xeno-canto pattern).
+
+    Available tasks
+    ---------------
+    Same as WABAD when combined with windowed reads and annotation
+    transforms: multilabel species, species count,
+    per-species call counts, frequency-range summaries, etc.
+
+    References
+    ----------
+    Xeno-canto annotated audio collection (see
+    ``configs/xc_annotated_audio.yaml`` and ``jobs/run_xc_annotated_audio.sh``
+    in the alp-data pipeline). License: CC-BY-NC-SA-4.0 dominates.
+    """
+
+    info = DatasetInfo(
+        name="xeno_canto_strong",
+        owner="david",
+        split_paths={
+            "all": f"{_RAW_ROOT}/xc_strong_with_selection_table.csv",
+        },
+        version="0.1.0",
+        description=(
+            "Xeno-canto event-level human annotations: 21,300 files with "
+            "68,755 events spanning 811 species, shaped as a WABAD-style "
+            "manifest with inline selection_table TSV per file."
+        ),
+        sources=(
+            "xeno-canto.org annotated recordings (gs://esp-data-ingestion/"
+            "xeno-canto/v0.1.0/raw/xc_annotation_segments.csv)"
+        ),
+        license="CC-BY-NC-SA-4.0 (mostly)",
+    )
+
+    _sample_rate_paths: dict[int, str] = {16000: "16khz_path", 32000: "32khz_path"}
+    _originals_path_column = "audio_fp"
+
+    def __init__(
+        self,
+        split: str = "all",
+        output_take_and_give: dict[str, str] | None = None,
+        sample_rate: int | None = 32000,
+        data_root: str | AnyPathT | None = None,
+        backend: BackendType = "pandas",
+        streaming: bool = False,
+    ) -> None:
+        """Initialise the XenoCantoStrong dataset.
+
+        Parameters
+        ----------
+        split : str
+            Split key in `info.split_paths`. Only ``"all"`` exists.
+        output_take_and_give : dict[str, str] | None
+            Optional column rename / selection mapping.
+        sample_rate : int | None
+            Target rate. Pre-resampled 16 kHz / 32 kHz mirrors used when
+            available. Defaults to 32 kHz to match the xeno-canto-focused
+            entries elsewhere in Stage 2.
+        data_root : str | AnyPathT | None
+            Root prepended to relative audio paths. Defaults to the GCS
+            xeno-canto raw root.
+        backend : BackendType
+            ``"polars"`` or ``"pandas"``.
+        streaming : bool
+            Whether to use streaming mode.
+        """
+        super().__init__(output_take_and_give, backend=backend, streaming=streaming)
+        self.split = split
+        self.sample_rate = sample_rate
+        self._data = None
+        self.annotation_columns = ["Species"]
+        self._load()
+
+        if data_root is None:
+            self.data_root = anypath(self.info.split_paths[self.split]).parent
+        else:
+            self.data_root = anypath(data_root)
+
+    @property
+    def columns(self) -> list[str]:
+        return list(self._data.columns) if self._data is not None else []
+
+    @property
+    def available_splits(self) -> list[str]:
+        return list(self.info.split_paths.keys())
+
+    @property
+    def available_sample_rates(self) -> list[int]:
+        """Return pre-resampled sample rates whose path columns exist in the data."""
+        return [
+            sr
+            for sr, col in self._sample_rate_paths.items()
+            if col in (self._data.columns if self._data is not None else [])
+        ]
+
+    def _load(self) -> None:
+        """Load the split CSV.
+
+        Raises
+        ------
+        LookupError
+            If the split is not valid.
+        """
+        if self.split not in self.info.split_paths:
+            raise LookupError(
+                f"Invalid split: {self.split}. Expected one of {list(self.info.split_paths.keys())}"
+            )
+        self._data = self._backend_class.from_csv(
+            self.info.split_paths[self.split],
+            streaming=self._streaming,
+            keep_default_na=False,
+            na_values=[""],
+        )
+
+    def __len__(self) -> int:
+        """Return the number of files in the split.
+
+        Returns
+        -------
+        int
+            Number of files in the current split.
+
+        Raises
+        ------
+        RuntimeError
+            If no split has been loaded yet.
+        """
+        if self._data is None:
+            raise RuntimeError("No split has been loaded yet. Call _load() first.")
+        if self._streaming:
+            raise NotImplementedError("Length is not available in streaming mode.")
+        return len(self._data)
+
+    def _process(self, row: dict[str, Any]) -> dict[str, Any]:
+        """Process a single row.
+
+        Mirrors `WABAD._process`. If a transform
+        has set ``window_start_sec`` / ``window_end_sec`` (e.g.
+        a caller or transform), only that audio segment is read.
+
+        Parameters
+        ----------
+        row : dict[str, Any]
+            A dictionary representing a single row of the dataset.
+
+        Returns
+        -------
+        dict[str, Any]
+            The processed row with ``audio``, ``sample_rate`` populated.
+        """
+        use_presampled = False
+        audio_path = None
+        if self.sample_rate is not None and self.sample_rate in self._sample_rate_paths:
+            col = self._sample_rate_paths[self.sample_rate]
+            val = row.get(col)
+            if val is not None:
+                s = str(val).strip()
+                if s and s.lower() != "nan":
+                    audio_path = anypath(self.data_root) / s
+                    use_presampled = True
+        if audio_path is None:
+            audio_path = anypath(self.data_root) / str(row[self._originals_path_column])
+
+        window_start = row.get("window_start_sec")
+        window_end = row.get("window_end_sec")
+        if window_start is not None and window_end is not None:
+            audio, sr = read_audio(
+                audio_path, start_time=float(window_start), end_time=float(window_end)
+            )
+        else:
+            audio, sr = read_audio(audio_path)
+
+        audio = audio_stereo_to_mono(audio, mono_method="average").astype(np.float32)
+        if not use_presampled and self.sample_rate is not None and sr != self.sample_rate:
+            audio = librosa.resample(
+                y=audio,
+                orig_sr=sr,
+                target_sr=self.sample_rate,
+                scale=True,
+                res_type="kaiser_best",
+            )
+            sr = self.sample_rate
+
+        row["audio"] = audio
+        row["sample_rate"] = sr
+
+        raw_st = row.get("selection_table")
+        if raw_st is not None:
+            if isinstance(raw_st, str):
+                st = pd.read_csv(StringIO(raw_st), sep="\t", keep_default_na=False)
+            elif isinstance(raw_st, pd.DataFrame):
+                st = raw_st
+            else:
+                st = pd.DataFrame()
+            audio_dur = len(audio) / float(sr)
+            if window_start is not None and window_end is not None:
+                st = window_selection_table(st, float(window_start), audio_dur)
+            else:
+                st = clip_selection_table(st, audio_dur)
+            row["selection_table"] = st
+
+        if self.output_take_and_give:
+            return {new: row[old] for old, new in self.output_take_and_give.items()}
+        return row
+
+    def __getitem__(self, idx: int) -> dict[str, Any]:
+        """Return a single processed row.
+
+        Returns
+        -------
+        dict[str, Any]
+            The processed row (audio + selection_table + metadata).
+        """
+        return self._process(self._data[idx])
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        """Iterate over processed rows.
+
+        Yields
+        ------
+        dict[str, Any]
+            Each processed row.
+        """
+        for row in self._data:
+            yield self._process(row)
+
+    @classmethod
+    def from_config(cls, dataset_config: DatasetConfig) -> tuple["XenoCantoStrong", dict[str, Any]]:
+        """Create an XenoCantoStrong instance from a configuration.
+
+        Parameters
+        ----------
+        dataset_config : DatasetConfig
+            Dataset configuration.
+
+        Returns
+        -------
+        tuple[XenoCantoStrong, dict[str, Any]]
+            The dataset and any transformation metadata.
+        """
+        cfg = dataset_config.model_dump(exclude={"dataset_name", "transformations"})
+        ds = cls(
+            split=cfg["split"],
+            output_take_and_give=cfg["output_take_and_give"],
+            sample_rate=cfg["sample_rate"],
+            data_root=cfg["data_root"],
+            backend=cfg["backend"],
+            streaming=cfg["streaming"],
+        )
+        if dataset_config.transformations:
+            meta = ds.apply_transformations(dataset_config.transformations)
+            return ds, meta
+        return ds, {}
+
+    def get_available_labels(self, annotation_column: str = "Species") -> list[str]:
+        """Return all per-event species labels found in selection_tables.
+
+        Parameters
+        ----------
+        annotation_column : str
+            Column inside each row's selection_table TSV. Defaults to ``"Species"``.
+
+        Returns
+        -------
+        list[str]
+            Sorted unique label values across the dataset.
+
+        Raises
+        ------
+        ValueError
+            If ``annotation_column`` is not present in the selection_table.
+        """
+        labels: set[str] = set()
+        for row in self._data:
+            raw = row.get("selection_table")
+            if not raw:
+                continue
+            st = pd.read_csv(StringIO(raw), sep="\t", keep_default_na=False)
+            if annotation_column not in st.columns:
+                raise ValueError(
+                    f"Column '{annotation_column}' not in selection_table; "
+                    f"available: {list(st.columns)}"
+                )
+            labels.update(st[annotation_column].astype(str).tolist())
+        return sorted(labels)
+
+    def __str__(self) -> str:
+        base = f"{self.info.name} (v{self.info.version})"
+        n = len(self) if self._data is not None and not self._streaming else "?"
+        return (
+            f"{base}\n"
+            f"Files: {n}\n"
+            f"Sources: {self.info.sources}\n"
+            f"License: {self.info.license}\n"
+            f"Available splits: {', '.join(self.info.split_paths.keys())}"
+        )

--- a/scripts/data_preprocessing_scripts/dartmouth_avian_soundscapes_build_csv.py
+++ b/scripts/data_preprocessing_scripts/dartmouth_avian_soundscapes_build_csv.py
@@ -1,0 +1,211 @@
+"""
+Build Dartmouth Avian Soundscapes split CSVs (WABAD-style) from staged data.
+
+Each 10-minute recording becomes one CSV row with an embedded tab-separated
+``selection_table`` string. Writes ``acad.csv`` / ``mabi.csv`` / ``simr.csv`` /
+``all.csv`` (one per split) plus ``species_labels.csv``, and a QC report, then
+uploads them to the GCS dataset root.
+
+Selection-table columns (per annotated event):
+    Begin Time (s), End Time (s), Low Freq (Hz), High Freq (Hz),
+    Species (GBIF canonical), Species Code (raw AOU), Common Name, Background
+
+Inputs (all local, from the staging dir produced by *_stage.sh):
+    meta/recording_metadata.csv   recording <-> annotation join + site/date
+    meta/site_metadata.csv        lat/lon per site
+    species_taxonomy.csv          AOU code -> GBIF canonical + common name
+    extract_ann/<Dataset>/*.txt   Raven Pro selection tables
+    extract_rec/<Dataset>/*.flac  used only to read audio_duration (header)
+
+Usage:
+    uv run python scripts/data_preprocessing_scripts/dartmouth_avian_soundscapes_build_csv.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+
+import pandas as pd
+import soundfile as sf
+
+UNKNOWN_LABEL = "Unknown"
+GCS_ROOT = "gs://esp-data-ingestion/dartmouth-avian-soundscapes/v0.1.0"
+
+# Dataset_ID -> short split key
+SUBDATASET = {"DatasetACAD": "acad", "DatasetMABI": "mabi", "DatasetSIMR": "simr"}
+
+# Final order of columns kept in each embedded selection table.
+ST_COLUMNS = [
+    "Begin Time (s)",
+    "End Time (s)",
+    "Low Freq (Hz)",
+    "High Freq (Hz)",
+    "Species",
+    "Species Code",
+    "Common Name",
+    "Background",
+]
+
+
+def build_selection_table(
+    ann_path: str,
+    code_to_species: dict[str, str],
+    code_to_common: dict[str, str],
+    qc: list[dict],
+    fn: str,
+) -> str:
+    """Parse one Raven .txt and return a cleaned tab-separated selection table.
+
+    Returns
+    -------
+    str
+        The cleaned selection table serialised as a tab-separated string.
+    """
+    if not ann_path or not os.path.exists(ann_path):
+        qc.append({"fn": fn, "issue": "annotation_file_missing"})
+        return pd.DataFrame(columns=ST_COLUMNS).to_csv(sep="\t", index=False)
+
+    raw = pd.read_csv(ann_path, sep="\t")
+    # Raw Raven column "Species" holds the 4-letter AOU code.
+    raw = raw.rename(columns={"Species": "Species Code"})
+    raw["Species Code"] = raw["Species Code"].astype(str).str.strip()
+
+    unmapped = sorted(set(raw["Species Code"]) - set(code_to_species))
+    if unmapped:
+        qc.append({"fn": fn, "issue": f"codes_not_in_metadata: {unmapped}"})
+
+    raw["Species"] = raw["Species Code"].map(lambda c: code_to_species.get(c, UNKNOWN_LABEL))
+    raw["Common Name"] = raw["Species Code"].map(lambda c: code_to_common.get(c, UNKNOWN_LABEL))
+    if "Background" not in raw.columns:
+        raw["Background"] = ""
+    raw["Background"] = raw["Background"].fillna("").astype(str).str.strip()
+
+    st = raw[[c for c in ST_COLUMNS if c in raw.columns]].copy()
+    return st.to_csv(sep="\t", index=False)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--work", default=os.path.expanduser("~/dartmouth_staging"))
+    p.add_argument("--taxonomy", default="species_taxonomy.csv")
+    p.add_argument("--gcs-root", default=GCS_ROOT)
+    p.add_argument("--out-dir", default=os.path.expanduser("~/dartmouth_staging/csv"))
+    args = p.parse_args()
+
+    meta_dir = os.path.join(args.work, "meta")
+    ann_dir = os.path.join(args.work, "extract_ann")
+    rec_dir = os.path.join(args.work, "extract_rec")
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    # Index local files by basename (robust to the differing zip folder names:
+    # recordings extract to <ds>_Recordings/ while annotations extract to <ds>/).
+    flac_paths = glob.glob(os.path.join(rec_dir, "**", "*.flac"), recursive=True)
+    ann_paths = glob.glob(os.path.join(ann_dir, "**", "*.txt"), recursive=True)
+    # Index by ItemID (filename prefix before the first "."). recording_metadata
+    # occasionally disagrees with the actual filename on the volatile middle
+    # field / time for a handful of rows, but the ItemID prefix is stable+unique.
+    flac_index = {os.path.basename(p).split(".")[0]: p for p in flac_paths}
+    ann_index = {os.path.basename(p).split(".")[0]: p for p in ann_paths}
+    print(
+        f"indexed {len(flac_index)} flac and {len(ann_index)} annotation files by ItemID "
+        f"({len(flac_paths)} flac / {len(ann_paths)} txt on disk)"
+    )
+
+    recs = pd.read_csv(os.path.join(meta_dir, "recording_metadata.csv"), dtype=str).fillna("")
+    sites = pd.read_csv(os.path.join(meta_dir, "site_metadata.csv"), dtype=str).fillna("")
+    site_ll = {
+        r["SiteID"]: (r.get("Latitude", ""), r.get("Longitude", "")) for _, r in sites.iterrows()
+    }
+
+    tax = pd.read_csv(args.taxonomy, dtype=str).fillna("")
+    code_to_species = dict(zip(tax["AOU_Code"], tax["canonical_name"], strict=False))
+    code_to_common = dict(zip(tax["AOU_Code"], tax["Common_Name"], strict=False))
+
+    qc: list[dict] = []
+    rows: list[dict] = []
+
+    for i, r in recs.iterrows():
+        if i % 200 == 0:
+            print(f"{i} / {len(recs)}")
+        ds_id = r["Dataset_ID"]
+        sub = SUBDATASET.get(ds_id)
+        if sub is None:
+            qc.append({"fn": r.get("Recording_FileName", ""), "issue": f"unknown_dataset:{ds_id}"})
+            continue
+
+        item_id = r.get("ItemID", "")
+        flac_path = flac_index.get(item_id, "")
+        ann_path = ann_index.get(item_id, "")
+        # use the actual on-disk filename for GCS paths (metadata can be stale)
+        rec_fn = os.path.basename(flac_path) if flac_path else r["Recording_FileName"]
+        stem = os.path.splitext(rec_fn)[0]
+        fn = stem
+
+        # audio_duration from FLAC header (fast; no decode)
+        duration = ""
+        sr = ""
+        if flac_path and os.path.exists(flac_path):
+            info = sf.info(flac_path)
+            duration = round(float(info.frames) / float(info.samplerate), 6)
+            sr = int(info.samplerate)
+        else:
+            qc.append({"fn": fn, "issue": "recording_file_missing"})
+
+        st_str = build_selection_table(ann_path, code_to_species, code_to_common, qc, fn)
+        n_events = max(st_str.count("\n") - 1, 0)  # minus header line
+        lat, lon = site_ll.get(r.get("SiteID", ""), ("", ""))
+
+        rows.append(
+            {
+                "fn": fn,
+                "item_id": r.get("ItemID", ""),
+                "subdataset": sub,
+                "audio_fp": f"recordings/{ds_id}/{rec_fn}",
+                "16khz_path": f"audio_16k/{ds_id}/{stem}.wav",
+                "32khz_path": f"audio_32k/{ds_id}/{stem}.wav",
+                "audio_duration": duration,
+                "sample_rate": sr,
+                "site_id": r.get("SiteID", ""),
+                "park_id": r.get("ParkID", ""),
+                "year": r.get("Year", ""),
+                "date": r.get("Date", ""),
+                "time": r.get("Time", ""),
+                "latitude": lat,
+                "longitude": lon,
+                "n_events": n_events,
+                "selection_table": st_str,
+            }
+        )
+
+    all_df = pd.DataFrame(rows)
+
+    # Write splits + all
+    def _save(df: pd.DataFrame, name: str) -> None:
+        local = os.path.join(args.out_dir, name)
+        df.to_csv(local, index=False)
+        os.system(f"gsutil -q cp {local} {args.gcs_root}/{name}")
+        print(f"  wrote {name}: {len(df)} rows -> {args.gcs_root}/{name}")
+
+    _save(all_df, "all.csv")
+    for sub in SUBDATASET.values():
+        _save(all_df[all_df["subdataset"] == sub].reset_index(drop=True), f"{sub}.csv")
+
+    # species label vocabulary (resolved canonical names, excludes Unknown)
+    labels = sorted({s for s in code_to_species.values() if s and s != UNKNOWN_LABEL})
+    labels_df = pd.DataFrame({"Species": labels})
+    _save(labels_df, "species_labels.csv")
+
+    # QC report
+    qc_df = pd.DataFrame(qc)
+    qc_local = os.path.join(args.out_dir, "qc_report.csv")
+    qc_df.to_csv(qc_local, index=False)
+    print(f"\nTotal recordings: {len(all_df)}  total events: {int(all_df['n_events'].sum())}")
+    print(f"QC issues: {len(qc_df)} -> {qc_local}")
+    if len(qc_df):
+        print(qc_df["issue"].str.replace(r":.*", "", regex=True).value_counts().to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data_preprocessing_scripts/dartmouth_avian_soundscapes_stage_job.sh
+++ b/scripts/data_preprocessing_scripts/dartmouth_avian_soundscapes_stage_job.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Stage the Dartmouth "Acoustic Forest Soundscape Dataset of Avian
+# Vocalizations from Eastern North America" (Zenodo record 20038954) into
+# gs://esp-data-ingestion/dartmouth-avian-soundscapes/v0.1.0/.
+#
+# Downloads the 3 recording zips, 3 annotation zips, and the metadata files
+# from Zenodo, extracts them, and uploads to GCS in the standard layout:
+#
+#   recordings/<DatasetID>/*.flac   (lossless originals, 32 kHz)
+#   annotations/<DatasetID>/*.txt   (Raven Pro selection tables)
+#   metadata/*.csv, ReadMe.txt
+#
+# Heavy on network/IO (not memory); intended to run on the dev VM in the
+# background (the Zenodo download needs external internet). Idempotent:
+# re-running resumes downloads and re-syncs to GCS.
+#
+# Set WORK to a directory on a disk with ~60 GB free (zips + extracted). On the
+# dev VM that is the NFS share (/mnt/home/...), not local $HOME.
+#
+# USAGE:
+#   WORK=/mnt/home/dartmouth_staging \
+#     nohup bash scripts/data_preprocessing_scripts/dartmouth_avian_soundscapes_stage.sh \
+#       > /mnt/home/dartmouth_staging/stage.log 2>&1 &
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+ZENODO="https://zenodo.org/records/20038954/files"
+GCS_ROOT="gs://esp-data-ingestion/dartmouth-avian-soundscapes/v0.1.0"
+WORK="${WORK:-$HOME/dartmouth_staging}"
+
+ZIPS="$WORK/zips"
+REC="$WORK/extract_rec"
+ANN="$WORK/extract_ann"
+META="$WORK/meta"
+mkdir -p "$ZIPS" "$REC" "$ANN" "$META"
+
+DATASETS=(DatasetACAD DatasetMABI DatasetSIMR)
+META_FILES=(recording_metadata.csv site_metadata.csv species_metadata.csv data_dictionary.csv ReadMe.txt)
+
+dl() {  # dl <filename> <dest_dir>   (skip if already complete; else resume)
+    local fn="$1" dest="$2"
+    local url="$ZENODO/$fn?download=1"
+    local remote local_sz=0
+    remote=$(curl -sIL "$url" 2>/dev/null \
+        | awk 'BEGIN{IGNORECASE=1}/^content-length:/{cl=$2} END{gsub(/\r/,"",cl); print cl}')
+    [ -f "$dest/$fn" ] && local_sz=$(stat -c%s "$dest/$fn")
+    if [ -n "$remote" ] && [ "$local_sz" = "$remote" ]; then
+        echo "[$(date +%H:%M:%S)] skip $fn (complete: $remote bytes)"
+        return 0
+    fi
+    curl -fsSL -C - --retry 8 --retry-delay 10 -o "$dest/$fn" "$url"
+}
+
+echo "=== 1. metadata ==="
+for f in "${META_FILES[@]}"; do
+    [ -f "$META/$f" ] || dl "$f" "$META"
+done
+gsutil -m -q cp "$META"/*.csv "$META/ReadMe.txt" "$GCS_ROOT/metadata/"
+
+echo "=== 2. download all zips in parallel (Zenodo throttles ~1MB/s per connection) ==="
+pids=()
+for ds in "${DATASETS[@]}"; do
+    dl "${ds}_Recordings.zip"  "$ZIPS" & pids+=($!)
+    dl "${ds}_Annotations.zip" "$ZIPS" & pids+=($!)
+done
+echo "[$(date +%H:%M:%S)] launched ${#pids[@]} downloads (pids: ${pids[*]})"
+fail=0
+for pid in "${pids[@]}"; do
+    wait "$pid" || { echo "WARN: download pid $pid exited non-zero"; fail=1; }
+done
+[ "$fail" -eq 0 ] || { echo "ERROR: one or more downloads failed; re-run to resume"; exit 1; }
+echo "[$(date +%H:%M:%S)] all downloads complete"
+
+echo "=== 3. extract + upload per dataset ==="
+# Recordings zips extract to <ds>_Recordings/ and annotations to <ds>/; both are
+# normalised to recordings/<ds>/ and annotations/<ds>/ on GCS.
+for ds in "${DATASETS[@]}"; do
+    echo "[$(date +%H:%M:%S)] extracting $ds ..."
+    # zip dir entries are stored read-only (mode 555); make writable so a
+    # re-run's `unzip -o` can overwrite instead of failing on delete.
+    chmod -R u+w "$REC" "$ANN" 2>/dev/null || true
+    unzip -o -q "$ZIPS/${ds}_Recordings.zip"  -d "$REC"
+    unzip -o -q "$ZIPS/${ds}_Annotations.zip" -d "$ANN"
+
+    rec_dir=$(find "$REC" -maxdepth 1 -type d -name "${ds}*" | head -1)
+    ann_dir=$(find "$ANN" -maxdepth 1 -type d -name "${ds}*" | head -1)
+    echo "[$(date +%H:%M:%S)] uploading $ds recordings ($(basename "$rec_dir")) -> GCS ..."
+    gsutil -m -q rsync -r "$rec_dir" "$GCS_ROOT/recordings/$ds"
+    echo "[$(date +%H:%M:%S)] uploading $ds annotations ($(basename "$ann_dir")) -> GCS ..."
+    gsutil -m -q rsync -r "$ann_dir" "$GCS_ROOT/annotations/$ds"
+done
+
+echo "=== 3. counts ==="
+echo "flac uploaded: $(gsutil ls -r "$GCS_ROOT/recordings/**.flac" 2>/dev/null | wc -l)"
+echo "txt  uploaded: $(gsutil ls -r "$GCS_ROOT/annotations/**.txt" 2>/dev/null | wc -l)"
+echo "[$(date +%H:%M:%S)] staging DONE"

--- a/scripts/data_preprocessing_scripts/dartmouth_avian_soundscapes_taxonomy.py
+++ b/scripts/data_preprocessing_scripts/dartmouth_avian_soundscapes_taxonomy.py
@@ -1,0 +1,123 @@
+"""
+Resolve Dartmouth Avian Soundscapes AOU species codes -> GBIF canonical names.
+
+Reads ``species_metadata.csv`` (AOU_Code, IsBird, Common_Name, Scientific_Name,
+Family, N_*) and resolves each ``Scientific_Name`` (eBird checklist 2021)
+against the GBIF animals backbone via
+``alp_data.discover.gbif_taxonomy.GBIFConverter``.
+
+Writes ``species_taxonomy.csv`` with columns:
+
+    AOU_Code, IsBird, Common_Name, Scientific_Name, canonical_name,
+    gbifID, kingdom, phylum, class, order, family, genus, resolved
+
+Codes with no scientific name (e.g. ``????``, ``UNMA``, ``UNWO``) map to
+``canonical_name = "Unknown"``. The ``canonical_name`` column is what gets
+written into the per-event ``Species`` field of the selection tables, while the
+raw ``AOU_Code`` is retained for traceability.
+
+Usage:
+    uv run python scripts/data_preprocessing_scripts/dartmouth_avian_soundscapes_taxonomy.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import pandas as pd
+
+from alp_data.discover.gbif_taxonomy import GBIFConverter
+
+UNKNOWN_LABEL = "Unknown"
+TAXONOMY_RANKS = ["kingdom", "phylum", "class", "order", "family", "genus"]
+
+# eBird-2021 scientific names that are not directly present in the GBIF animals
+# backbone (filled in after inspecting the first run's unresolved list).
+SCI_NAME_FIX: dict[str, str] = {
+    # Cooper's Hawk: moved Accipiter -> Astur (AOU/IOC 2023); GBIF backbone
+    # predates the split and lists the accepted usage under Accipiter.
+    "Astur cooperii": "Accipiter cooperii",
+}
+
+
+def _is_unknown(sci_name: str) -> bool:
+    s = str(sci_name).strip()
+    return s == "" or s.upper() == "NA" or s.lower() == "nan"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--species-csv",
+        default=os.path.expanduser("~/dartmouth_staging/meta/species_metadata.csv"),
+    )
+    p.add_argument("--out", default="species_taxonomy.csv")
+    p.add_argument(
+        "--gcs",
+        default="gs://esp-data-ingestion/dartmouth-avian-soundscapes/v0.1.0/metadata/species_taxonomy.csv",
+        help="Optional GCS destination to upload the result to ('' to skip).",
+    )
+    p.add_argument(
+        "--gbif-cache",
+        default=os.path.expanduser("~/dartmouth_staging/gbif_animals.tsv"),
+        help="Local cache path for the GBIF animals TSV (kept outside the repo).",
+    )
+    args = p.parse_args()
+
+    df = pd.read_csv(args.species_csv, keep_default_na=False, na_values=[])
+    converter = GBIFConverter(precomputed_cache_path=args.gbif_cache)
+
+    rows = []
+    unresolved = []
+    for _, r in df.iterrows():
+        code = str(r["AOU_Code"]).strip()
+        sci = str(r["Scientific_Name"]).strip()
+        out = {
+            "AOU_Code": code,
+            "IsBird": r.get("IsBird", ""),
+            "Common_Name": r.get("Common_Name", ""),
+            "Scientific_Name": sci,
+            "canonical_name": UNKNOWN_LABEL,
+            "gbifID": "",
+            "resolved": False,
+        }
+        for rank in TAXONOMY_RANKS:
+            out[rank] = ""
+
+        if _is_unknown(sci):
+            rows.append(out)
+            continue
+
+        lookup = SCI_NAME_FIX.get(sci, sci)
+        info, ok = converter(lookup)
+        if ok:
+            out["canonical_name"] = info["canonicalName"]
+            out["gbifID"] = int(info["taxonID"])
+            out["resolved"] = True
+            for rank in TAXONOMY_RANKS:
+                out[rank] = info.get(rank, "")
+        else:
+            unresolved.append((code, sci))
+        rows.append(out)
+
+    out_df = pd.DataFrame(rows)
+    out_df.to_csv(args.out, index=False)
+    print(f"Wrote {args.out} with {len(out_df)} species rows")
+    print(
+        f"Resolved {int(out_df['resolved'].sum())} / {len(out_df)} "
+        f"({(out_df['canonical_name'] == UNKNOWN_LABEL).sum()} mapped to Unknown)"
+    )
+
+    if unresolved:
+        print("\nUNRESOLVED (need SCI_NAME_FIX entries):")
+        for code, sci in unresolved:
+            print(f"  {code}\t{sci}")
+
+    if args.gcs:
+        os.system(f"gsutil cp {args.out} {args.gcs}")
+        print(f"\nUploaded to {args.gcs}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data_preprocessing_scripts/indian_fauna_strong.py
+++ b/scripts/data_preprocessing_scripts/indian_fauna_strong.py
@@ -1,0 +1,331 @@
+"""Build the India Ecoacoustics Network (IEN) Type-A STRONG detection dataset.
+
+Ramesh, Singh et al. 2026, "A large-scale crowd-sourced annotated acoustic dataset
+of Indian fauna" (bioRxiv 10.64898/2026.07.20.739496; data CC-BY-NC-4.0). Type-A =
+strong labels: Raven-style time+frequency bounding boxes on full-length recordings,
+518 species across 25 Indian states and four classes (Aves-dominant + Amphibia,
+Insecta, Mammalia). WABAD-shaped ingest — one row per audio file + a
+``selection_table`` (``Selection, Begin Time (s), End Time (s), Low Freq (Hz),
+High Freq (Hz), Species``).
+
+Join gotcha: the audio zips renumber the leading sequential ID, so the audio
+filename and the ``media_file_name`` in the csv tables differ in that prefix but
+share the rest. The canonical key is therefore ``media_file_name`` with the leading
+``{seqID}_`` stripped (== ``state_date_hash``), applied to both audio files and the
+annotation/metadata tables.
+
+Two stages (mirrors build_mediterranean_cetaceans.py):
+1. ``resample`` — extract each ``audio_typeA_<state>.zip``, decode every
+   (extensionless) WAV, write 16 kHz + 32 kHz mono mirrors flattened to
+   ``<state>/<key>.wav``, and a ``durations.csv``. Run on Slurm.
+2. ``manifests`` — join ``type_A_annotations.csv`` to the audio by key; group boxes
+   per file into selection tables; attach per-file taxonomy from ``taxa_info``;
+   write the manifest.
+
+Nyquist: crowd-sourced 8-384 kHz source -> 16k/32k stack. Per-class @16 kHz:
+Aves 81% boxes fully in band, Insecta 79%, Mammalia 73% (15% fully ultrasonic = bats,
+lost), Amphibia boxes are full-band (freq not meaningful) — but 100% of boxes have
+their low edge in band, so time-presence detection is viable across all classes;
+freq-bbox usable for birds/insects/mammals with a ``High Freq (Hz) <= 16000`` filter.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import csv
+import sys
+from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+import pandas as pd
+
+csv.field_size_limit(sys.maxsize)
+
+LICENSE = "CC-BY-NC-4.0"
+SOURCE_DATASET = "indian_fauna_strong"
+ST_COLUMNS = [
+    "Selection",
+    "Begin Time (s)",
+    "End Time (s)",
+    "Low Freq (Hz)",
+    "High Freq (Hz)",
+    "Species",
+]
+
+
+def _key(media_file_name: str) -> str:
+    """Return the join key ``state_date_hash`` (media_file_name minus leading seqID).
+
+    Returns
+    -------
+    str
+    """
+    stem = Path(str(media_file_name)).stem
+    return stem.split("_", 1)[1] if "_" in stem else stem
+
+
+def _parse(s: str) -> dict:
+    """Parse a Python-repr dict string (``taxa_info`` / ``media_info``); ``{}`` on fail.
+
+    Returns
+    -------
+    dict
+    """
+    try:
+        return ast.literal_eval(s) or {}
+    except (ValueError, SyntaxError):
+        return {}
+
+
+def _num(v: str) -> str:
+    """Return a numeric/date string, blanking ``NA``/``None``/empty.
+
+    Returns
+    -------
+    str
+    """
+    v = str(v).strip()
+    return "" if v in ("", "NA", "nan", "None") else v
+
+
+# ── resample ────────────────────────────────────────────────────────────────
+def _resample_one(args: tuple[str, str, str, str]) -> tuple[str, str, float, int, str]:
+    """Write 16k + 32k mono mirrors of one recording; return (key, state, dur, sr, status).
+
+    Parameters
+    ----------
+    args : tuple[str, str, str, str]
+        ``(src, out_root, state, key)``.
+
+    Returns
+    -------
+    tuple[str, str, float, int, str]
+    """
+    import librosa
+    import numpy as np
+    import soundfile as sf
+
+    src, out_root, state, key = args
+    try:
+        audio, sr = sf.read(src, dtype="float32", always_2d=False)
+        if audio.ndim > 1:
+            audio = audio.mean(axis=1)
+        dur = len(audio) / float(sr)
+        for tgt in (16000, 32000):
+            y = (
+                audio
+                if sr == tgt
+                else librosa.resample(
+                    y=audio, orig_sr=sr, target_sr=tgt, scale=True, res_type="kaiser_best"
+                )
+            )
+            out = Path(out_root) / f"audio_{tgt // 1000}k" / state / f"{key}.wav"
+            out.parent.mkdir(parents=True, exist_ok=True)
+            sf.write(out, np.clip(y, -1.0, 1.0), tgt, subtype="PCM_16")
+        return key, state, dur, int(sr), "ok"
+    except Exception as exc:  # noqa: BLE001 - crowd-sourced audio; tolerate + report
+        return key, state, 0.0, 0, f"ERROR: {exc}"
+
+
+def _wavs(work: Path) -> list[tuple[Path, str, str]]:
+    """List extracted recordings under ``work/<state>/*`` -> (path, state, key).
+
+    Returns
+    -------
+    list[tuple[Path, str, str]]
+    """
+    out = []
+    for state_dir in sorted(p for p in work.iterdir() if p.is_dir()):
+        state = state_dir.name
+        for f in sorted(state_dir.rglob("*")):
+            if f.is_file():
+                out.append((f, state, _key(f.name)))
+    return out
+
+
+def resample(work: Path, out_root: Path, workers: int) -> None:
+    """Write 16k + 32k mirrors for every recording and emit durations.csv."""
+    out_root.mkdir(parents=True, exist_ok=True)
+    wavs = _wavs(work)
+    print(f"resampling {len(wavs)} recordings with {workers} workers ...", flush=True)
+    jobs = [(str(f), str(out_root), state, key) for (f, state, key) in wavs]
+    rows, errors, done = [], 0, 0
+    with ProcessPoolExecutor(max_workers=workers) as ex:
+        for fut in as_completed([ex.submit(_resample_one, j) for j in jobs]):
+            key, state, dur, sr, status = fut.result()
+            done += 1
+            if status != "ok":
+                errors += 1
+                if errors <= 30:
+                    print(f"  {status} ({state}/{key})", flush=True)
+            else:
+                rows.append((key, state, round(dur, 3), sr))
+            if done % 200 == 0:
+                print(f"  {done}/{len(jobs)} ...", flush=True)
+    with open(out_root / "durations.csv", "w", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(["key", "state", "duration_sec", "orig_sr"])
+        w.writerows(sorted(rows))
+    print(f"done: {len(rows)} written, {errors} errors", flush=True)
+
+
+# ── manifests ────────────────────────────────────────────────────────────────
+def _selection_tsv(events: list[dict]) -> str:
+    """Serialise per-file boxes into a WABAD-shaped Raven TSV blob.
+
+    Returns
+    -------
+    str
+    """
+    events = sorted(events, key=lambda e: e["b"])
+    df = pd.DataFrame(
+        {
+            "Selection": range(1, len(events) + 1),
+            "Begin Time (s)": [round(e["b"], 4) for e in events],
+            "End Time (s)": [round(e["e"], 4) for e in events],
+            "Low Freq (Hz)": [round(e["lo"], 1) for e in events],
+            "High Freq (Hz)": [round(e["hi"], 1) for e in events],
+            "Species": [e["sp"] for e in events],
+        }
+    )[ST_COLUMNS]
+    return df.to_csv(sep="\t", index=False)
+
+
+def build_manifests(anno_csv: Path, meta_csv: Path, durations_csv: Path, out_dir: Path) -> None:
+    """Join annotations to audio by key -> per-file selection tables -> manifest."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    dur = pd.read_csv(durations_csv, dtype={"key": str, "state": str})
+    dur_by_key = {
+        r["key"]: (r["state"], float(r["duration_sec"]), int(r["orig_sr"]))
+        for _, r in dur.iterrows()
+    }
+
+    # per-file target species + taxonomy from metadata
+    meta = pd.read_csv(meta_csv, dtype=str, keep_default_na=False)
+    meta_by_key: dict[str, dict] = {}
+    for _, r in meta.iterrows():
+        ti = _parse(r["taxa_info"])
+        # Type-A metadata has no scientific_name column; the per-file target species
+        # is the taxa_info GBIF match (canonicalName, else the raw scientificName).
+        target = str(r.get("scientific_name", "")).strip() or ti.get("canonicalName") or ""
+        # Location/time context columns named to match context_builder defaults
+        # (locality / latitudeDecimal / longitudeDecimal / eventDate) so the
+        # with-context soundscape task works verbatim; "NA"/blank left empty.
+        locality = (
+            str(r.get("archive_name", "")).replace("audio_type_A_", "").replace(".zip", "").strip()
+        )
+        meta_by_key[_key(r["media_file_name"])] = {
+            "target_species": target,
+            "class": ti.get("class") or "",
+            "canonical_name": ti.get("canonicalName") or "",
+            "rank": ti.get("rank") or "",
+            "locality": locality,
+            "latitudeDecimal": _num(r.get("latitude", "")),
+            "longitudeDecimal": _num(r.get("longitude", "")),
+            "eventDate": _num(r.get("recording_date", "")),
+        }
+
+    # group annotation boxes by key
+    anno = pd.read_csv(anno_csv, dtype=str, keep_default_na=False)
+    events_by_key: dict[str, list[dict]] = defaultdict(list)
+    labels: set[str] = set()
+    for _, r in anno.iterrows():
+        k = _key(r["media_file_name"])
+        sp = str(r.get("scientific_name", "")).strip()
+        try:
+            lo, hi = float(r.get("low_freq") or 0), float(r.get("high_freq") or 0)
+            b, e = float(r.get("begin_time") or 0), float(r.get("end_time") or 0)
+        except ValueError:
+            continue
+        if sp:
+            labels.add(sp)
+        events_by_key[k].append({"b": max(0.0, b), "e": e, "lo": lo, "hi": hi, "sp": sp})
+
+    rows, n_no_audio = [], 0
+    for k, (state, d, orig_sr) in dur_by_key.items():
+        evs = [e for e in events_by_key.get(k, []) if e["b"] < d + 0.5]  # clip stray boxes
+        md = meta_by_key.get(k, {})
+        rows.append(
+            {
+                "sound_name": f"{k}.wav",
+                "key": k,
+                "state": state,
+                "target_species": md.get("target_species", ""),
+                "class": md.get("class", ""),
+                "locality": md.get("locality", state),
+                "latitudeDecimal": md.get("latitudeDecimal", ""),
+                "longitudeDecimal": md.get("longitudeDecimal", ""),
+                "eventDate": md.get("eventDate", ""),
+                "split": "all",
+                "audio_duration": round(d, 3),
+                "orig_sample_rate": orig_sr,
+                "audio_fp": f"audio_32k/{state}/{k}.wav",
+                "16khz_path": f"audio_16k/{state}/{k}.wav",
+                "32khz_path": f"audio_32k/{state}/{k}.wav",
+                "n_events": len(evs),
+                "source_dataset": SOURCE_DATASET,
+                "license": LICENSE,
+                "selection_table": _selection_tsv(evs),
+            }
+        )
+    # annotations whose key has no matching audio (should be ~0)
+    n_no_audio = len(set(events_by_key) - set(dur_by_key))
+
+    df = pd.DataFrame(rows)
+    head = [
+        "sound_name",
+        "key",
+        "state",
+        "target_species",
+        "class",
+        "locality",
+        "latitudeDecimal",
+        "longitudeDecimal",
+        "eventDate",
+        "split",
+        "audio_duration",
+        "orig_sample_rate",
+        "audio_fp",
+        "16khz_path",
+        "32khz_path",
+        "n_events",
+    ]
+    df = df[head + [c for c in df.columns if c not in head]]
+    out = out_dir / "indian_fauna_strong_all.csv"
+    df.to_csv(out, index=False)
+    n_evt = int(df["n_events"].sum())
+    cls = df.groupby("class").size().to_dict()
+    print(
+        f"  all: {len(df)} recordings, {n_evt} boxes, {int((df['n_events'] == 0).sum())} empty, "
+        f"{n_no_audio} anno-keys w/o audio -> {out.name}"
+    )
+    print(f"  class distribution (files): {cls}")
+    lab_out = out_dir / "indian_fauna_strong_labels.csv"
+    pd.DataFrame({"Species": sorted(labels)}).to_csv(lab_out, index=False)
+    print(f"  labels: {len(labels)} species -> {lab_out.name}")
+
+
+def main() -> None:
+    """Entry point — see module docstring."""
+    p = argparse.ArgumentParser(description=__doc__)
+    sub = p.add_subparsers(dest="stage", required=True)
+    pr = sub.add_parser("resample")
+    pr.add_argument("--work", type=Path, required=True, help="dir of work/<state>/ extracted audio")
+    pr.add_argument("--out-root", type=Path, required=True)
+    pr.add_argument("--workers", type=int, default=16)
+    pm = sub.add_parser("manifests")
+    pm.add_argument("--anno-csv", type=Path, required=True)
+    pm.add_argument("--meta-csv", type=Path, required=True)
+    pm.add_argument("--durations-csv", type=Path, required=True)
+    pm.add_argument("--out-dir", type=Path, required=True)
+    args = p.parse_args()
+    if args.stage == "resample":
+        resample(args.work, args.out_root, args.workers)
+    else:
+        build_manifests(args.anno_csv, args.meta_csv, args.durations_csv, args.out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data_preprocessing_scripts/indian_fauna_strong_job.sh
+++ b/scripts/data_preprocessing_scripts/indian_fauna_strong_job.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=ien-strong-build
+#SBATCH --partition=cpu
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=64G
+#SBATCH --time=08:00:00
+#SBATCH --output="/home/%u/logs/%A_%x.log"
+#SBATCH --qos=naturelm
+
+# ───────────────────────────────────────────────────────────────────
+# Build the IEN Type-A STRONG detection dataset (Zenodo 18743214) into
+# gs://esp-data-ingestion/indian-fauna/v0.1.0/typeA/. Uses the by-state zips +
+# CSVs already on NFS: extracts each audio_typeA_<state>.zip into work/<state>/,
+# resamples every (extensionless) WAV -> 16k+32k mono mirrors + durations.csv,
+# joins type_A_annotations.csv by key (state_date_hash) into per-file selection
+# tables, uploads.
+#   sbatch scripts/data_preprocessing_scripts/indian_fauna/build_indian_fauna_strong.sh
+# ───────────────────────────────────────────────────────────────────
+set -euo pipefail
+cd "${HOME}/alp-data"
+
+GCS="gs://esp-data-ingestion/indian-fauna/v0.1.0/typeA"
+STAGE="${HOME}/esp-data-staging/indian_fauna"
+WORK="${STAGE}/work_typeA"
+MIRRORS="${STAGE}/mirrors_typeA"
+SCRIPT="scripts/data_preprocessing_scripts/indian_fauna_strong.py"
+
+export CLOUDSDK_CONFIG="$(mktemp -d)"   # attached SA for gsutil + gcsfs
+echo "Node: $(hostname)  work=${WORK}"
+echo "ok" | gsutil cp - "${GCS}/.auth_probe" && gsutil rm "${GCS}/.auth_probe" && echo "auth probe OK"
+
+# 1. Extract each Type-A state zip into work/<state>/.
+mkdir -p "${WORK}"
+for z in "${STAGE}"/audio_typeA_*.zip; do
+  state="$(basename "${z}" .zip | sed 's/^audio_typeA_//')"
+  if [ ! -d "${WORK}/${state}" ]; then
+    echo "extracting ${state} ..."; mkdir -p "${WORK}/${state}"; unzip -o -q "${z}" -d "${WORK}/${state}/"
+  fi
+done
+echo "recordings: $(find "${WORK}" -type f | wc -l)"
+
+# 2. Resample -> 16k + 32k mono mirrors + durations.csv.
+rm -rf "${MIRRORS}"; mkdir -p "${MIRRORS}"
+uv run python "${SCRIPT}" resample \
+    --work "${WORK}" --out-root "${MIRRORS}" --workers "${SLURM_CPUS_PER_TASK:-16}"
+
+# 3. Build manifests.
+uv run python "${SCRIPT}" manifests \
+    --anno-csv "${STAGE}/type_A_annotations.csv" \
+    --meta-csv "${STAGE}/type_A_metadata.csv" \
+    --durations-csv "${MIRRORS}/durations.csv" \
+    --out-dir "${MIRRORS}/manifests"
+
+# 4. Upload audio mirrors + manifests.
+gsutil -m -q rsync -r "${MIRRORS}/audio_16k" "${GCS}/audio_16k"
+gsutil -m -q rsync -r "${MIRRORS}/audio_32k" "${GCS}/audio_32k"
+gsutil -m -q cp "${MIRRORS}/manifests"/*.csv "${GCS}/"
+
+echo "final listing:"; gsutil ls "${GCS}/"
+echo "Done."

--- a/scripts/data_preprocessing_scripts/indian_fauna_strong_validate_job.sh
+++ b/scripts/data_preprocessing_scripts/indian_fauna_strong_validate_job.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=ien-strong-validate
+#SBATCH --partition=cpu
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=8G
+#SBATCH --time=00:40:00
+#SBATCH --output="/home/%u/logs/%A_%x.log"
+#SBATCH --qos=naturelm
+set -euo pipefail
+cd "${HOME}/alp-data"
+export CLOUDSDK_CONFIG="$(mktemp -d)"   # attached SA for gsutil + gcsfs
+GCS="gs://esp-data-ingestion/indian-fauna/v0.1.0/typeA"
+
+echo "=== 1. audio-present cross-check ==="
+uv run python - <<PY
+import subprocess, sys
+from io import StringIO
+import pandas as pd
+GCS="${GCS}"
+listings={}
+for d in ("audio_16k","audio_32k"):
+    out=subprocess.run(["gsutil","ls","-r",f"{GCS}/{d}"],capture_output=True,text=True,check=True).stdout
+    listings[d]={l.split(f"{GCS}/{d}/",1)[-1] for l in out.splitlines() if l.strip().endswith(".wav")}
+    print(f"{d}/: {len(listings[d])} wavs on GCS")
+blob=subprocess.run(["gsutil","cat",f"{GCS}/indian_fauna_strong_all.csv"],capture_output=True,text=True,check=True).stdout
+df=pd.read_csv(StringIO(blob),keep_default_na=False,na_values=[""])
+miss=0
+for _,r in df.iterrows():
+    for d,col in (("audio_16k","16khz_path"),("audio_32k","32khz_path")):
+        rel=str(r[col]).split(f"{d}/",1)[-1]
+        if rel not in listings[d]: miss+=1;  print("MISSING",d,rel) if miss<=10 else None
+print("rows:",len(df),"missing:",miss); sys.exit(1 if miss else 0)
+PY
+
+echo "=== 2. dataset smoke-load ==="
+uv run python - <<'PY'
+import numpy as np
+from alp_data.datasets import IndianFaunaStrong
+COLS=["Selection","Begin Time (s)","End Time (s)","Low Freq (Hz)","High Freq (Hz)","Species"]
+for sr in [16000,32000]:
+    ds=IndianFaunaStrong(split="all",sample_rate=sr)
+    it=ds[0]; a,st=it["audio"],it["selection_table"]
+    assert isinstance(a,np.ndarray) and a.ndim==1 and a.size>0
+    assert it["sample_rate"]==sr
+    assert list(st.columns)==COLS, list(st.columns)
+    print(f"all@{sr}: n={len(ds)} audio={a.shape} dur={a.size/sr:.1f}s events0={len(st)} class={it['class']}")
+
+ds=IndianFaunaStrong(split="all",sample_rate=32000)
+nz=[i for i in range(len(ds)) if int(ds._data[i]["n_events"])>0]
+r=ds[nz[0]]; st=r["selection_table"]
+print(f"non-empty {r['sound_name']} ({r['state']}/{r['class']}): {len(st)} boxes, "
+      f"species={sorted(st['Species'].unique())[:5]}")
+# windowed 10s
+row=dict(ds._data[nz[0]]); row["window_start_sec"],row["window_end_sec"]=0.0,10.0
+out=ds._process(row)
+assert abs(out["audio"].size/out["sample_rate"]-10.0)<0.3, out["audio"].size
+print(f"windowed 10s -> {out['audio'].size} samples, {len(out['selection_table'])} boxes in-window")
+labs=ds.get_available_labels()
+print(f"labels: {len(labs)} species; sample={labs[:5]}")
+print("SMOKE OK")
+PY
+echo "Done."

--- a/scripts/data_preprocessing_scripts/pteroset_build_csv.py
+++ b/scripts/data_preprocessing_scripts/pteroset_build_csv.py
@@ -1,0 +1,203 @@
+"""
+Build PteroSet split CSVs (WABAD-style) from staged data.
+
+Each recording becomes one CSV row with an embedded tab-separated
+``selection_table`` string. Writes one CSV per project
+(``map1``/``ppa1``/``ppa2``/``ppa3``/``ppa4``) plus ``all.csv`` and
+``species_labels.csv``, and a QC report, then uploads them to the GCS root.
+
+Selection-table columns (per annotated event):
+    Begin Time (s), End Time (s), Low Freq (Hz), High Freq (Hz),
+    Species (GBIF canonical), Species Code (raw Determination),
+    Identification (Raven ID, e.g. AVEVOC), Type (Raven Tipo, e.g. BIO)
+
+The Raven ``Determination`` column holds a species code resolved to a GBIF
+canonical name; empty or ``INDETE`` (indeterminate) -> ``Unknown``.
+
+Inputs (local, from pteroset_stage.sh):
+    meta/metadata.csv               recording<->annotation join + project/site
+    pteroset_species_taxonomy.csv   species code -> GBIF canonical
+    extract_lab/**/*.txt            Raven Pro selection tables
+    extract_audio/**/*.wav          used only to read audio_duration (header)
+
+Usage:
+    uv run python scripts/data_preprocessing_scripts/pteroset_build_csv.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+
+import pandas as pd
+import soundfile as sf
+
+UNKNOWN_LABEL = "Unknown"
+INDETERMINATE = "INDETE"
+GCS_ROOT = "gs://esp-data-ingestion/pteroset/v0.1.0"
+
+PROJECTS = {"MAP1": "map1", "PPA1": "ppa1", "PPA2": "ppa2", "PPA3": "ppa3", "PPA4": "ppa4"}
+
+ST_COLUMNS = [
+    "Begin Time (s)",
+    "End Time (s)",
+    "Low Freq (Hz)",
+    "High Freq (Hz)",
+    "Species",
+    "Species Code",
+    "Identification",
+    "Type",
+]
+
+_ANN_SUFFIX = re.compile(r"\.Table\.\d+\.selections\.txt$")
+
+
+def _ann_stem(basename: str) -> str:
+    s = _ANN_SUFFIX.sub("", basename)
+    return s if s != basename else os.path.splitext(basename)[0]
+
+
+def build_selection_table(ann_path: str, code_to_species: dict[str, str], qc: list, fn: str) -> str:
+    """Parse one Raven .txt and return a cleaned tab-separated selection table.
+
+    Returns
+    -------
+    str
+        The cleaned selection table serialised as a tab-separated string.
+    """
+    if not ann_path or not os.path.exists(ann_path):
+        qc.append({"fn": fn, "issue": "annotation_file_missing"})
+        return pd.DataFrame(columns=ST_COLUMNS).to_csv(sep="\t", index=False)
+
+    raw = pd.read_csv(ann_path, sep="\t")
+    raw = raw.rename(
+        columns={"Determination": "Species Code", "ID": "Identification", "Tipo": "Type"}
+    )
+    for col in ("Species Code", "Identification", "Type"):
+        if col not in raw.columns:
+            raw[col] = ""
+        raw[col] = raw[col].fillna("").astype(str).str.strip()
+
+    def to_species(code: str) -> str:
+        if code == "" or code == INDETERMINATE:
+            return UNKNOWN_LABEL
+        return code_to_species.get(code, UNKNOWN_LABEL)
+
+    raw["Species"] = raw["Species Code"].map(to_species)
+
+    unmapped = sorted(
+        {c for c in raw["Species Code"] if c and c != INDETERMINATE and c not in code_to_species}
+    )
+    if unmapped:
+        qc.append({"fn": fn, "issue": f"codes_not_in_species_csv: {unmapped}"})
+
+    st = raw[[c for c in ST_COLUMNS if c in raw.columns]].copy()
+    return st.to_csv(sep="\t", index=False)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--work", default="/mnt/home/pteroset_staging")
+    p.add_argument("--taxonomy", default="pteroset_species_taxonomy.csv")
+    p.add_argument("--gcs-root", default=GCS_ROOT)
+    p.add_argument("--out-dir", default="/mnt/home/pteroset_staging/csv")
+    args = p.parse_args()
+
+    meta_dir = os.path.join(args.work, "meta")
+    ann_dir = os.path.join(args.work, "extract_lab")
+    rec_dir = os.path.join(args.work, "extract_audio")
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    wav_paths = glob.glob(os.path.join(rec_dir, "**", "*.wav"), recursive=True)
+    txt_paths = glob.glob(os.path.join(ann_dir, "**", "*.txt"), recursive=True)
+    # index by recording stem (annotation files share the stem before ".Table")
+    rec_index = {os.path.splitext(os.path.basename(p))[0]: p for p in wav_paths}
+    ann_index = {_ann_stem(os.path.basename(p)): p for p in txt_paths}
+    print(f"indexed {len(rec_index)} wav / {len(ann_index)} txt by stem")
+
+    recs = pd.read_csv(os.path.join(meta_dir, "metadata.csv"), dtype=str).fillna("")
+    tax = pd.read_csv(args.taxonomy, dtype=str).fillna("")
+    code_to_species = dict(zip(tax["code"], tax["canonical_name"], strict=False))
+
+    qc: list = []
+    rows: list = []
+    for i, r in recs.iterrows():
+        if i % 100 == 0:
+            print(f"{i} / {len(recs)}")
+        proj = r["project_name"]
+        sub = PROJECTS.get(proj)
+        if sub is None:
+            qc.append({"fn": r.get("audio_file", ""), "issue": f"unknown_project:{proj}"})
+            continue
+
+        audio_file = r["audio_file"]
+        stem = os.path.splitext(audio_file)[0]
+        wav_path = rec_index.get(stem, "")
+        ann_path = ann_index.get(stem, "")
+        # use the actual on-disk filename for GCS paths
+        rec_fn = os.path.basename(wav_path) if wav_path else audio_file
+        stem = os.path.splitext(rec_fn)[0]
+
+        duration = ""
+        sr = ""
+        if wav_path and os.path.exists(wav_path):
+            info = sf.info(wav_path)
+            duration = round(float(info.frames) / float(info.samplerate), 6)
+            sr = int(info.samplerate)
+        else:
+            qc.append({"fn": stem, "issue": "recording_file_missing"})
+
+        st_str = build_selection_table(ann_path, code_to_species, qc, stem)
+        n_events = max(st_str.count("\n") - 1, 0)
+
+        rows.append(
+            {
+                "fn": stem,
+                "site": r.get("event_indicator", ""),
+                "project": sub,
+                "audio_fp": f"recordings/{rec_fn}",
+                "16khz_path": f"audio_16k/{stem}.wav",
+                "32khz_path": f"audio_32k/{stem}.wav",
+                "audio_duration": duration,
+                "sample_rate": sr,
+                "date": r.get("date_recorded", ""),
+                "country": r.get("country", ""),
+                "department": r.get("department", ""),
+                "municipality": r.get("municipality", ""),
+                "latitude": r.get("latitude", ""),
+                "longitude": r.get("longitude", ""),
+                "zone": r.get("zone", ""),
+                "land_cover": r.get("land_cover", ""),
+                "n_events": n_events,
+                "selection_table": st_str,
+            }
+        )
+
+    all_df = pd.DataFrame(rows)
+
+    def _save(df: pd.DataFrame, name: str) -> None:
+        local = os.path.join(args.out_dir, name)
+        df.to_csv(local, index=False)
+        os.system(f"gsutil -q cp {local} {args.gcs_root}/{name}")
+        print(f"  wrote {name}: {len(df)} rows -> {args.gcs_root}/{name}")
+
+    _save(all_df, "all.csv")
+    for sub in PROJECTS.values():
+        _save(all_df[all_df["project"] == sub].reset_index(drop=True), f"{sub}.csv")
+
+    labels = sorted({c for c in code_to_species.values() if c and c != UNKNOWN_LABEL})
+    _save(pd.DataFrame({"Species": labels}), "species_labels.csv")
+
+    qc_df = pd.DataFrame(qc)
+    qc_local = os.path.join(args.out_dir, "qc_report.csv")
+    qc_df.to_csv(qc_local, index=False)
+    print(f"\nTotal recordings: {len(all_df)}  total events: {int(all_df['n_events'].sum())}")
+    print(f"QC issues: {len(qc_df)} -> {qc_local}")
+    if len(qc_df):
+        print(qc_df["issue"].str.replace(r":.*", "", regex=True).value_counts().to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data_preprocessing_scripts/pteroset_stage_job.sh
+++ b/scripts/data_preprocessing_scripts/pteroset_stage_job.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Stage the PteroSet tropical-bird PAM dataset (Zenodo record 19137071) into
+# gs://esp-data-ingestion/pteroset/v0.1.0/.
+#
+# Downloads audios.zip (~86 GB, 192 kHz WAV), labels.zip (Raven Pro selection
+# tables), and the metadata/JSON files, extracts them, and uploads to GCS:
+#
+#   recordings/*.wav    (192 kHz originals, flat)
+#   annotations/*.txt   (Raven Pro selection tables)
+#   metadata/           (metadata.csv, species.csv, annotations_*.json)
+#
+# audios.zip is a single huge file and Zenodo throttles ~1 MB/s per
+# connection, so it is fetched with a parallel byte-range downloader.
+#
+# Heavy on network/IO (not memory); run on the dev VM (needs external
+# internet). Set WORK to a disk with ~180 GB free (zip + extracted) — on the
+# dev VM that is the NFS share (/mnt/home/...), NOT local $HOME.
+#
+# USAGE:
+#   WORK=/mnt/home/pteroset_staging \
+#     nohup bash scripts/data_preprocessing_scripts/pteroset_stage.sh \
+#       > /mnt/home/pteroset_staging/stage.log 2>&1 &
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+ZENODO="https://zenodo.org/records/19137071/files"
+GCS_ROOT="gs://esp-data-ingestion/pteroset/v0.1.0"
+WORK="${WORK:-/mnt/home/pteroset_staging}"
+NCONN="${NCONN:-24}"   # parallel connections for the big zip
+
+ZIPS="$WORK/zips"; META="$WORK/meta"; AUD="$WORK/extract_audio"; LAB="$WORK/extract_lab"
+mkdir -p "$ZIPS" "$META" "$AUD" "$LAB"
+
+META_FILES=(species.csv metadata.csv annotations_species.json annotations_identification.json)
+
+remote_size() { curl -sIL "$1" 2>/dev/null \
+    | awk 'BEGIN{IGNORECASE=1}/^content-length:/{cl=$2} END{gsub(/\r/,"",cl); print cl}'; }
+
+dl() {  # dl <filename> <dest_dir>   (skip if already complete; else resume)
+    local fn="$1" dest="$2"
+    local url="$ZENODO/$fn?download=1"
+    local remote local_sz=0
+    remote=$(remote_size "$url")
+    [ -f "$dest/$fn" ] && local_sz=$(stat -c%s "$dest/$fn")
+    if [ -n "$remote" ] && [ "$local_sz" = "$remote" ]; then
+        echo "[$(date +%H:%M:%S)] skip $fn (complete: $remote bytes)"; return 0
+    fi
+    curl -fsSL -C - --retry 8 --retry-delay 10 -o "$dest/$fn" "$url"
+}
+
+download_part() {  # url start end part  — resume via manual offset across drops
+    local url="$1" start="$2" end="$3" part="$4"
+    local want=$(( end - start + 1 )) have a
+    for ((a = 0; a < 50; a++)); do
+        have=0; [ -f "$part" ] && have=$(stat -c%s "$part")
+        [ "$have" -ge "$want" ] && return 0
+        # one request for the remaining bytes, appended; a dropped connection
+        # just means the next iteration resumes from the new (larger) offset.
+        curl -fsS --connect-timeout 30 -r "$(( start + have ))-${end}" "$url" >> "$part" || true
+        sleep 2
+    done
+    have=0; [ -f "$part" ] && have=$(stat -c%s "$part")
+    [ "$have" -ge "$want" ]
+}
+
+parallel_dl() {  # parallel_dl <filename> <dest_dir>   (N byte-range parts, resumable)
+    local fn="$1" dest="$2"
+    local url="$ZENODO/$fn?download=1" out="$dest/$fn"
+    local size; size=$(remote_size "$url")
+    [ -n "$size" ] || { echo "ERROR: no content-length for $fn"; return 1; }
+    if [ -f "$out" ] && [ "$(stat -c%s "$out")" = "$size" ]; then
+        echo "[$(date +%H:%M:%S)] skip $fn (complete: $size bytes)"; return 0
+    fi
+    local chunk=$(( (size + NCONN - 1) / NCONN ))
+    echo "[$(date +%H:%M:%S)] $fn: $size bytes, $NCONN parts of ~$((chunk/1024/1024)) MB"
+    local pids=()
+    for ((i=0; i<NCONN; i++)); do
+        local start=$(( i * chunk )); [ "$start" -ge "$size" ] && break
+        local end=$(( start + chunk - 1 )); [ "$end" -ge "$size" ] && end=$(( size - 1 ))
+        local part="$out.part$i" want=$(( end - start + 1 )) have=0
+        [ -f "$part" ] && have=$(stat -c%s "$part")
+        if [ "$have" -ge "$want" ]; then continue; fi   # part already complete
+        download_part "$url" "$start" "$end" "$part" & pids+=($!)
+    done
+    local fail=0
+    for p in "${pids[@]:-}"; do [ -n "$p" ] && { wait "$p" || fail=1; }; done
+    [ "$fail" -eq 0 ] || { echo "ERROR: a part of $fn failed; re-run to resume"; return 1; }
+    # assemble parts in NUMERIC order (ls -v); plain glob sorts lexically
+    # (part0, part1, part10, ...) which would scramble the file.
+    cat $(ls -v "$out".part*) > "$out"
+    if [ "$(stat -c%s "$out")" != "$size" ]; then
+        echo "ERROR: $fn assembled size mismatch"; rm -f "$out"; return 1
+    fi
+    case "$fn" in *.zip)
+        unzip -l "$out" >/dev/null 2>&1 || { echo "ERROR: $fn invalid zip after assembly"; return 1; } ;;
+    esac
+    rm -f "$out".part*
+    echo "[$(date +%H:%M:%S)] $fn assembled OK ($size bytes)"
+}
+
+echo "=== 1. metadata ==="
+for f in "${META_FILES[@]}"; do [ -f "$META/$f" ] || dl "$f" "$META"; done
+gsutil -m -q cp "$META"/*.csv "$META"/*.json "$GCS_ROOT/metadata/"
+
+echo "=== 2. labels (Raven tables) ==="
+dl "labels.zip" "$ZIPS"
+chmod -R u+w "$LAB" 2>/dev/null || true
+unzip -o -q "$ZIPS/labels.zip" -d "$LAB"
+labdir=$(find "$LAB" -maxdepth 2 -type d -name labels | head -1); labdir="${labdir:-$LAB}"
+echo "[$(date +%H:%M:%S)] uploading $(find "$labdir" -name '*.txt' | wc -l) annotations -> GCS ..."
+gsutil -m -q rsync -r "$labdir" "$GCS_ROOT/annotations"
+
+echo "=== 3. audios (192 kHz WAV, ~86 GB, parallel) ==="
+parallel_dl "audios.zip" "$ZIPS"
+echo "[$(date +%H:%M:%S)] extracting audios.zip ..."
+chmod -R u+w "$AUD" 2>/dev/null || true
+unzip -o -q "$ZIPS/audios.zip" -d "$AUD"
+# upload all WAVs flat to recordings/ (robust to internal folder layout)
+for d in $(find "$AUD" -name '*.wav' -printf '%h\n' | sort -u); do
+    echo "[$(date +%H:%M:%S)] uploading $(find "$d" -maxdepth 1 -name '*.wav' | wc -l) wav from $(basename "$d") -> recordings/ ..."
+    gsutil -m -q rsync "$d" "$GCS_ROOT/recordings"
+done
+
+echo "=== 4. counts ==="
+echo "wav uploaded: $(gsutil ls "$GCS_ROOT/recordings/**.wav" 2>/dev/null | wc -l)"
+echo "txt uploaded: $(gsutil ls "$GCS_ROOT/annotations/**.txt" 2>/dev/null | wc -l)"
+echo "[$(date +%H:%M:%S)] staging DONE"

--- a/scripts/data_preprocessing_scripts/pteroset_taxonomy.py
+++ b/scripts/data_preprocessing_scripts/pteroset_taxonomy.py
@@ -1,0 +1,117 @@
+"""
+Resolve PteroSet species codes -> GBIF canonical names.
+
+Reads ``species.csv`` (columns: code, species, identification, type) and
+resolves each ``species`` (scientific name) against the GBIF animals backbone
+via ``alp_data.discover.gbif_taxonomy.GBIFConverter``.
+
+Writes ``pteroset_species_taxonomy.csv`` with columns:
+
+    code, species, identification, type, canonical_name, gbifID,
+    kingdom, phylum, class, order, family, genus, resolved
+
+The ``canonical_name`` populates the per-event ``Species`` field of the
+selection tables; the raw ``code`` is retained for traceability. Annotation
+rows whose ``Determination`` code is empty or ``INDETE`` (indeterminate) are
+mapped to ``Unknown`` at CSV-build time, not here.
+
+Usage:
+    uv run python scripts/data_preprocessing_scripts/pteroset_taxonomy.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import pandas as pd
+
+from alp_data.discover.gbif_taxonomy import GBIFConverter
+
+UNKNOWN_LABEL = "Unknown"
+TAXONOMY_RANKS = ["kingdom", "phylum", "class", "order", "family", "genus"]
+
+# Source scientific-name typos / synonyms corrected to GBIF-accepted binomials
+# (verified against the GBIF animals backbone). Entries left unresolved after
+# this (higher-taxon / indeterminate labels like "Picidae" or "-") fall back to
+# canonical_name = "Unknown".
+SCI_NAME_FIX: dict[str, str] = {
+    "Icterus cayaensis": "Icterus cayanensis",
+    "Megarynchus pitagua": "Megarynchus pitangua",
+    "Melanerpes cruentats": "Melanerpes cruentatus",
+    "Ramphoceaenus melanurus": "Ramphocaenus melanurus",
+    "Daptrius chimachima": "Milvago chimachima",
+    "Hypnellus ruficollis": "Hypnelus ruficollis",
+    "Orthopsittaca manilatus": "Orthopsittaca manilata",
+    "Aramides cajaneus": "Aramides cajanea",
+    "Mesembrinibis cayanensis": "Mesembrinibis cayennensis",
+}
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--species-csv",
+        default="/mnt/home/pteroset_staging/meta/species.csv",
+    )
+    p.add_argument("--out", default="pteroset_species_taxonomy.csv")
+    p.add_argument(
+        "--gcs",
+        default="gs://esp-data-ingestion/pteroset/v0.1.0/metadata/species_taxonomy.csv",
+        help="Optional GCS destination ('' to skip).",
+    )
+    p.add_argument(
+        "--gbif-cache",
+        default="/mnt/home/pteroset_staging/gbif_animals.tsv",
+        help="Local cache path for the GBIF animals TSV (kept outside the repo).",
+    )
+    args = p.parse_args()
+
+    df = pd.read_csv(args.species_csv, keep_default_na=False, na_values=[])
+    converter = GBIFConverter(precomputed_cache_path=args.gbif_cache)
+
+    rows = []
+    unresolved = []
+    for _, r in df.iterrows():
+        code = str(r["code"]).strip()
+        sci = " ".join(str(r["species"]).split())  # collapse stray double spaces
+        out = {
+            "code": code,
+            "species": sci,
+            "identification": r.get("identification", ""),
+            "type": r.get("type", ""),
+            "canonical_name": UNKNOWN_LABEL,
+            "gbifID": "",
+            "resolved": False,
+        }
+        for rank in TAXONOMY_RANKS:
+            out[rank] = ""
+
+        info, ok = converter(SCI_NAME_FIX.get(sci, sci))
+        if ok:
+            out["canonical_name"] = info["canonicalName"]
+            out["gbifID"] = int(info["taxonID"])
+            out["resolved"] = True
+            for rank in TAXONOMY_RANKS:
+                out[rank] = info.get(rank, "")
+        else:
+            unresolved.append((code, sci))
+        rows.append(out)
+
+    out_df = pd.DataFrame(rows)
+    out_df.to_csv(args.out, index=False)
+    print(f"Wrote {args.out} with {len(out_df)} species rows")
+    print(f"Resolved {int(out_df['resolved'].sum())} / {len(out_df)}")
+
+    if unresolved:
+        print("\nUNRESOLVED (need SCI_NAME_FIX entries):")
+        for code, sci in unresolved:
+            print(f"  {code}\t{sci}")
+
+    if args.gcs:
+        os.system(f"gsutil cp {args.out} {args.gcs}")
+        print(f"\nUploaded to {args.gcs}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data_preprocessing_scripts/xeno_canto_strong.py
+++ b/scripts/data_preprocessing_scripts/xeno_canto_strong.py
@@ -1,0 +1,321 @@
+"""Pivot xeno-canto strong-annotation segments into a WABAD-shaped manifest.
+
+Input (from a prior pipeline run already on GCS). We read the ``_unseen``
+variants — pre-filtered to drop xc_ids whose recording-level OR per-event
+species appear in the BEANS-Zero held-out list. The YAML chain layers a
+second ``drop_where_text_mentions_taxa`` filter on top as defense in depth.
+
+- ``gs://esp-data-ingestion/xeno-canto/v0.1.0/raw/xc_annotation_segments_unseen.csv``
+    One row per annotation event (68,744 events on ~21,291 files; 811
+    unique species via segment-level ``scientific_name``). 11 events / 9
+    xc_ids pre-filtered vs. the full segments table.
+- ``gs://esp-data-ingestion/xeno-canto/v0.1.0/raw/xc_annotated_extras_unseen.csv``
+    File-level GBIF + paths (21,300 files; the recording-level focal
+    species is mostly ``Sonus naturalis`` so the unseen filter drops 0
+    rows here, but we read this variant for symmetry / future-proofing).
+- ``gs://esp-data-ingestion/xeno-canto/v0.1.0/raw/xc_annotated_recordings.csv``
+    XC's raw recording metadata (42,770 rows; not held-out-filtered, but
+    we only join the ``length`` field for duration parsing).
+
+Output (one row per file with inline selection_table TSV — WABAD shape):
+- ``gs://esp-data-ingestion/xeno-canto/v0.1.0/raw/xc_strong_with_selection_table.csv``
+
+Schema (matches WABAD's expectations exactly so the existing
+``window_annotations`` + ``annotation_features`` chain works as-is):
+    audio_fp                  - relative path to original (e.g. ``audio/XC65654.mp3``)
+    16khz_path / 32khz_path   - relative paths to pre-resampled mirrors
+    audio_duration            - float seconds (parsed from XC ``length``)
+    selection_table           - TSV string, columns:
+                                ``Begin Time (s)``, ``End Time (s)``,
+                                ``Low Freq (Hz)``, ``High Freq (Hz)``,
+                                ``Species`` (= segment ``scientific_name``),
+                                ``sound_type``, ``sex``, ``life_stage``,
+                                ``annotator``
+    xc_id                     - XC recording id (numeric, no XC prefix)
+    recording_canonical_name  - file-level focal species (mostly Sonus naturalis)
+    recording_species_common  - file-level common name
+    annotator_set             - top-level annotation set name
+    license                   - license URL
+    media_license             - media-specific license URL
+    rightsHolder, recordedBy  - attribution
+    country_code, locality    - geo
+    latitudeDecimal, longitudeDecimal - geo
+    source_dataset            - constant "xeno_canto_strong"
+    n_events                  - count of events in selection_table
+
+Pipeline is metadata-only (~50 MB CSV in, ~30 MB CSV out); runs in seconds
+locally, no Slurm needed.
+
+Usage:
+    uv run python scripts/data_preprocessing_scripts/xeno_canto_strong.py \\
+        [--out-dir DIR] [--upload]
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import re
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+
+INPUT_ROOT = "gs://esp-data-ingestion/xeno-canto/v0.1.0/raw"
+SEGMENTS_CSV = f"{INPUT_ROOT}/xc_annotation_segments_unseen.csv"
+EXTRAS_CSV = f"{INPUT_ROOT}/xc_annotated_extras_unseen.csv"
+RECORDINGS_CSV = f"{INPUT_ROOT}/xc_annotated_recordings.csv"
+OUT_CSV_NAME = "xc_strong_with_selection_table.csv"
+
+_DURATION_RE = re.compile(r"^\s*(?:(\d+):)?(\d+):(\d+)\s*$")
+
+
+def parse_duration(s: str) -> float | None:
+    """Parse the XC ``length`` field into seconds.
+
+    Accepts ``M:SS`` or ``H:MM:SS``. Returns ``None`` if unparsable.
+
+    Parameters
+    ----------
+    s : str
+        Duration string from xc_annotated_recordings.csv ``length`` column.
+
+    Returns
+    -------
+    float | None
+        Total seconds, or ``None`` if input is empty / malformed.
+    """
+    if not isinstance(s, str):
+        return None
+    m = _DURATION_RE.match(s)
+    if not m:
+        return None
+    h = int(m.group(1) or 0)
+    mm = int(m.group(2))
+    ss = int(m.group(3))
+    return float(h * 3600 + mm * 60 + ss)
+
+
+def gsutil_cat(uri: str) -> str:
+    """Stream a file via gsutil cat.
+
+    Parameters
+    ----------
+    uri : str
+        The ``gs://`` URI to read.
+
+    Returns
+    -------
+    str
+        The decoded file contents.
+    """
+    out = subprocess.run(
+        ["gsutil", "cat", uri],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    return out.stdout
+
+
+def build(out_dir: Path, upload: bool) -> Path:
+    """Build the WABAD-shaped CSV and optionally upload.
+
+    Parameters
+    ----------
+    out_dir : Path
+        Local staging directory for the CSV.
+    upload : bool
+        If True, gsutil cp the result to the GCS output path.
+
+    Returns
+    -------
+    Path
+        Local CSV path written.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Fetching {SEGMENTS_CSV} ...", flush=True)
+    seg = pd.read_csv(io.StringIO(gsutil_cat(SEGMENTS_CSV)), keep_default_na=False, na_values=[""])
+    print(f"  loaded {len(seg):,} segments")
+
+    print(f"Fetching {EXTRAS_CSV} ...", flush=True)
+    extras = pd.read_csv(io.StringIO(gsutil_cat(EXTRAS_CSV)), keep_default_na=False, na_values=[""])
+    print(f"  loaded {len(extras):,} extras")
+
+    print(f"Fetching {RECORDINGS_CSV} ...", flush=True)
+    rec = pd.read_csv(
+        io.StringIO(gsutil_cat(RECORDINGS_CSV)), keep_default_na=False, na_values=[""]
+    )
+    print(f"  loaded {len(rec):,} recordings")
+    rec["audio_duration"] = rec["length"].map(parse_duration)
+    rec = rec[["xc_id", "audio_duration"]].dropna()
+    print(f"  parsed durations for {len(rec):,} recordings")
+
+    # --- Pivot: group segments by xc_id, write selection_table TSV ---
+    print("Building per-file selection_tables ...", flush=True)
+    seg["start_time_s"] = pd.to_numeric(seg["start_time_s"], errors="coerce")
+    seg["end_time_s"] = pd.to_numeric(seg["end_time_s"], errors="coerce")
+    seg["frequency_low_hz"] = pd.to_numeric(seg["frequency_low_hz"], errors="coerce")
+    seg["frequency_high_hz"] = pd.to_numeric(seg["frequency_high_hz"], errors="coerce")
+    seg = seg.dropna(subset=["start_time_s", "end_time_s"])
+    seg = seg[seg["scientific_name"].astype(str).str.strip().ne("")]
+    seg = seg.sort_values(["xc_id", "start_time_s"]).reset_index(drop=True)
+
+    st_columns = [
+        "Begin Time (s)",
+        "End Time (s)",
+        "Low Freq (Hz)",
+        "High Freq (Hz)",
+        "Species",
+        "sound_type",
+        "sex",
+        "life_stage",
+        "annotator",
+    ]
+
+    def _to_tsv(group: pd.DataFrame) -> str:
+        df = pd.DataFrame(
+            {
+                "Begin Time (s)": group["start_time_s"].round(4),
+                "End Time (s)": group["end_time_s"].round(4),
+                "Low Freq (Hz)": group["frequency_low_hz"].fillna(0).astype(int),
+                "High Freq (Hz)": group["frequency_high_hz"].fillna(0).astype(int),
+                "Species": group["scientific_name"].astype(str),
+                "sound_type": group["sound_type"].fillna("").astype(str),
+                "sex": group["sex"].fillna("").astype(str),
+                "life_stage": group["life_stage"].fillna("").astype(str),
+                "annotator": group["annotator"].fillna("").astype(str),
+            }
+        )[st_columns]
+        return df.to_csv(sep="\t", index=False)
+
+    pivot = (
+        seg.groupby("xc_id", sort=False)
+        .apply(
+            lambda g: pd.Series(
+                {
+                    "selection_table": _to_tsv(g),
+                    "n_events": len(g),
+                }
+            )
+        )
+        .reset_index()
+    )
+    print(f"  pivoted to {len(pivot):,} files (mean {seg.shape[0] / len(pivot):.1f} events/file)")
+
+    # --- Join with extras for file-level metadata + paths ---
+    extras_keep = [
+        "xc_id",
+        "gcs_path",
+        "relative_path",
+        "16khz_path",
+        "32khz_path",
+        "scientific_name_unified",
+        "vernacularName",
+        "species_common",
+        "kingdom",
+        "phylum",
+        "class",
+        "order",
+        "family",
+        "genus",
+        "gbifID",
+        "taxonKey",
+        "speciesKey",
+        "latitudeDecimal",
+        "longitudeDecimal",
+        "country_code",
+        "locality",
+        "continent",
+        "eventDate",
+        "year",
+        "month",
+        "day",
+        "recordedBy",
+        "rightsHolder",
+    ]
+    # `license` and `media_license` columns vary in the extras file — pull
+    # what's present.
+    for col in ("license", "media_license", "license_url", "media_license_url"):
+        if col in extras.columns:
+            extras_keep.append(col)
+    extras_keep = [c for c in extras_keep if c in extras.columns]
+    extras_slim = extras[extras_keep].copy()
+    extras_slim["xc_id"] = extras_slim["xc_id"].astype(int)
+    pivot["xc_id"] = pivot["xc_id"].astype(int)
+    rec["xc_id"] = rec["xc_id"].astype(int)
+
+    df = pivot.merge(extras_slim, on="xc_id", how="left")
+    df = df.merge(rec, on="xc_id", how="left")
+
+    # --- Derive WABAD-shaped path columns (relative-to-data_root) ---
+    # data_root will be gs://esp-data-ingestion/xeno-canto/v0.1.0/raw/, so the
+    # relative paths need the audio/ + audio_16k/ + audio_32k/ subdirs.
+    def _prefix(col: str, sub: str) -> pd.Series:
+        return sub + "/" + df[col].astype(str)
+
+    df["audio_fp"] = _prefix("relative_path", "audio")
+    df["16khz_path"] = _prefix("16khz_path", "audio_16k")
+    df["32khz_path"] = _prefix("32khz_path", "audio_32k")
+
+    # Rename file-level focal columns so they don't shadow the per-event
+    # species name embedded in selection_table.
+    df = df.rename(
+        columns={
+            "scientific_name_unified": "recording_scientific_name",
+            "species_common": "recording_species_common",
+        }
+    )
+
+    df["source_dataset"] = "xeno_canto_strong"
+
+    # Drop missing-duration rows (loader needs it for window bounds).
+    n_pre = len(df)
+    df = df.dropna(subset=["audio_duration"])
+    if n_pre - len(df):
+        print(f"  WARN dropped {n_pre - len(df)} rows with no audio_duration")
+
+    # Drop columns we no longer need to keep the CSV lean.
+    df = df.drop(columns=["gcs_path", "relative_path"], errors="ignore")
+
+    # Final column order (small headers first for readability).
+    head_cols = [
+        "xc_id",
+        "audio_fp",
+        "16khz_path",
+        "32khz_path",
+        "audio_duration",
+        "n_events",
+        "selection_table",
+        "recording_scientific_name",
+        "recording_species_common",
+    ]
+    tail_cols = [c for c in df.columns if c not in head_cols]
+    df = df[head_cols + tail_cols]
+
+    out = out_dir / OUT_CSV_NAME
+    df.to_csv(out, index=False)
+    print(f"Wrote {len(df):,} rows -> {out} ({out.stat().st_size / 1024 / 1024:.1f} MB)")
+
+    if upload:
+        dest = f"{INPUT_ROOT}/{OUT_CSV_NAME}"
+        print(f"Uploading to {dest} ...", flush=True)
+        subprocess.run(["gsutil", "-q", "cp", str(out), dest], check=True)
+        print("Upload done.")
+
+    return out
+
+
+def main() -> None:
+    """Entry point — see module docstring."""
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--out-dir", default="/mnt/home/alp-data/xc_strong_staging")
+    p.add_argument("--upload", action="store_true")
+    args = p.parse_args()
+    build(Path(args.out_dir), upload=args.upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data_preprocessing_scripts/xeno_canto_strong_validate.py
+++ b/scripts/data_preprocessing_scripts/xeno_canto_strong_validate.py
@@ -1,0 +1,167 @@
+"""Validate that every audio referenced by xc_strong_with_selection_table.csv
+exists on GCS at the expected 16k + 32k paths.
+
+Streaming, memory-light: keeps two sets (~600 KB + ~30 MB peak), no full
+materialisation of any DataFrame. Designed to run on Slurm CPU partition.
+
+Outputs:
+- A JSON summary with per-shard missing counts.
+- A CSV of missing xc_ids with which shards they're missing from.
+- Lines like ``XC1120736: missing in audio_16k, audio_32k, audio`` to stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+MANIFEST_URI = "gs://esp-data-ingestion/xeno-canto/v0.1.0/raw/xc_strong_with_selection_table.csv"
+AUDIO_ROOT = "gs://esp-data-ingestion/xeno-canto/v0.1.0/raw"
+
+
+def _set_from_listing(prefix: str, suffix: str) -> set[str]:
+    """Stream a `gsutil ls -r prefix/**` listing; return set of basename stems.
+
+    Parameters
+    ----------
+    prefix : str
+        e.g. ``gs://.../audio_16k``
+    suffix : str
+        File extension to keep (``.wav`` / ``.mp3``).
+
+    Returns
+    -------
+    set[str]
+        Filename stems (e.g. ``XC65654``).
+    """
+    print(f"Listing {prefix}/ ...", flush=True)
+    out = set()
+    # Pipe gsutil's output and parse line-by-line so we never hold the
+    # full listing in memory at once.
+    proc = subprocess.Popen(
+        ["gsutil", "ls", f"{prefix}/**"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        bufsize=1,
+    )
+    assert proc.stdout is not None
+    n = 0
+    pat = re.compile(rf".*/(XC\d+){re.escape(suffix)}$")
+    for line in proc.stdout:
+        m = pat.match(line.strip())
+        if m:
+            out.add(m.group(1))
+            n += 1
+            if n % 100_000 == 0:
+                print(f"  {n:,} files indexed ...", flush=True)
+    proc.wait()
+    print(f"  {len(out):,} unique IDs at {prefix}", flush=True)
+    return out
+
+
+def _manifest_ids() -> tuple[set[str], dict[str, dict[str, str]]]:
+    """Stream the XCStrong manifest; return its full XC-id set + per-row paths.
+
+    Returns
+    -------
+    tuple
+        ``(set_of_xc_ids, {xc_id: {'audio_fp': ..., '16khz_path': ..., '32khz_path': ...}})``.
+    """
+    print(f"Streaming manifest {MANIFEST_URI} ...", flush=True)
+    out = subprocess.run(
+        ["gsutil", "cat", MANIFEST_URI],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    ).stdout
+    ids: set[str] = set()
+    rows: dict[str, dict[str, str]] = {}
+    csv.field_size_limit(100 * 1024 * 1024)
+    for r in csv.DictReader(io.StringIO(out)):
+        xcid = f"XC{r['xc_id']}"
+        ids.add(xcid)
+        rows[xcid] = {
+            "audio_fp": r.get("audio_fp", ""),
+            "16khz_path": r.get("16khz_path", ""),
+            "32khz_path": r.get("32khz_path", ""),
+        }
+    print(f"  {len(ids):,} unique XC IDs in manifest", flush=True)
+    return ids, rows
+
+
+def main() -> None:
+    """Run the existence sweep and write a report."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out-dir", type=Path, default=Path("/home/david_earthspecies_org/logs"))
+    args = parser.parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest_ids, manifest_paths = _manifest_ids()
+
+    audio_16k = _set_from_listing(f"{AUDIO_ROOT}/audio_16k", ".wav")
+    audio_32k = _set_from_listing(f"{AUDIO_ROOT}/audio_32k", ".wav")
+    audio_mp3 = _set_from_listing(f"{AUDIO_ROOT}/audio", ".mp3")
+
+    missing_16k = manifest_ids - audio_16k
+    missing_32k = manifest_ids - audio_32k
+    missing_mp3 = manifest_ids - audio_mp3
+    missing_any = missing_16k | missing_32k | missing_mp3
+    missing_all = missing_16k & missing_32k & missing_mp3
+
+    summary = {
+        "manifest_rows": len(manifest_ids),
+        "audio_16k_present_total": len(audio_16k),
+        "audio_32k_present_total": len(audio_32k),
+        "audio_mp3_present_total": len(audio_mp3),
+        "missing_16k": len(missing_16k),
+        "missing_32k": len(missing_32k),
+        "missing_mp3": len(missing_mp3),
+        "missing_in_any_shard": len(missing_any),
+        "missing_in_all_three_shards": len(missing_all),
+    }
+    print("\n=== SUMMARY ===")
+    print(json.dumps(summary, indent=2))
+
+    (args.out_dir / "xc_strong_audio_audit.json").write_text(json.dumps(summary, indent=2))
+
+    missing_csv = args.out_dir / "xc_strong_missing_audio.csv"
+    with missing_csv.open("w") as f:
+        w = csv.writer(f)
+        w.writerow(["xc_id", "missing_16k", "missing_32k", "missing_mp3", "manifest_audio_fp"])
+        for xcid in sorted(missing_any):
+            w.writerow(
+                [
+                    xcid,
+                    int(xcid in missing_16k),
+                    int(xcid in missing_32k),
+                    int(xcid in missing_mp3),
+                    manifest_paths[xcid]["audio_fp"],
+                ]
+            )
+    print(f"Wrote {len(missing_any):,} missing-row report -> {missing_csv}")
+
+    if missing_any:
+        print("\nFirst 20 IDs missing in any shard:")
+        for xcid in sorted(missing_any)[:20]:
+            shards = []
+            if xcid in missing_16k:
+                shards.append("16k")
+            if xcid in missing_32k:
+                shards.append("32k")
+            if xcid in missing_mp3:
+                shards.append("mp3")
+            print(f"  {xcid}: missing in {','.join(shards)}")
+
+    sys.exit(0 if not missing_any else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unittests/datasets_tests/test_dartmouth_avian_soundscapes.py
+++ b/tests/unittests/datasets_tests/test_dartmouth_avian_soundscapes.py
@@ -1,0 +1,218 @@
+"""
+Unit tests for DartmouthAvianSoundscapes dataset.
+
+Run with:
+    pytest -q test_dartmouth_avian_soundscapes.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from alp_data import DatasetConfig
+from alp_data.datasets import DartmouthAvianSoundscapes
+from alp_data.utils import create_hash
+
+
+EXPECTED_LEN_ALL = 1302
+EXPECTED_LEN_SMALL = 396          # split 'acad'
+FIRST_ITEM_AUDIO_SHA256 = (
+    "e5f8430b46ae3d6f32cf9fe42efa3a7e004740eccad6365f68e37351fa948da2"
+)
+MANIFEST_SHA256 = "bba6b47abdaef7b096ee941707e8164752474da67acbb7c819b988353f5a6c80"
+
+# Shared by every strongly-labeled soundscape dataset in this family.
+CORE_ST_COLUMNS = ["Begin Time (s)", "End Time (s)", "Low Freq (Hz)", "High Freq (Hz)", "Species"]
+EXTRA_ST_COLUMNS = ["Species Code", "Common Name", "Background"]
+AUDIO_FP_PREFIX = 'recordings/'
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def ds_all() -> DartmouthAvianSoundscapes:
+    """Full manifest (metadata-level assertions; avoid bulk audio here)."""
+    return DartmouthAvianSoundscapes(split="all", backend="pandas")
+
+
+@pytest.fixture(scope="module")
+def ds() -> DartmouthAvianSoundscapes:
+    """Smallest split, used for every audio-level test."""
+    return DartmouthAvianSoundscapes(split='acad', sample_rate=32000, backend="pandas")
+
+
+def test_lengths(ds_all: DartmouthAvianSoundscapes, ds: DartmouthAvianSoundscapes):
+    assert len(ds_all) == EXPECTED_LEN_ALL
+    assert len(ds) == EXPECTED_LEN_SMALL
+
+
+def test_available_splits(ds_all: DartmouthAvianSoundscapes):
+    assert "all" in ds_all.available_splits
+    assert set(ds_all.available_splits) == {'mabi', 'simr', 'all', 'acad'}
+
+
+def test_invalid_split_raises():
+    with pytest.raises(LookupError):
+        DartmouthAvianSoundscapes(split="not_a_split")
+
+
+def test_check_audio(ds: DartmouthAvianSoundscapes):
+    """Audio integrity on deterministic indices."""
+    for idx in (0, 1, 2):
+        item = ds[idx]
+        audio = item["audio"]
+        assert isinstance(audio, np.ndarray), f"[{idx}] audio is not a numpy array"
+        assert audio.dtype == np.float32, f"[{idx}] dtype is {audio.dtype}"
+        assert audio.ndim == 1, f"[{idx}] not mono, shape={audio.shape}"
+        assert audio.size >= 10, f"[{idx}] too short"
+        assert not np.any(np.isnan(audio)), f"[{idx}] contains NaN"
+        assert not np.all(audio == 0), f"[{idx}] all zeros"
+        assert item["sample_rate"] == 32000
+
+
+def test_presampled_columns_exist(ds: DartmouthAvianSoundscapes):
+    assert "16khz_path" in ds.columns
+    assert "32khz_path" in ds.columns
+    assert ds.available_sample_rates == [16000, 32000]
+
+
+def test_load_presampled_16khz(ds: DartmouthAvianSoundscapes):
+    """16 kHz reads the 16 kHz mirror: exactly half the samples of the 32 kHz read."""
+    ds_16 = DartmouthAvianSoundscapes(split='acad', sample_rate=16000, backend="pandas")
+    item_16 = ds_16[0]
+    assert item_16["sample_rate"] == 16000
+    # Independently resampled mirrors, so allow a sample of rounding slack.
+    assert abs(ds[0]["audio"].size - 2 * item_16["audio"].size) <= 2
+
+
+def test_audio_fp_target(ds_all: DartmouthAvianSoundscapes):
+    """`audio_fp` should point where this dataset's originals actually live."""
+    assert ds_all._data.unwrap["audio_fp"].str.startswith(AUDIO_FP_PREFIX).all()
+
+
+def test_annotation_columns(ds_all: DartmouthAvianSoundscapes):
+    """The family contract: Species is the annotation column."""
+    assert ds_all.annotation_columns == ["Species"]
+
+
+def test_selection_table_schema(ds: DartmouthAvianSoundscapes):
+    """Raven-shaped table with the columns this family guarantees."""
+    for idx in (0, 1, 2):
+        item = ds[idx]
+        st = item["selection_table"]
+        assert isinstance(st, pd.DataFrame), f"[{idx}] not a DataFrame"
+        missing = set(CORE_ST_COLUMNS) - set(st.columns)
+        assert not missing, f"[{idx}] missing {sorted(missing)}"
+        for col in EXTRA_ST_COLUMNS:
+            assert col in st.columns, f"[{idx}] missing {col}"
+        if len(st):
+            assert (st["End Time (s)"] >= st["Begin Time (s)"]).all()
+            duration = item["audio"].size / item["sample_rate"]
+            assert st["End Time (s)"].max() <= duration + 1.0
+            assert st["Species"].astype(str).str.len().gt(0).all()
+
+
+def test_n_events_matches_table(ds: DartmouthAvianSoundscapes):
+    for idx in (0, 1, 2):
+        item = ds[idx]
+        assert len(item["selection_table"]) == int(item["n_events"])
+
+
+def _windowed(ds: DartmouthAvianSoundscapes, idx: int, start: float, end: float) -> dict:
+    """Process a row as if a caller had attached window columns."""
+    row = dict(ds._data[idx])
+    row["window_start_sec"], row["window_end_sec"] = start, end
+    return ds._process(row)
+
+
+def test_windowed_read_returns_only_the_window(ds: DartmouthAvianSoundscapes):
+    item = _windowed(ds, 0, 5.0, 15.0)
+    assert abs(item["audio"].size / item["sample_rate"] - 10.0) < 0.05
+    assert item["audio"].size < ds[0]["audio"].size
+
+
+def test_windowed_selection_table_is_window_relative(ds: DartmouthAvianSoundscapes):
+    """
+    Events must be filtered to the window and shifted onto the returned audio.
+
+    Regression guard: these datasets previously clipped with
+    `Begin Time (s) < audio_dur` against the *window* length while leaving times
+    recording-absolute, which silently dropped every event in a non-zero window.
+    """
+    full_st = ds[0]["selection_table"]
+    candidates = full_st[full_st["Begin Time (s)"] >= 2.0]
+    if candidates.empty:
+        pytest.skip("first recording has no event beyond 2 s")
+    event = candidates.iloc[0]
+    start = float(event["Begin Time (s)"]) - 2.0
+    st = _windowed(ds, 0, start, start + 6.0)["selection_table"]
+
+    assert len(st) > 0, "window was built around an event, so it cannot be empty"
+    assert (st["Begin Time (s)"] >= 0).all()
+    assert (st["End Time (s)"] <= 6.0 + 1e-6).all()
+    assert np.isclose(st["Begin Time (s)"], 2.0, atol=1e-6).any(), (
+        "the event the window was built around is not at its expected offset"
+    )
+    assert len(st) < len(full_st), "no events were filtered out of the window"
+
+
+def test_unwindowed_selection_table_stays_absolute(ds: DartmouthAvianSoundscapes):
+    item = ds[0]
+    st = item["selection_table"]
+    assert len(st) == int(item["n_events"]), "unwindowed read dropped events"
+
+
+def test_backends_agree(ds: DartmouthAvianSoundscapes):
+    ds_polars = DartmouthAvianSoundscapes(split='acad', sample_rate=32000, backend="polars")
+    assert len(ds_polars) == len(ds)
+    assert np.array_equal(ds_polars[0]["audio"], ds[0]["audio"])
+
+
+def test_from_config():
+    config = DatasetConfig(
+        dataset_name='dartmouth_avian_soundscapes', split='acad', sample_rate=32000, backend="pandas"
+    )
+    ds_cfg, meta = DartmouthAvianSoundscapes.from_config(config)
+    assert isinstance(ds_cfg, DartmouthAvianSoundscapes)
+    assert meta == {}
+    assert len(ds_cfg) == EXPECTED_LEN_SMALL
+
+
+def test_output_take_and_give(ds: DartmouthAvianSoundscapes):
+    ds_mapped = DartmouthAvianSoundscapes(
+        split='acad',
+        sample_rate=32000,
+        backend="pandas",
+        output_take_and_give={"audio": "waveform", "selection_table": "events"},
+    )
+    item = ds_mapped[0]
+    assert set(item.keys()) == {"waveform", "events"}
+    assert isinstance(item["waveform"], np.ndarray)
+
+
+def test_reference_item_stability(ds: DartmouthAvianSoundscapes):
+    """
+    Canonical item (index 0 of the smallest split) is bitwise-stable.
+
+    Catches sample-rate, channel-handling, dtype and split-ordering changes.
+    Recompute and update the constants if a dataset revision is intentional.
+    """
+    audio = ds[0]["audio"]
+    h = create_hash(audio.tobytes())
+    assert h == FIRST_ITEM_AUDIO_SHA256, (
+        f"First item's audio hash changed.\nGot    {h}\nExpect {FIRST_ITEM_AUDIO_SHA256}"
+    )
+    csv_bytes = (
+        ds._data.unwrap.sort_index(axis=0).sort_index(axis=1).to_csv(index=True).encode("utf-8")
+    )
+    h = create_hash(csv_bytes)
+    assert h == MANIFEST_SHA256, (
+        f"Manifest hash changed.\nGot    {h}\nExpect {MANIFEST_SHA256}"
+    )
+
+
+def test_str(ds_all: DartmouthAvianSoundscapes):
+    text = str(ds_all)
+    assert 'dartmouth_avian_soundscapes' in text
+    assert "0.1.0" in text

--- a/tests/unittests/datasets_tests/test_indian_fauna_strong.py
+++ b/tests/unittests/datasets_tests/test_indian_fauna_strong.py
@@ -1,0 +1,218 @@
+"""
+Unit tests for IndianFaunaStrong dataset.
+
+Run with:
+    pytest -q test_indian_fauna_strong.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from alp_data import DatasetConfig
+from alp_data.datasets import IndianFaunaStrong
+from alp_data.utils import create_hash
+
+
+EXPECTED_LEN_ALL = 1702
+EXPECTED_LEN_SMALL = 1702          # split 'all'
+FIRST_ITEM_AUDIO_SHA256 = (
+    "9820645e5fc74f70943c7336fe143c0dc2748f10dbbbf5d5ef85a8933785c6c2"
+)
+MANIFEST_SHA256 = "5a21c6cc34739de4d60e8b72b555627874e180e1d3c82b675e5758a7553dc4d5"
+
+# Shared by every strongly-labeled soundscape dataset in this family.
+CORE_ST_COLUMNS = ["Begin Time (s)", "End Time (s)", "Low Freq (Hz)", "High Freq (Hz)", "Species"]
+EXTRA_ST_COLUMNS = ["Selection"]
+AUDIO_FP_PREFIX = 'audio_32k/'
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def ds_all() -> IndianFaunaStrong:
+    """Full manifest (metadata-level assertions; avoid bulk audio here)."""
+    return IndianFaunaStrong(split="all", backend="pandas")
+
+
+@pytest.fixture(scope="module")
+def ds() -> IndianFaunaStrong:
+    """Smallest split, used for every audio-level test."""
+    return IndianFaunaStrong(split='all', sample_rate=32000, backend="pandas")
+
+
+def test_lengths(ds_all: IndianFaunaStrong, ds: IndianFaunaStrong):
+    assert len(ds_all) == EXPECTED_LEN_ALL
+    assert len(ds) == EXPECTED_LEN_SMALL
+
+
+def test_available_splits(ds_all: IndianFaunaStrong):
+    assert "all" in ds_all.available_splits
+    assert set(ds_all.available_splits) == {'all'}
+
+
+def test_invalid_split_raises():
+    with pytest.raises(LookupError):
+        IndianFaunaStrong(split="not_a_split")
+
+
+def test_check_audio(ds: IndianFaunaStrong):
+    """Audio integrity on deterministic indices."""
+    for idx in (0, 1, 2):
+        item = ds[idx]
+        audio = item["audio"]
+        assert isinstance(audio, np.ndarray), f"[{idx}] audio is not a numpy array"
+        assert audio.dtype == np.float32, f"[{idx}] dtype is {audio.dtype}"
+        assert audio.ndim == 1, f"[{idx}] not mono, shape={audio.shape}"
+        assert audio.size >= 10, f"[{idx}] too short"
+        assert not np.any(np.isnan(audio)), f"[{idx}] contains NaN"
+        assert not np.all(audio == 0), f"[{idx}] all zeros"
+        assert item["sample_rate"] == 32000
+
+
+def test_presampled_columns_exist(ds: IndianFaunaStrong):
+    assert "16khz_path" in ds.columns
+    assert "32khz_path" in ds.columns
+    assert ds.available_sample_rates == [16000, 32000]
+
+
+def test_load_presampled_16khz(ds: IndianFaunaStrong):
+    """16 kHz reads the 16 kHz mirror: exactly half the samples of the 32 kHz read."""
+    ds_16 = IndianFaunaStrong(split='all', sample_rate=16000, backend="pandas")
+    item_16 = ds_16[0]
+    assert item_16["sample_rate"] == 16000
+    # Independently resampled mirrors, so allow a sample of rounding slack.
+    assert abs(ds[0]["audio"].size - 2 * item_16["audio"].size) <= 2
+
+
+def test_audio_fp_target(ds_all: IndianFaunaStrong):
+    """`audio_fp` should point where this dataset's originals actually live."""
+    assert ds_all._data.unwrap["audio_fp"].str.startswith(AUDIO_FP_PREFIX).all()
+
+
+def test_annotation_columns(ds_all: IndianFaunaStrong):
+    """The family contract: Species is the annotation column."""
+    assert ds_all.annotation_columns == ["Species"]
+
+
+def test_selection_table_schema(ds: IndianFaunaStrong):
+    """Raven-shaped table with the columns this family guarantees."""
+    for idx in (0, 1, 2):
+        item = ds[idx]
+        st = item["selection_table"]
+        assert isinstance(st, pd.DataFrame), f"[{idx}] not a DataFrame"
+        missing = set(CORE_ST_COLUMNS) - set(st.columns)
+        assert not missing, f"[{idx}] missing {sorted(missing)}"
+        for col in EXTRA_ST_COLUMNS:
+            assert col in st.columns, f"[{idx}] missing {col}"
+        if len(st):
+            assert (st["End Time (s)"] >= st["Begin Time (s)"]).all()
+            duration = item["audio"].size / item["sample_rate"]
+            assert st["End Time (s)"].max() <= duration + 1.0
+            assert st["Species"].astype(str).str.len().gt(0).all()
+
+
+def test_n_events_matches_table(ds: IndianFaunaStrong):
+    for idx in (0, 1, 2):
+        item = ds[idx]
+        assert len(item["selection_table"]) == int(item["n_events"])
+
+
+def _windowed(ds: IndianFaunaStrong, idx: int, start: float, end: float) -> dict:
+    """Process a row as if a caller had attached window columns."""
+    row = dict(ds._data[idx])
+    row["window_start_sec"], row["window_end_sec"] = start, end
+    return ds._process(row)
+
+
+def test_windowed_read_returns_only_the_window(ds: IndianFaunaStrong):
+    item = _windowed(ds, 0, 5.0, 15.0)
+    assert abs(item["audio"].size / item["sample_rate"] - 10.0) < 0.05
+    assert item["audio"].size < ds[0]["audio"].size
+
+
+def test_windowed_selection_table_is_window_relative(ds: IndianFaunaStrong):
+    """
+    Events must be filtered to the window and shifted onto the returned audio.
+
+    Regression guard: these datasets previously clipped with
+    `Begin Time (s) < audio_dur` against the *window* length while leaving times
+    recording-absolute, which silently dropped every event in a non-zero window.
+    """
+    full_st = ds[0]["selection_table"]
+    candidates = full_st[full_st["Begin Time (s)"] >= 2.0]
+    if candidates.empty:
+        pytest.skip("first recording has no event beyond 2 s")
+    event = candidates.iloc[0]
+    start = float(event["Begin Time (s)"]) - 2.0
+    st = _windowed(ds, 0, start, start + 6.0)["selection_table"]
+
+    assert len(st) > 0, "window was built around an event, so it cannot be empty"
+    assert (st["Begin Time (s)"] >= 0).all()
+    assert (st["End Time (s)"] <= 6.0 + 1e-6).all()
+    assert np.isclose(st["Begin Time (s)"], 2.0, atol=1e-6).any(), (
+        "the event the window was built around is not at its expected offset"
+    )
+    assert len(st) < len(full_st), "no events were filtered out of the window"
+
+
+def test_unwindowed_selection_table_stays_absolute(ds: IndianFaunaStrong):
+    item = ds[0]
+    st = item["selection_table"]
+    assert len(st) == int(item["n_events"]), "unwindowed read dropped events"
+
+
+def test_backends_agree(ds: IndianFaunaStrong):
+    ds_polars = IndianFaunaStrong(split='all', sample_rate=32000, backend="polars")
+    assert len(ds_polars) == len(ds)
+    assert np.array_equal(ds_polars[0]["audio"], ds[0]["audio"])
+
+
+def test_from_config():
+    config = DatasetConfig(
+        dataset_name='indian_fauna_strong', split='all', sample_rate=32000, backend="pandas"
+    )
+    ds_cfg, meta = IndianFaunaStrong.from_config(config)
+    assert isinstance(ds_cfg, IndianFaunaStrong)
+    assert meta == {}
+    assert len(ds_cfg) == EXPECTED_LEN_SMALL
+
+
+def test_output_take_and_give(ds: IndianFaunaStrong):
+    ds_mapped = IndianFaunaStrong(
+        split='all',
+        sample_rate=32000,
+        backend="pandas",
+        output_take_and_give={"audio": "waveform", "selection_table": "events"},
+    )
+    item = ds_mapped[0]
+    assert set(item.keys()) == {"waveform", "events"}
+    assert isinstance(item["waveform"], np.ndarray)
+
+
+def test_reference_item_stability(ds: IndianFaunaStrong):
+    """
+    Canonical item (index 0 of the smallest split) is bitwise-stable.
+
+    Catches sample-rate, channel-handling, dtype and split-ordering changes.
+    Recompute and update the constants if a dataset revision is intentional.
+    """
+    audio = ds[0]["audio"]
+    h = create_hash(audio.tobytes())
+    assert h == FIRST_ITEM_AUDIO_SHA256, (
+        f"First item's audio hash changed.\nGot    {h}\nExpect {FIRST_ITEM_AUDIO_SHA256}"
+    )
+    csv_bytes = (
+        ds._data.unwrap.sort_index(axis=0).sort_index(axis=1).to_csv(index=True).encode("utf-8")
+    )
+    h = create_hash(csv_bytes)
+    assert h == MANIFEST_SHA256, (
+        f"Manifest hash changed.\nGot    {h}\nExpect {MANIFEST_SHA256}"
+    )
+
+
+def test_str(ds_all: IndianFaunaStrong):
+    text = str(ds_all)
+    assert 'indian_fauna_strong' in text
+    assert "0.1.0" in text

--- a/tests/unittests/datasets_tests/test_pteroset.py
+++ b/tests/unittests/datasets_tests/test_pteroset.py
@@ -1,0 +1,218 @@
+"""
+Unit tests for PteroSet dataset.
+
+Run with:
+    pytest -q test_pteroset.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from alp_data import DatasetConfig
+from alp_data.datasets import PteroSet
+from alp_data.utils import create_hash
+
+
+EXPECTED_LEN_ALL = 563
+EXPECTED_LEN_SMALL = 46          # split 'map1'
+FIRST_ITEM_AUDIO_SHA256 = (
+    "6742ea8b20c63ae79edfc11fae4694f21ee5cfd44c37413a36a782e1b23e9ba5"
+)
+MANIFEST_SHA256 = "f3bb116823ed1be4d88020c6a8480a1a4f7404f7ceaef9bdae7aea5c7e86f817"
+
+# Shared by every strongly-labeled soundscape dataset in this family.
+CORE_ST_COLUMNS = ["Begin Time (s)", "End Time (s)", "Low Freq (Hz)", "High Freq (Hz)", "Species"]
+EXTRA_ST_COLUMNS = ["Species Code", "Identification", "Type"]
+AUDIO_FP_PREFIX = 'recordings/'
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def ds_all() -> PteroSet:
+    """Full manifest (metadata-level assertions; avoid bulk audio here)."""
+    return PteroSet(split="all", backend="pandas")
+
+
+@pytest.fixture(scope="module")
+def ds() -> PteroSet:
+    """Smallest split, used for every audio-level test."""
+    return PteroSet(split='map1', sample_rate=32000, backend="pandas")
+
+
+def test_lengths(ds_all: PteroSet, ds: PteroSet):
+    assert len(ds_all) == EXPECTED_LEN_ALL
+    assert len(ds) == EXPECTED_LEN_SMALL
+
+
+def test_available_splits(ds_all: PteroSet):
+    assert "all" in ds_all.available_splits
+    assert set(ds_all.available_splits) == {'ppa2', 'all', 'ppa4', 'map1', 'ppa1', 'ppa3'}
+
+
+def test_invalid_split_raises():
+    with pytest.raises(LookupError):
+        PteroSet(split="not_a_split")
+
+
+def test_check_audio(ds: PteroSet):
+    """Audio integrity on deterministic indices."""
+    for idx in (0, 1, 2):
+        item = ds[idx]
+        audio = item["audio"]
+        assert isinstance(audio, np.ndarray), f"[{idx}] audio is not a numpy array"
+        assert audio.dtype == np.float32, f"[{idx}] dtype is {audio.dtype}"
+        assert audio.ndim == 1, f"[{idx}] not mono, shape={audio.shape}"
+        assert audio.size >= 10, f"[{idx}] too short"
+        assert not np.any(np.isnan(audio)), f"[{idx}] contains NaN"
+        assert not np.all(audio == 0), f"[{idx}] all zeros"
+        assert item["sample_rate"] == 32000
+
+
+def test_presampled_columns_exist(ds: PteroSet):
+    assert "16khz_path" in ds.columns
+    assert "32khz_path" in ds.columns
+    assert ds.available_sample_rates == [16000, 32000]
+
+
+def test_load_presampled_16khz(ds: PteroSet):
+    """16 kHz reads the 16 kHz mirror: exactly half the samples of the 32 kHz read."""
+    ds_16 = PteroSet(split='map1', sample_rate=16000, backend="pandas")
+    item_16 = ds_16[0]
+    assert item_16["sample_rate"] == 16000
+    # Independently resampled mirrors, so allow a sample of rounding slack.
+    assert abs(ds[0]["audio"].size - 2 * item_16["audio"].size) <= 2
+
+
+def test_audio_fp_target(ds_all: PteroSet):
+    """`audio_fp` should point where this dataset's originals actually live."""
+    assert ds_all._data.unwrap["audio_fp"].str.startswith(AUDIO_FP_PREFIX).all()
+
+
+def test_annotation_columns(ds_all: PteroSet):
+    """The family contract: Species is the annotation column."""
+    assert ds_all.annotation_columns == ["Species"]
+
+
+def test_selection_table_schema(ds: PteroSet):
+    """Raven-shaped table with the columns this family guarantees."""
+    for idx in (0, 1, 2):
+        item = ds[idx]
+        st = item["selection_table"]
+        assert isinstance(st, pd.DataFrame), f"[{idx}] not a DataFrame"
+        missing = set(CORE_ST_COLUMNS) - set(st.columns)
+        assert not missing, f"[{idx}] missing {sorted(missing)}"
+        for col in EXTRA_ST_COLUMNS:
+            assert col in st.columns, f"[{idx}] missing {col}"
+        if len(st):
+            assert (st["End Time (s)"] >= st["Begin Time (s)"]).all()
+            duration = item["audio"].size / item["sample_rate"]
+            assert st["End Time (s)"].max() <= duration + 1.0
+            assert st["Species"].astype(str).str.len().gt(0).all()
+
+
+def test_n_events_matches_table(ds: PteroSet):
+    for idx in (0, 1, 2):
+        item = ds[idx]
+        assert len(item["selection_table"]) == int(item["n_events"])
+
+
+def _windowed(ds: PteroSet, idx: int, start: float, end: float) -> dict:
+    """Process a row as if a caller had attached window columns."""
+    row = dict(ds._data[idx])
+    row["window_start_sec"], row["window_end_sec"] = start, end
+    return ds._process(row)
+
+
+def test_windowed_read_returns_only_the_window(ds: PteroSet):
+    item = _windowed(ds, 0, 5.0, 15.0)
+    assert abs(item["audio"].size / item["sample_rate"] - 10.0) < 0.05
+    assert item["audio"].size < ds[0]["audio"].size
+
+
+def test_windowed_selection_table_is_window_relative(ds: PteroSet):
+    """
+    Events must be filtered to the window and shifted onto the returned audio.
+
+    Regression guard: these datasets previously clipped with
+    `Begin Time (s) < audio_dur` against the *window* length while leaving times
+    recording-absolute, which silently dropped every event in a non-zero window.
+    """
+    full_st = ds[0]["selection_table"]
+    candidates = full_st[full_st["Begin Time (s)"] >= 2.0]
+    if candidates.empty:
+        pytest.skip("first recording has no event beyond 2 s")
+    event = candidates.iloc[0]
+    start = float(event["Begin Time (s)"]) - 2.0
+    st = _windowed(ds, 0, start, start + 6.0)["selection_table"]
+
+    assert len(st) > 0, "window was built around an event, so it cannot be empty"
+    assert (st["Begin Time (s)"] >= 0).all()
+    assert (st["End Time (s)"] <= 6.0 + 1e-6).all()
+    assert np.isclose(st["Begin Time (s)"], 2.0, atol=1e-6).any(), (
+        "the event the window was built around is not at its expected offset"
+    )
+    assert len(st) < len(full_st), "no events were filtered out of the window"
+
+
+def test_unwindowed_selection_table_stays_absolute(ds: PteroSet):
+    item = ds[0]
+    st = item["selection_table"]
+    assert len(st) == int(item["n_events"]), "unwindowed read dropped events"
+
+
+def test_backends_agree(ds: PteroSet):
+    ds_polars = PteroSet(split='map1', sample_rate=32000, backend="polars")
+    assert len(ds_polars) == len(ds)
+    assert np.array_equal(ds_polars[0]["audio"], ds[0]["audio"])
+
+
+def test_from_config():
+    config = DatasetConfig(
+        dataset_name='pteroset', split='map1', sample_rate=32000, backend="pandas"
+    )
+    ds_cfg, meta = PteroSet.from_config(config)
+    assert isinstance(ds_cfg, PteroSet)
+    assert meta == {}
+    assert len(ds_cfg) == EXPECTED_LEN_SMALL
+
+
+def test_output_take_and_give(ds: PteroSet):
+    ds_mapped = PteroSet(
+        split='map1',
+        sample_rate=32000,
+        backend="pandas",
+        output_take_and_give={"audio": "waveform", "selection_table": "events"},
+    )
+    item = ds_mapped[0]
+    assert set(item.keys()) == {"waveform", "events"}
+    assert isinstance(item["waveform"], np.ndarray)
+
+
+def test_reference_item_stability(ds: PteroSet):
+    """
+    Canonical item (index 0 of the smallest split) is bitwise-stable.
+
+    Catches sample-rate, channel-handling, dtype and split-ordering changes.
+    Recompute and update the constants if a dataset revision is intentional.
+    """
+    audio = ds[0]["audio"]
+    h = create_hash(audio.tobytes())
+    assert h == FIRST_ITEM_AUDIO_SHA256, (
+        f"First item's audio hash changed.\nGot    {h}\nExpect {FIRST_ITEM_AUDIO_SHA256}"
+    )
+    csv_bytes = (
+        ds._data.unwrap.sort_index(axis=0).sort_index(axis=1).to_csv(index=True).encode("utf-8")
+    )
+    h = create_hash(csv_bytes)
+    assert h == MANIFEST_SHA256, (
+        f"Manifest hash changed.\nGot    {h}\nExpect {MANIFEST_SHA256}"
+    )
+
+
+def test_str(ds_all: PteroSet):
+    text = str(ds_all)
+    assert 'pteroset' in text
+    assert "0.1.0" in text

--- a/tests/unittests/datasets_tests/test_xeno_canto_strong.py
+++ b/tests/unittests/datasets_tests/test_xeno_canto_strong.py
@@ -1,0 +1,218 @@
+"""
+Unit tests for XenoCantoStrong dataset.
+
+Run with:
+    pytest -q test_xeno_canto_strong.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from alp_data import DatasetConfig
+from alp_data.datasets import XenoCantoStrong
+from alp_data.utils import create_hash
+
+
+EXPECTED_LEN_ALL = 21192
+EXPECTED_LEN_SMALL = 21192          # split 'all'
+FIRST_ITEM_AUDIO_SHA256 = (
+    "4a9310dfcc00bb717d2c07111e9dc756275501628f25223e5632b103dbaeabee"
+)
+MANIFEST_SHA256 = "9f3620aa34a3a3d19663e656c2b6dbfecc98026f468d3de2051ab7f7edf4ffc7"
+
+# Shared by every strongly-labeled soundscape dataset in this family.
+CORE_ST_COLUMNS = ["Begin Time (s)", "End Time (s)", "Low Freq (Hz)", "High Freq (Hz)", "Species"]
+EXTRA_ST_COLUMNS = ["sound_type", "sex", "life_stage", "annotator"]
+AUDIO_FP_PREFIX = 'audio/'
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def ds_all() -> XenoCantoStrong:
+    """Full manifest (metadata-level assertions; avoid bulk audio here)."""
+    return XenoCantoStrong(split="all", backend="pandas")
+
+
+@pytest.fixture(scope="module")
+def ds() -> XenoCantoStrong:
+    """Smallest split, used for every audio-level test."""
+    return XenoCantoStrong(split='all', sample_rate=32000, backend="pandas")
+
+
+def test_lengths(ds_all: XenoCantoStrong, ds: XenoCantoStrong):
+    assert len(ds_all) == EXPECTED_LEN_ALL
+    assert len(ds) == EXPECTED_LEN_SMALL
+
+
+def test_available_splits(ds_all: XenoCantoStrong):
+    assert "all" in ds_all.available_splits
+    assert set(ds_all.available_splits) == {'all'}
+
+
+def test_invalid_split_raises():
+    with pytest.raises(LookupError):
+        XenoCantoStrong(split="not_a_split")
+
+
+def test_check_audio(ds: XenoCantoStrong):
+    """Audio integrity on deterministic indices."""
+    for idx in (0, 1, 2):
+        item = ds[idx]
+        audio = item["audio"]
+        assert isinstance(audio, np.ndarray), f"[{idx}] audio is not a numpy array"
+        assert audio.dtype == np.float32, f"[{idx}] dtype is {audio.dtype}"
+        assert audio.ndim == 1, f"[{idx}] not mono, shape={audio.shape}"
+        assert audio.size >= 10, f"[{idx}] too short"
+        assert not np.any(np.isnan(audio)), f"[{idx}] contains NaN"
+        assert not np.all(audio == 0), f"[{idx}] all zeros"
+        assert item["sample_rate"] == 32000
+
+
+def test_presampled_columns_exist(ds: XenoCantoStrong):
+    assert "16khz_path" in ds.columns
+    assert "32khz_path" in ds.columns
+    assert ds.available_sample_rates == [16000, 32000]
+
+
+def test_load_presampled_16khz(ds: XenoCantoStrong):
+    """16 kHz reads the 16 kHz mirror: exactly half the samples of the 32 kHz read."""
+    ds_16 = XenoCantoStrong(split='all', sample_rate=16000, backend="pandas")
+    item_16 = ds_16[0]
+    assert item_16["sample_rate"] == 16000
+    # Independently resampled mirrors, so allow a sample of rounding slack.
+    assert abs(ds[0]["audio"].size - 2 * item_16["audio"].size) <= 2
+
+
+def test_audio_fp_target(ds_all: XenoCantoStrong):
+    """`audio_fp` should point where this dataset's originals actually live."""
+    assert ds_all._data.unwrap["audio_fp"].str.startswith(AUDIO_FP_PREFIX).all()
+
+
+def test_annotation_columns(ds_all: XenoCantoStrong):
+    """The family contract: Species is the annotation column."""
+    assert ds_all.annotation_columns == ["Species"]
+
+
+def test_selection_table_schema(ds: XenoCantoStrong):
+    """Raven-shaped table with the columns this family guarantees."""
+    for idx in (0, 1, 2):
+        item = ds[idx]
+        st = item["selection_table"]
+        assert isinstance(st, pd.DataFrame), f"[{idx}] not a DataFrame"
+        missing = set(CORE_ST_COLUMNS) - set(st.columns)
+        assert not missing, f"[{idx}] missing {sorted(missing)}"
+        for col in EXTRA_ST_COLUMNS:
+            assert col in st.columns, f"[{idx}] missing {col}"
+        if len(st):
+            assert (st["End Time (s)"] >= st["Begin Time (s)"]).all()
+            duration = item["audio"].size / item["sample_rate"]
+            assert st["End Time (s)"].max() <= duration + 1.0
+            assert st["Species"].astype(str).str.len().gt(0).all()
+
+
+def test_n_events_matches_table(ds: XenoCantoStrong):
+    for idx in (0, 1, 2):
+        item = ds[idx]
+        assert len(item["selection_table"]) == int(item["n_events"])
+
+
+def _windowed(ds: XenoCantoStrong, idx: int, start: float, end: float) -> dict:
+    """Process a row as if a caller had attached window columns."""
+    row = dict(ds._data[idx])
+    row["window_start_sec"], row["window_end_sec"] = start, end
+    return ds._process(row)
+
+
+def test_windowed_read_returns_only_the_window(ds: XenoCantoStrong):
+    item = _windowed(ds, 0, 5.0, 15.0)
+    assert abs(item["audio"].size / item["sample_rate"] - 10.0) < 0.05
+    assert item["audio"].size < ds[0]["audio"].size
+
+
+def test_windowed_selection_table_is_window_relative(ds: XenoCantoStrong):
+    """
+    Events must be filtered to the window and shifted onto the returned audio.
+
+    Regression guard: these datasets previously clipped with
+    `Begin Time (s) < audio_dur` against the *window* length while leaving times
+    recording-absolute, which silently dropped every event in a non-zero window.
+    """
+    full_st = ds[0]["selection_table"]
+    candidates = full_st[full_st["Begin Time (s)"] >= 2.0]
+    if candidates.empty:
+        pytest.skip("first recording has no event beyond 2 s")
+    event = candidates.iloc[0]
+    start = float(event["Begin Time (s)"]) - 2.0
+    st = _windowed(ds, 0, start, start + 6.0)["selection_table"]
+
+    assert len(st) > 0, "window was built around an event, so it cannot be empty"
+    assert (st["Begin Time (s)"] >= 0).all()
+    assert (st["End Time (s)"] <= 6.0 + 1e-6).all()
+    assert np.isclose(st["Begin Time (s)"], 2.0, atol=1e-6).any(), (
+        "the event the window was built around is not at its expected offset"
+    )
+    assert len(st) < len(full_st), "no events were filtered out of the window"
+
+
+def test_unwindowed_selection_table_stays_absolute(ds: XenoCantoStrong):
+    item = ds[0]
+    st = item["selection_table"]
+    assert len(st) == int(item["n_events"]), "unwindowed read dropped events"
+
+
+def test_backends_agree(ds: XenoCantoStrong):
+    ds_polars = XenoCantoStrong(split='all', sample_rate=32000, backend="polars")
+    assert len(ds_polars) == len(ds)
+    assert np.array_equal(ds_polars[0]["audio"], ds[0]["audio"])
+
+
+def test_from_config():
+    config = DatasetConfig(
+        dataset_name='xeno_canto_strong', split='all', sample_rate=32000, backend="pandas"
+    )
+    ds_cfg, meta = XenoCantoStrong.from_config(config)
+    assert isinstance(ds_cfg, XenoCantoStrong)
+    assert meta == {}
+    assert len(ds_cfg) == EXPECTED_LEN_SMALL
+
+
+def test_output_take_and_give(ds: XenoCantoStrong):
+    ds_mapped = XenoCantoStrong(
+        split='all',
+        sample_rate=32000,
+        backend="pandas",
+        output_take_and_give={"audio": "waveform", "selection_table": "events"},
+    )
+    item = ds_mapped[0]
+    assert set(item.keys()) == {"waveform", "events"}
+    assert isinstance(item["waveform"], np.ndarray)
+
+
+def test_reference_item_stability(ds: XenoCantoStrong):
+    """
+    Canonical item (index 0 of the smallest split) is bitwise-stable.
+
+    Catches sample-rate, channel-handling, dtype and split-ordering changes.
+    Recompute and update the constants if a dataset revision is intentional.
+    """
+    audio = ds[0]["audio"]
+    h = create_hash(audio.tobytes())
+    assert h == FIRST_ITEM_AUDIO_SHA256, (
+        f"First item's audio hash changed.\nGot    {h}\nExpect {FIRST_ITEM_AUDIO_SHA256}"
+    )
+    csv_bytes = (
+        ds._data.unwrap.sort_index(axis=0).sort_index(axis=1).to_csv(index=True).encode("utf-8")
+    )
+    h = create_hash(csv_bytes)
+    assert h == MANIFEST_SHA256, (
+        f"Manifest hash changed.\nGot    {h}\nExpect {MANIFEST_SHA256}"
+    )
+
+
+def test_str(ds_all: XenoCantoStrong):
+    text = str(ds_all)
+    assert 'xeno_canto_strong' in text
+    assert "0.1.0" in text


### PR DESCRIPTION
## What

Ports four strong-detection soundscape datasets from `david-nlm`:

| dataset | source | recordings | events | species |
|---|---|---|---:|---:|
| `DartmouthAvianSoundscapes` | [Zenodo 20038954](https://zenodo.org/records/20038954) | 1,302 × 10 min | 184,207 | 99 |
| `PteroSet` | [Zenodo 19137071](https://zenodo.org/records/19137071) | 563 | 15,372 | 159 |
| `IndianFaunaStrong` | [Zenodo 18743214](https://zenodo.org/records/18743214) | 1,702 | 36,639 | 397 |
| `XenoCantoStrong` | xeno-canto annotated subset | 21,192 | 68,413 | 808 |

```python
from alp_data.datasets import DartmouthAvianSoundscapes, PteroSet, XenoCantoStrong

ds = DartmouthAvianSoundscapes(split="acad", sample_rate=32000)
item = ds[0]        # audio, sample_rate, selection_table, metadata
```

`david-nlm` predates the `esp_data` → `alp_data` rename, so this is a transplant rather than a cherry-pick.

## They really are one family

Verified against the shipped data, not assumed. All four are WABAD-shaped: one row per recording, an inline Raven-style `selection_table`, `annotation_columns == ["Species"]`, 16 k/32 k mirrors, `available_sample_rates == [16000, 32000]`, and windowed reads. Every selection table carries `Begin Time (s)`, `End Time (s)`, `Low Freq (Hz)`, `High Freq (Hz)`, `Species`, plus per-dataset extras (dartmouth `Species Code`/`Common Name`/`Background`; pteroset `Species Code`/`Identification`/`Type`; indian `Selection`; xc `sound_type`/`sex`/`life_stage`/`annotator`).

## Fixes a bug all four shared

Each honoured `window_start_sec`/`window_end_sec`, then clipped its selection table with `Begin Time (s) < audio_dur` against the **window** length while leaving the times recording-absolute. A window at [1000, 1010] therefore dropped every event it contained.

Five datasets now need identical logic (these four plus FASD13 in #322), so the fix lands as a shared helper — `alp_data/datasets/_windowing.py` — with the semantics settled in #322: drop non-overlapping events, shift onto the returned audio, clip to it, leave identity columns untouched. Each dataset has a regression test.

Once #322 merges, a one-line follow-up switches FASD13 from its private copy to this helper.

## GBIF linkage

Three of four resolve cleanly:

- **Dartmouth** (AOU 4-letter codes) and **PteroSet** (PteroSet codes) were coerced to GBIF canonical names through *this repo's own* `GBIFConverter`, and ship a `species_labels.csv` in exactly the shape of WABAD's `gbif_labels.csv`.
- **xc_strong** carries file-level GBIF columns from the XC pipeline; event labels are annotator-supplied binomials.

Exact-string overlap with WABAD's 1,188-name vocabulary is 68 % / 47 % / 20 % / 40 %. The gaps are biogeographic — xc is global and overlaps all three, the regional ones barely overlap each other — and the names that *do* overlap match exactly, which is the evidence they share one canonical-name convention.

One caveat for reviewers: the fork's `GBIFConverter` has since diverged from `main`'s by ~495 lines (`main` reads a precomputed cache and applies `SCI_NAME_CORRECTION_MANUAL`). A Slurm job is confirming the older converter produces no disagreement; nothing here depends on the outcome.

## ⚠️ `indian_fauna_strong` ships with known gaps

Documented in its docstring rather than hidden. Neither affects the 16 k/32 k read paths, and the other three are unaffected:

- **Labels are not normalised through this repo's converter** — they come from the upstream release's `taxa_info`, so `Species` mixes ranks: genera (`Corvus`), families (`Gryllidae`), classes (`Aves`, `Insecta`), subspecies trinomials, one common name (**`Dugong`, 320 events**) and one non-taxon value (`Camera`). Filtering to binomials silently drops the Dugong events.
- **No native-rate audio** — `audio_fp` points at the 32 kHz mirror because originals were never staged. Native rates run 8–384 kHz and ~15 % of Mammalia boxes are fully ultrasonic, so that content is currently unreachable. The other three point at true originals (`recordings/`, `recordings/`, `audio/`).

Both are being cleaned up now and will land as a follow-up.

## Data location

Everything stays in `gs://esp-data-ingestion/` and moves under `DATA_HOME` at merge. Each loader reads a single `_RAW_ROOT` constant, so that's a one-line change per dataset.

Worth recording: `gs://esp-data-274503` is **write-protected** — an attempted copy failed with `storage.objects.create denied` for `david@earthspecies.org`, so the move needs someone with write access. Nothing was written.

## Validation

```
uv run ruff check . / ruff format --check         pass
uv run pytest <the four test files>               72 passed
uv run pytest tests/test_dataset.py tests/test_chained.py tests/test_concat.py   33 passed, 2 skipped
uv run deptry .                                   pass
uv run mkdocs build --strict                      pass (all four render on Available Datasets)
uv run prek run --files <changed>                 pass
```

Tests pin audio reads to the smallest split at fixed indices — dartmouth ships 1,302 × 10-minute recordings and indian runs to 60 minutes, so random sampling would be a CI hazard. 18 tests per dataset from one shared template, so the four stay consistent as they evolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)